### PR TITLE
fix: handle @public JSDoc on controllers and quote SDK property names

### DIFF
--- a/e2e/realworld.test.ts
+++ b/e2e/realworld.test.ts
@@ -114,6 +114,33 @@ describe("realworld fixture", () => {
     expect(schemas).toContain("Comment");
   });
 
+  it("should use class-level @tag JSDoc for OpenAPI tags", () => {
+    runTsgonest([
+      "--project",
+      "testdata/realworld/tsconfig.json",
+      "--config",
+      "testdata/realworld/tsgonest.config.json",
+    ]);
+    const doc = JSON.parse(readFileSync(openapiFile, "utf-8"));
+
+    // The realworld fixtures use class-level @tag on controllers:
+    // auth.controller.ts:    @tag Auth
+    // user.controller.ts:    @tag Users
+    // article.controller.ts: @tag Articles
+    // payment.controller.ts: @tag Payments
+    // admin.controller.ts:   @tag Admin
+    const tagNames = (doc.tags ?? []).map((t: any) => t.name);
+    expect(tagNames).toContain("Auth");
+    expect(tagNames).toContain("Users");
+    expect(tagNames).toContain("Articles");
+    expect(tagNames).toContain("Payments");
+    expect(tagNames).toContain("Admin");
+
+    // Verify operations use the @tag value, not the auto-derived tag
+    const loginOp = doc.paths["/auth/login"]?.post;
+    expect(loginOp?.tags).toContain("Auth");
+  });
+
   it("should validate LoginDto at runtime", () => {
     runTsgonest([
       "--project",

--- a/internal/analyzer/constraints.go
+++ b/internal/analyzer/constraints.go
@@ -550,6 +550,13 @@ func extractJSDocTagInfo(tagNode *ast.Node) (tagName string, comment string) {
 		return "deprecated", ""
 	}
 
+	// TypeScript parses @public as a known visibility tag (KindJSDocPublicTag),
+	// not as a custom KindJSDocTag. Handle it explicitly so that class-level
+	// @public JSDoc is recognized by extractClassJSDoc.
+	if tagNode.Kind == ast.KindJSDocPublicTag {
+		return "public", ""
+	}
+
 	// Handle @type tag — TypeScript recognizes it as KindJSDocTypeTag.
 	// We extract the type name text (e.g., "int32") from the type expression.
 	// When user writes `@type {int32}`, TS parses `int32` as a TypeReference inside JSDocTypeExpression.

--- a/internal/sdkgen/schema2ts.go
+++ b/internal/sdkgen/schema2ts.go
@@ -112,7 +112,7 @@ func objectToInlineTS(node *SchemaNode, visited map[string]bool) string {
 		if requiredSet[name] {
 			opt = ""
 		}
-		fields = append(fields, fmt.Sprintf("%s%s: %s", name, opt, tsType))
+		fields = append(fields, fmt.Sprintf("%s%s: %s", tsPropertyKey(name), opt, tsType))
 	}
 
 	return "{ " + strings.Join(fields, "; ") + " }"
@@ -161,10 +161,31 @@ func GenerateInterface(name string, node *SchemaNode, visited map[string]bool) s
 		if prop.Description != "" {
 			sb.WriteString(buildPropertyJSDoc(prop.Description))
 		}
-		fmt.Fprintf(&sb, "  %s%s: %s;\n", propName, opt, tsType)
+		fmt.Fprintf(&sb, "  %s%s: %s;\n", tsPropertyKey(propName), opt, tsType)
 	}
 	sb.WriteString("}\n")
 	return sb.String()
+}
+
+// tsPropertyKey returns a properly quoted TypeScript property key.
+// Valid identifiers are returned as-is, while names containing spaces
+// or other non-identifier characters are double-quoted.
+func tsPropertyKey(name string) string {
+	if len(name) == 0 {
+		return `""`
+	}
+	for i, r := range name {
+		if i == 0 {
+			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || r == '$') {
+				return `"` + name + `"`
+			}
+		} else {
+			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '$') {
+				return `"` + name + `"`
+			}
+		}
+	}
+	return name
 }
 
 // buildSchemaJSDoc generates a JSDoc comment for a schema type or interface.


### PR DESCRIPTION
## Summary

- **Fix `@public` JSDoc on controller classes**: TypeScript parses `@public` as a built-in visibility tag (`KindJSDocPublicTag`), not a custom `KindJSDocTag`. `extractJSDocTagInfo` was not handling this kind, so class-level `@public` was silently ignored — routes never inherited the public flag from their controller. Added explicit handling for `KindJSDocPublicTag`.
- **Fix unquoted property names in SDK `types.ts`**: The SDK generator emitted property names verbatim in generated interfaces. Names containing spaces, dashes, dots, or starting with digits produced invalid TypeScript (e.g. `first name?: string` instead of `"first name"?: string`). Added `tsPropertyKey()` helper to quote non-identifier names, applied to both `GenerateInterface` and `objectToInlineTS`.
- **Add class-level JSDoc test coverage**: Previously there were zero tests for class-level JSDoc on controllers. Added tests for `@tag`, `@security`, `@hidden`, and `@public` inheritance from controller class to routes, including method-level override behavior.
- **Add e2e tag verification**: The realworld fixture uses class-level `@tag` on all controllers but no e2e test verified the tags appeared in the OpenAPI output. Added assertion checking all 5 expected tags.

## Test plan

- [x] `TestControllerAnalyzer_ClassLevelTag` — class `@tag` inherited by routes (3 subtests: basic, with security+description, method override)
- [x] `TestControllerAnalyzer_ClassLevelSecurity` — class `@security` inherited by routes
- [x] `TestControllerAnalyzer_ClassLevelHidden` — class `@hidden` sets `IgnoreOpenAPI=true`
- [x] `TestControllerAnalyzer_ClassLevelPublic` — class `@public` inherited by routes (was failing before fix)
- [x] `TestGenerateInterface_PropertyWithSpaces` — interface properties with spaces are quoted
- [x] `TestSchemaToTS_InlineObjectWithSpaces` — inline object properties with spaces are quoted
- [x] `TestTsPropertyKey` — unit tests for the identifier check helper
- [x] e2e: realworld fixture OpenAPI tags match class-level `@tag` values
- [x] Full unit test suite passes (`go test ./internal/...`)