### PR TITLE
fix: quote and escape non-identifier property names in SDK generation

### DIFF
--- a/internal/sdkgen/controller.go
+++ b/internal/sdkgen/controller.go
@@ -151,7 +151,7 @@ func generateStandaloneFunction(ctrlName string, method SDKMethod) string {
 	if len(method.PathParams) > 0 {
 		sb.WriteString("  const params: Record<string, string> = {\n")
 		for _, p := range method.PathParams {
-			sb.WriteString(fmt.Sprintf("    %s: String(options.%s),\n", p.Name, p.Name))
+			sb.WriteString(fmt.Sprintf("    %s: String(%s),\n", tsPropertyKey(p.Name), tsPropAccess("options", p.Name)))
 		}
 		sb.WriteString("  };\n")
 	}
@@ -160,7 +160,7 @@ func generateStandaloneFunction(ctrlName string, method SDKMethod) string {
 	if len(method.QueryParams) > 0 {
 		sb.WriteString("  const query: Record<string, unknown> = {};\n")
 		for _, p := range method.QueryParams {
-			sb.WriteString(fmt.Sprintf("  if (options.query?.%s !== undefined) query['%s'] = options.query.%s;\n", p.Name, p.Name, p.Name))
+			sb.WriteString(fmt.Sprintf("  if (%s !== undefined) query[\"%s\"] = %s;\n", tsOptionalAccess("options.query", p.Name), escapeJSString(p.Name), tsPropAccess("options.query", p.Name)))
 		}
 	}
 
@@ -248,7 +248,7 @@ func buildOptionsTypeDecl(method SDKMethod, typeName string) string {
 
 	// Path params (required)
 	for _, p := range method.PathParams {
-		sb.WriteString(fmt.Sprintf("  %s: %s;\n", p.Name, p.TSType))
+		sb.WriteString(fmt.Sprintf("  %s: %s;\n", tsPropertyKey(p.Name), p.TSType))
 	}
 
 	// Query params
@@ -270,7 +270,7 @@ func buildOptionsTypeDecl(method SDKMethod, typeName string) string {
 			if p.Required {
 				qopt = ""
 			}
-			sb.WriteString(fmt.Sprintf("    %s%s: %s;\n", p.Name, qopt, p.TSType))
+			sb.WriteString(fmt.Sprintf("    %s%s: %s;\n", tsPropertyKey(p.Name), qopt, p.TSType))
 		}
 		sb.WriteString("  };\n")
 	}

--- a/internal/sdkgen/parse.go
+++ b/internal/sdkgen/parse.go
@@ -661,7 +661,7 @@ func (r *schemaResolver) inlineObjectToTS(node map[string]json.RawMessage) strin
 		if requiredSet[name] {
 			opt = ""
 		}
-		fields = append(fields, fmt.Sprintf("%s%s: %s", name, opt, tsType))
+		fields = append(fields, fmt.Sprintf("%s%s: %s", tsPropertyKey(name), opt, tsType))
 	}
 
 	return "{ " + strings.Join(fields, "; ") + " }"


### PR DESCRIPTION
## Summary
- SDK-generated `types.ts` interfaces, inline object types, client param access, and options type declarations now properly quote property names that aren't valid JS identifiers (spaces, dots, hyphens, brackets, etc.)
- Added `escapeJSString()` to safely handle `"`, `\`, and control characters in quoted property names
- Added `tsPropAccess()` / `tsOptionalAccess()` helpers for correct dot vs bracket notation in generated client code

## What was broken
OpenAPI schemas with property names like `first name`, `user-id`, `first.name`, or `filter[name]` produced invalid TypeScript:
```ts
// Before (broken)
export interface Contact {
  first.name?: string;  // syntax error
}
// After (fixed)
export interface Contact {
  "first.name"?: string;
}
```

## Files changed
- `internal/sdkgen/schema2ts.go` — core helpers (`isJSIdentifier`, `escapeJSString`, `tsPropertyKey`, `tsPropAccess`, `tsOptionalAccess`)
- `internal/sdkgen/parse.go` — inline object type property quoting
- `internal/sdkgen/controller.go` — SDK client path/query param access and options interface
- `internal/sdkgen/schema2ts_test.go` — 25 new test cases covering identifiers, special chars, and escaping edge cases

## Test plan
- [x] All Go unit tests pass (`go test ./internal/...`)
- [x] All e2e tests pass (154/154)