### PR TITLE
docs: fix factual errors, add Rules & Limitations page

### DIFF
--- a/apps/docs/content/docs/comparisons/vs-nestia-typia.mdx
+++ b/apps/docs/content/docs/comparisons/vs-nestia-typia.mdx
@@ -60,19 +60,18 @@ dist/
   user.dto.js                             # tsgo output
   user.dto.CreateUserDto.tsgonest.js      # validate + assert + serialize + schema
   user.dto.CreateUserDto.tsgonest.d.ts    # type declarations
-  __tsgonest_manifest.json                # manifest for runtime discovery
   openapi.json                            # OpenAPI 3.2 document
 ```
 
-The companion files are loaded on demand at runtime via the manifest — your application code doesn't need to import them directly.
+The companion files are imported automatically — tsgonest's controller rewriter injects the correct `import` and function calls into the compiled controller JS at build time. Your source code doesn't need to reference them directly.
 
 ### What this means in practice
 
 | Aspect | Typia (plugin) | tsgonest (codegen) |
 | --- | --- | --- |
-| Explicit calls needed | Yes — `typia.assert<T>()` at every use site | No — discovered via manifest |
+| Explicit calls needed | Yes — `typia.assert<T>()` at every use site | No — injected at compile time |
 | Bundle size impact | Inline code at every call site | Single companion per type |
-| NestJS integration | `@nestia/core` decorators replace NestJS ones | Drop-in pipe/interceptor, keep standard decorators |
+| NestJS integration | `@nestia/core` decorators replace NestJS ones | Zero-config, keep standard decorators |
 | Build tooling | Requires ts-patch, plugin config in tsconfig | Single `tsgonest build` command |
 | Build speed | tsc speed (with plugin overhead) | tsgo speed (~4x faster full pipeline, ~10x raw compilation) |
 | Incremental builds | Via tsc incremental | Built-in caching |
@@ -130,22 +129,30 @@ export class UserController {
 ```
 
 ```ts
-// tsgonest — automatic via pipe
-import { TsgonestValidationPipe } from '@tsgonest/runtime';
-
-// In main.ts — one line, applies to all routes:
-app.useGlobalPipes(new TsgonestValidationPipe({ distDir: 'dist' }));
-
-// Controller — no validation code needed:
+// tsgonest — automatic via compile-time injection
+// Source controller (what you write):
 @Controller('users')
 export class UserController {
   @Post()
   create(@Body() dto: CreateUserDto) {
-    // dto is already validated
     return this.userService.create(dto);
   }
 }
 ```
+
+```js
+// Compiled output (what tsgonest generates):
+import { assertCreateUserDto } from './user.dto.CreateUserDto.tsgonest.js';
+
+class UserController {
+  create(dto) {
+    dto = assertCreateUserDto(dto); // injected at compile time
+    return this.userService.create(dto);
+  }
+}
+```
+
+No pipes, no runtime setup. The controller rewriter injects `assert` calls directly into the compiled JS.
 
 ### Nestia vs standard NestJS decorators
 
@@ -245,17 +252,25 @@ findAll(): UserResponse[] {
 ### tsgonest
 
 ```ts
-// Automatic via interceptor — one line in main.ts
-app.useGlobalInterceptors(new TsgonestFastInterceptor({ distDir: 'dist' }));
-
-// Controller — no serialization code needed
+// Source controller (what you write):
 @Get()
 findAll(): UserResponse[] {
   return this.userService.findAll();
 }
 ```
 
-Both approaches generate fast string-concatenation-based serializers. The difference is that tsgonest wires serialization automatically via the manifest route map, while typia/nestia requires explicit calls or Nestia-specific decorators.
+```js
+// Compiled output (what tsgonest generates):
+import { serializeUserResponseArray } from './user.dto.UserResponse.tsgonest.js';
+
+class UserController {
+  async findAll() {
+    return serializeUserResponseArray(await this.userService.findAll()); // injected at compile time
+  }
+}
+```
+
+Both approaches generate fast string-concatenation-based serializers. The difference is that tsgonest injects serialization calls directly into the compiled controller JS at build time, while typia/nestia requires explicit calls or Nestia-specific decorators.
 
 ---
 
@@ -310,8 +325,8 @@ That's it. No patches. No plugins. No tsconfig modifications. tsgonest uses its 
 
 | Feature | Typia | Nestia | tsgonest |
 | --- | --- | --- | --- |
-| Validation | `typia.assert<T>()` | Via `@TypedBody()` | Generated companions |
-| Serialization | `typia.json.stringify<T>()` | Via `@TypedRoute` | Generated companions |
+| Validation | `typia.assert<T>()` | Via `@TypedBody()` | Compile-time injection |
+| Serialization | `typia.json.stringify<T>()` | Via `@TypedRoute` | Compile-time injection |
 | OpenAPI | N/A | `@nestia/sdk` (runtime) | Static analysis (build time) |
 | Interfaces support | Yes | Yes | Yes |
 | Type aliases support | Yes | Yes | Yes |
@@ -424,7 +439,7 @@ Your existing typia branded types are auto-detected. But for better DX, you can 
 -   create(@Body() input: CreateUserDto) {
 -     const dto = typia.assert<CreateUserDto>(input);
 +   create(@Body() dto: CreateUserDto) {
-+     // Validated automatically by TsgonestValidationPipe
++     // Validated automatically at compile time
       return this.userService.create(dto);
     }
   }

--- a/apps/docs/content/docs/comparisons/vs-nestjs-cli.mdx
+++ b/apps/docs/content/docs/comparisons/vs-nestjs-cli.mdx
@@ -3,7 +3,7 @@ title: tsgonest vs NestJS CLI
 description: How tsgonest compares to the standard NestJS CLI and its ecosystem of runtime libraries.
 ---
 
-This page compares tsgonest with the standard NestJS development setup: `@nestjs/cli` for building, `class-validator` + `class-transformer` for validation, and `@nestjs/swagger` for OpenAPI documentation.
+A typical NestJS project uses `@nestjs/cli` for building, `class-validator` + `class-transformer` for validation, and `@nestjs/swagger` for OpenAPI. Here's how tsgonest replaces each piece.
 
 ## At a glance
 

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -8,6 +8,7 @@
     "validation",
     "serialization-runtime",
     "openapi",
+    "rules",
     "---",
     "comparisons",
     "---",

--- a/apps/docs/content/docs/rules.mdx
+++ b/apps/docs/content/docs/rules.mdx
@@ -1,0 +1,151 @@
+---
+title: Rules & Limitations
+description: What tsgonest can and cannot analyze at compile time, and how to work around the boundaries.
+---
+
+tsgonest is a compile-time tool. It uses static analysis of your TypeScript source code to generate validators, serializers, and OpenAPI schemas. It does not run your application, cannot evaluate runtime expressions, cannot look inside factory functions, and cannot resolve dynamic values. This page documents the boundaries and the escape hatches available to you.
+
+## Static Analysis Only
+
+tsgonest reads your source code at build time. It does **not** start your NestJS application, instantiate any classes, or execute any of your code.
+
+This means it cannot:
+
+- Resolve runtime-computed values — variables, function return values, environment variables
+- See through factory functions that return NestJS decorators
+- Analyze dynamically constructed controller classes
+- Evaluate conditional logic that determines types or routes at runtime
+
+If tsgonest can't see it in the source text, it doesn't exist.
+
+## Factory Decorators Are Opaque
+
+tsgonest introspects a fixed set of core NestJS decorators:
+
+- **Parameter decorators**: `@Body`, `@Query`, `@Param`, `@Headers`
+- **Route decorators**: `@Get`, `@Post`, `@Put`, `@Delete`, `@Patch`, `@Sse`
+- **Class/method decorators**: `@Controller`, `@HttpCode`, `@Version`
+
+If you wrap **any** of these in a factory function, tsgonest cannot detect them:
+
+```ts
+// This breaks — tsgonest sees `@ValidatedBody()`, not `@Body()`
+function ValidatedBody() {
+  return Body();
+}
+
+@Post()
+create(@ValidatedBody() dto: CreateUserDto) { ... }
+```
+
+tsgonest resolves decorator identity through the type checker's symbol resolution. It asks "what symbol does this decorator reference?" and checks if that symbol is one of the known NestJS decorators. A factory function returns a **new** function — the link to `Body` is severed.
+
+**Import aliases ARE supported.** This works because tsgonest resolves the original symbol:
+
+```ts
+import { Body as NestBody } from '@nestjs/common';
+
+@Post()
+create(@NestBody() dto: CreateUserDto) { ... } // works
+```
+
+**Custom parameter decorators** are also supported if you annotate them with `@in` JSDoc to tell tsgonest where the parameter comes from. See the [parameters documentation](/docs/parameters) for details.
+
+## Dynamic Paths Are Not Supported
+
+Controller paths and route paths must be **string literals** or **arrays of string literals**.
+
+```ts
+// works
+@Controller('users')
+
+// works
+@Controller(['v1/users', 'v2/users'])
+
+// skipped with a warning — tsgonest cannot evaluate variables
+const prefix = 'users';
+@Controller(prefix)
+
+// skipped with a warning
+@Get(computedPath)
+```
+
+When tsgonest encounters a dynamic path, it emits a warning and skips that controller or route entirely. No OpenAPI entry is generated for it.
+
+## Controller Classes Must Be Top-Level
+
+Controllers must be declared at the top level of a module. Classes declared inside factory functions, conditionally defined, or dynamically generated are skipped:
+
+```ts
+// works
+@Controller('users')
+export class UsersController { ... }
+
+// skipped — not a top-level declaration
+function createController(prefix: string) {
+  @Controller(prefix)
+  class DynamicController { ... }
+  return DynamicController;
+}
+```
+
+This is intentional. An OpenAPI document is a **static contract** — it describes a fixed set of endpoints. If your controller's existence depends on runtime conditions, it cannot be represented in a static schema.
+
+## Generic Types in OpenAPI
+
+OpenAPI 3.2 has no concept of generics. tsgonest flattens every generic instantiation into a concrete schema.
+
+`PaginatedResponse<UserDto>` becomes a flat schema named **`PaginatedResponse_UserDto`** with all properties materialized — no `x-` extensions, no type parameter reconstruction. This is deliberate: flat schemas work with every OpenAPI tool (Swagger UI, Redocly, third-party SDK generators).
+
+**Unnamed type arguments are inlined.** If a generic type argument can't be named — for example `Wrapper<{ x: number }>` — the schema is inlined directly and a warning is emitted telling you to create a named type alias. tsgonest will **never** generate opaque names like `T12345`. If it can't name a type cleanly, it inlines it.
+
+**Pre-registered type aliases win.** If you write:
+
+```ts
+type ProductResponse = PaginatedResponse<Product>;
+```
+
+tsgonest uses `ProductResponse` as the schema name, not `PaginatedResponse_Product`. Your chosen name takes priority.
+
+## @tsgonest-ignore
+
+You can suppress companion file generation for specific types with the `@tsgonest-ignore` JSDoc tag:
+
+```ts
+/** @tsgonest-ignore */
+interface InternalConfig {
+  dbHost: string;
+  dbPort: number;
+  // no .tsgonest.js companion generated for this type
+}
+```
+
+This is useful for types that are only used internally and don't need validation, serialization, or OpenAPI schema generation.
+
+## @Res() Routes Skip Serialization
+
+If a route handler uses `@Res()` or `@Response()`, tsgonest does **not** inject serialization. You are manually controlling the response — tsgonest respects that.
+
+```ts
+@Get(':id')
+@Returns<UserDto>() // used for OpenAPI only — no runtime serialization
+async findOne(@Param('id') id: string, @Res() res: Response) {
+  const user = await this.usersService.findOne(id);
+  res.json(user); // you handle serialization
+}
+```
+
+`@Returns<T>()` on `@Res()` routes is purely for OpenAPI documentation. It tells tsgonest what the response schema looks like, but generates no runtime code for that route's return value.
+
+## What IS Supported
+
+tsgonest handles the full breadth of TypeScript's type system at compile time:
+
+- **All TypeScript types**: interfaces, type aliases, classes, enums, unions, intersections, tuples, mapped types, template literal types, recursive types
+- **JSDoc tags AND branded phantom types** from `@tsgonest/types` — can be mixed freely on the same type
+- **Standard NestJS decorators** with full import alias support via symbol resolution
+- **Custom parameter decorators** annotated with `@in` JSDoc
+- **Generic type instantiation** with automatic composite naming (`PaginatedResponse_UserDto`) and type alias priority
+- **Incremental builds** and post-processing cache — unchanged files are not re-analyzed
+- **Array paths** on controllers and routes
+- **`@HttpCode`**, **`@Version`**, and **`@Sse`** decorator extraction for OpenAPI

--- a/apps/docs/content/docs/serialization-runtime.mdx
+++ b/apps/docs/content/docs/serialization-runtime.mdx
@@ -11,10 +11,12 @@ When `transforms.serialization` is enabled, each companion file includes a `seri
 
 ```js
 // Generated in dist/user.dto.UserResponse.tsgonest.js
-var __esc = /[\x00-\x1f"\\]/;
 function __s(s) {
-  if (!__esc.test(s)) return '"' + s + '"';
-  return JSON.stringify(s);
+  for (var i = 0; i < s.length; i++) {
+    var c = s.charCodeAt(i);
+    if (c < 32 || c === 34 || c === 92 || c === 0x2028 || c === 0x2029) return JSON.stringify(s);
+  }
+  return '"' + s + '"';
 }
 
 export function serializeUserResponse(input) {
@@ -35,7 +37,7 @@ export function serializeUserResponse(input) {
 
 tsgonest serializers skip all of that — they know the exact shape at build time and generate direct string concatenation. This is the same technique used by [fast-json-stringify](https://github.com/fastify/fast-json-stringify).
 
-The `__s()` helper uses a regex fast-path: most strings in API responses don't contain special characters (quotes, backslashes, control characters). A single `regex.test()` call detects this common case and avoids `JSON.stringify` entirely, wrapping the string directly in quotes.
+The `__s()` helper scans each character's charCode — if any control character (below 32), double-quote (34), backslash (92), or LINE/PARAGRAPH SEPARATOR (U+2028/U+2029) is found, it falls back to `JSON.stringify`. Otherwise it wraps the string directly in quotes. Most strings in API responses contain no special characters, so the fast path avoids `JSON.stringify` entirely.
 
 ### Performance
 
@@ -54,7 +56,7 @@ tsgonest serialization wins on simple, flat objects (the vast majority of API DT
 
 | Type | Serialization strategy |
 | --- | --- |
-| `string` | `__s()` regex fast-path (avoids JSON.stringify when no special chars) |
+| `string` | `__s()` charCode scan (avoids JSON.stringify when no special chars) |
 | `number`, `bigint` | Direct concatenation |
 | `boolean` | `"true"` / `"false"` |
 | `null` | `"null"` |

--- a/apps/docs/content/docs/validation/index.mdx
+++ b/apps/docs/content/docs/validation/index.mdx
@@ -7,16 +7,16 @@ tsgonest generates **companion files** (`.tsgonest.js` / `.tsgonest.d.ts`) along
 
 ## Companion files
 
-When you run `tsgonest generate`, the CLI analyzes your TypeScript types and emits a companion file for each source file that contains validated types:
+Running `tsgonest build` analyzes your TypeScript types and emits one companion file per exported type:
 
 ```
-src/
-  user.dto.ts          ← your types
-  user.dto.tsgonest.js   ← generated validator + serializer
-  user.dto.tsgonest.d.ts ← generated type declarations
+dist/
+  user.dto.js                          ← tsgo output
+  user.dto.CreateUserDto.tsgonest.js   ← generated validator + serializer
+  user.dto.CreateUserDto.tsgonest.d.ts ← generated type declarations
 ```
 
-Each companion exports three functions per type:
+Each companion exports three functions:
 
 | Function    | Returns                          | On failure            |
 | ----------- | -------------------------------- | --------------------- |
@@ -29,9 +29,9 @@ Each companion exports three functions per type:
 `validate` returns a result object and **never throws**. Use it when you need to handle errors programmatically.
 
 ```ts title="usage-validate.ts"
-import { validate_CreateUserDto } from './user.dto.tsgonest.js';
+import { validateCreateUserDto } from './user.dto.CreateUserDto.tsgonest.js';
 
-const result = validate_CreateUserDto(input);
+const result = validateCreateUserDto(input);
 
 if (result.success) {
   // result.data is typed as CreateUserDto
@@ -39,7 +39,7 @@ if (result.success) {
 } else {
   // result.errors is ValidationErrorDetail[]
   for (const err of result.errors) {
-    console.log(`${err.path}: ${err.message}`);
+    console.log(`${err.path}: expected ${err.expected}, received ${err.received}`);
   }
 }
 ```
@@ -48,23 +48,21 @@ The `errors` array contains objects with the following shape:
 
 ```ts title="validation-error.ts"
 interface ValidationErrorDetail {
-  path: string;      // e.g. "address.zip"
-  message: string;   // human-readable message
-  code: string;      // machine-readable error code
-  expected?: string; // what was expected
-  received?: string; // what was received
+  path: string;     // e.g. "address.zip"
+  expected: string; // what was expected
+  received: string; // what was received
 }
 ```
 
 ## `assert` — throw on failure
 
-`assert` returns the validated data directly or throws a `TsgonestValidationError`. Use it in contexts where you want exceptions to propagate (e.g., inside NestJS pipes).
+`assert` returns the validated data directly or throws a `TsgonestValidationError`. Use it when you want exceptions to propagate.
 
 ```ts title="usage-assert.ts"
-import { assert_CreateUserDto } from './user.dto.tsgonest.js';
+import { assertCreateUserDto } from './user.dto.CreateUserDto.tsgonest.js';
 
 try {
-  const user = assert_CreateUserDto(input);
+  const user = assertCreateUserDto(input);
   // user is typed as CreateUserDto
 } catch (err) {
   // err is TsgonestValidationError


### PR DESCRIPTION
## Summary

- Fix factual errors across validation, serialization, and comparison docs
- Add new "Rules & Limitations" page documenting static analysis boundaries
- Improve tone (less AI-generated, more direct)

## Changes

### Factual fixes
- **validation/index.mdx**: Wrong function names (`validate_CreateUserDto` → `validateCreateUserDto`), wrong companion file naming, wrong error shape, wrong command name
- **serialization-runtime.mdx**: Old `__esc` regex pattern → current `__s()` charCode scanner with U+2028/U+2029 detection
- **vs-nestia-typia.mdx**: Removed references to non-existent `TsgonestValidationPipe` and `TsgonestFastInterceptor` — replaced with compile-time injection examples showing actual generated code

### New page
- **rules.mdx**: "Rules & Limitations" — documents static analysis boundaries, factory decorator limitations, dynamic paths, generic naming in OpenAPI, `@tsgonest-ignore`, `@Res()` serialization skip, and full list of supported types

### Tone
- **vs-nestjs-cli.mdx**: Replaced AI-sounding opener
- General tightening across modified files

### Verified
- Docs build passes (`pnpm --filter docs build`)