### PR TITLE
fix: resolve OpenAPI generic type collapse and named array double-nesting

### DIFF
--- a/cmd/tsgonest/build.go
+++ b/cmd/tsgonest/build.go
@@ -588,6 +588,13 @@ func runBuild(args []string) int {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w.Message)
 	}
 
+	// Print type walker warnings (e.g., generic types with anonymous type arguments).
+	if sharedWalker != nil {
+		for _, msg := range sharedWalker.Warnings() {
+			fmt.Fprintf(os.Stderr, "warning: %s\n", msg)
+		}
+	}
+
 	// Generate OpenAPI document (using pre-analyzed controllers)
 	openapiStart := time.Now()
 	if cfg != nil && cfg.OpenAPI.Output != "" && len(controllers) > 0 {


### PR DESCRIPTION
## Summary

Fixes two OpenAPI code generation bugs that caused incorrect schemas in projects with generic types and array type aliases:

- **Generic type collapse**: All instantiations of a generic type (e.g., `PaginatedResponse<T>`) collapsed into a single non-generic schema, hardcoding whichever `T` was encountered first. Each instantiation now gets a unique composite name (e.g., `PaginatedResponse_UserResponse`, `PaginatedResponse_CampaignResponse`).
- **Named array double-nesting**: Type aliases resolving to arrays (e.g., `type X = {...}[]`) were registered as array schemas in the type registry, causing double `array` wrapping when used as `X[]` in DTOs. Fixed by excluding `KindArray` from the named type registration path in `WalkNamedType`.

## Additional improvements

- **Anonymous type args → inline + warn**: When a generic type like `Wrapper<{ x: number }>` has anonymous/unnameable type arguments, it is now inlined instead of being registered under a `T{id}` fallback name. A deduplicated warning suggests creating a named type alias.
- **String literal union naming**: Unions of up to 4 string/number literals can now be resolved as composite names (e.g., `Pick<User, 'id' | 'name'>` produces a readable schema name instead of failing to name).
- **Warning deduplication**: Multiple uses of the same unnameable generic only produce a single warning.
- **Walker warnings surfaced in CLI**: Type walker warnings (anonymous type args) are now printed alongside controller analyzer warnings during `tsgonest build`.

## Testing

- **14 new unit tests** in `type_walker_test.go`: generic instantiation naming, array alias handling, anonymous arg inlining, warning deduplication, literal union naming, utility type patterns (Pick, Record)
- **2 new integration tests** in `integration_test.go`: end-to-end OpenAPI schema verification for both bugs
- **All 580+ existing tests pass** with zero regressions
- **Smoke tested on ecom-bot** (real-world NestJS project): 1229 files, 1752 companions, 120 controllers, 838 routes, 25 distinct `PaginatedResponse_*` schemas, clean SDK generation with zero `T{id}` fallback names

## Files changed

| File | Change |
|------|--------|
| `internal/analyzer/type_walker.go` | Core fixes: composite naming, KindArray exclusion, inline+warn for anonymous args, literal union naming, warning deduplication |
| `internal/analyzer/type_walker_test.go` | 14 new tests |
| `internal/openapi/integration_test.go` | 2 new integration tests |
| `cmd/tsgonest/build.go` | Surface walker warnings in CLI output |