### PR TITLE
fix: resolve branded type degradation, breadth limit exhaustion, and self-referential type handling

### DIFF
--- a/internal/analyzer/branded.go
+++ b/internal/analyzer/branded.go
@@ -23,9 +23,9 @@ func (w *TypeWalker) tryDetectBranded(rawTypes []*shimchecker.Type, members []me
 
 	for i := range members {
 		m := &members[i]
-		if m.Kind == metadata.KindAtomic {
+		if m.Kind == metadata.KindAtomic || m.Kind == metadata.KindLiteral {
 			if atomicMember != nil {
-				return nil // Multiple atomics — not a branded type
+				return nil // Multiple atomics/literals — not a branded type
 			}
 			atomicMember = m
 		} else if m.Kind == metadata.KindObject && isPhantomObject(m) {

--- a/internal/sdkgen/schema2ts.go
+++ b/internal/sdkgen/schema2ts.go
@@ -124,6 +124,21 @@ func GenerateInterface(name string, node *SchemaNode, visited map[string]bool) s
 		return fmt.Sprintf("export type %s = unknown;\n", name)
 	}
 
+	// Object with additionalProperties but no declared properties:
+	// emit as interface with index signature instead of Record<> type alias.
+	// Interfaces support self-referential types (e.g., JsonObject where
+	// additionalProperties references JsonValue which includes JsonObject),
+	// while type aliases would cause TS2456: "Type alias circularly references itself".
+	if node.Type == "object" && len(node.Properties) == 0 && node.AdditionalProperties != nil {
+		valType := SchemaToTS(node.AdditionalProperties, visited)
+		var sb strings.Builder
+		if node.Description != "" {
+			sb.WriteString(buildSchemaJSDoc(node.Description))
+		}
+		fmt.Fprintf(&sb, "export interface %s { [key: string]: %s }\n", name, valType)
+		return sb.String()
+	}
+
 	// Non-object schemas: emit as type alias
 	if node.Type != "object" || len(node.Properties) == 0 {
 		ts := SchemaToTS(node, visited)


### PR DESCRIPTION
## Summary

Fixes multiple interrelated bugs that caused OpenAPI schemas and SDK types to degrade to `{}` / `unknown` for branded types, large literal unions, self-referential intersection types, and interfaces used as property types.

## Problems

### Bug 1: Branded types / imported types degrade to `{}` in OpenAPI

Properties with branded type constraints (e.g., `string & MaxLength<100>`, `string & Pattern<"^[0-9a-f]{24}$">`) and imported types (Prisma enums, `Record<string, any>` aliases, branded arrays) produced empty `{}` schemas in OpenAPI output.

**Three interrelated root causes:**

1. **`tryDetectBranded` only handled `KindAtomic`, not `KindLiteral`** — When TypeScript distributes `TCurrencyCode4217 & tags.MaxLength<3>` across a union, each member becomes `"USD" & phantom`. The `"USD"` is `KindLiteral`, not `KindAtomic`, so the intersection was output with phantom objects intact.

2. **Breadth limit exhaustion** — Walking 163 currency intersection members (each with 3 types) consumed ~490 of the 500-type budget (`maxTotalTypes`). Subsequent properties hit the limit and degraded to `KindAny` → `{}`.

3. **No breadth counter isolation for named types** — When entering a named interface like `ContactConfig`, the breadth counter inherited the parent's consumed budget instead of getting a fresh budget.

### Bug 2: Exported interfaces used as property types missing from OpenAPI

Interface types used as DTO properties (e.g., `ContactConfig`, `CompanyConfig`) were entirely absent from `components.schemas`. This was a downstream effect of Bug 1 — breadth limit exhaustion caused the type walker to return `KindAny` before reaching `walkObjectType`.

### Additional issues fixed

- **Self-referential intersection types** (`type Message = Entity & { replies: Message[] }`) expanded infinitely until hitting depth limits, producing empty schemas
- **Interfaces extending `Array<T>`** (e.g., Prisma's `JsonArray`) were expanded as objects with all Array.prototype methods instead of being recognized as arrays
- **`File`/`Blob` types** not recognized as native types
- **Generic type alias names** not propagated to OpenAPI (mechanical names like `PagedResult_Item` used instead of user-defined `MyItemList`)
- **Named enum unions** short-circuited by placeholder in `buildRefSchema`, producing empty schemas
- **Branded array item constraints** (e.g., `(string & Pattern<...>)[]`) silently dropped by `MetadataToSchema`
- **`@tsgonest/types` phantom type structure** triggered tsgo checker bug with `Partial<T>` / `Omit<T, K>` / `Pick<T, K>` on branded properties

## Fixes

### Type Walker (`internal/analyzer/type_walker.go`)

- **Branded literal fast-path**: `tryFastBrandedLiteral` and `extractBrandedLiteralValue` detect `literal & phantom` intersections directly using the checker API, avoiding breadth counter increments for 163+ union members
- **Breadth counter isolation**: Save/restore `totalTypesWalked` when entering named object types, giving each named type its own budget
- **`pendingName` recursion guards**: Replace `visiting` in `WalkNamedType` with separate `pendingName` map; add recursion guards in `walkUnion` and `walkIntersection` that check both `visiting` and `pendingName`
- **`resolveAliasName`**: Fallback name resolution for self-referential types encountered as sub-fields (not walked directly via `WalkNamedType`)
- **Array extends detection**: Check `getBaseTypes` for `ObjectFlagsClassOrInterface` types to detect `interface JsonArray extends Array<JsonValue>`
- **File/Blob native types**: Added to the native type switch
- **Alias name propagation**: `WalkNamedType` sets `m.Name` on `KindRef` results so downstream consumers can use the user-defined name

### Branded Type Detection (`internal/analyzer/branded.go`)

- Accept `KindLiteral` in addition to `KindAtomic` in `tryDetectBranded`

### OpenAPI Schema (`internal/openapi/schema.go`)

- **`convertRef` alias propagation**: Use `m.Name` (user-defined alias) as the schema name instead of mechanical `refName`
- **`buildUnionSchemaInline`**: New method that builds union schemas without named-type registration, avoiding placeholder short-circuit for enum unions
- **`MetadataToSchema` constraints**: Apply `Metadata.Constraints` for array items and standalone branded types
- **File/Blob**: Map to `{type: "string", format: "binary"}`

### SDK Generator (`internal/sdkgen/schema2ts.go`)

- Emit Record-like objects (additionalProperties, no declared properties) as `interface` with index signature instead of `type` alias, preventing TS2456 for self-referential types like Prisma's `JsonObject`

### Phantom Types (`packages/types/src/tags.ts`)

- Restructured all constraint types from `{ __prop?: Val<N> } & WithErr<"__prop", N>` (intersection with conditional) to a single top-level conditional type
- This avoids a tsgo checker bug where mapped types (`Partial<T>`, `Omit<T,K>`, `Pick<T,K>`) return `any` for branded intersection properties

## Test Coverage

- **25 new type walker tests** covering branded literal unions, breadth counter isolation, self-referential intersections (direct + sub-field), Array extends, File/Blob, generic alias propagation, Partial/Omit with conditional phantoms, single-constraint branded types, multi-file imports, old WithErr backward compat
- **10 new schema tests** covering ref alias propagation (with/without alias, full pipeline, multiple aliases), self-referential schemas, File/Blob, branded array item constraints, branded literal union constraints, atomic constraints
- **3 new integration tests** covering the exact bug scenarios end-to-end (branded constraints in OpenAPI, Partial/Omit constraint propagation, interface property types in OpenAPI)
- **3 new sdkgen tests** covering Record with additionalProperties (self-referential, non-self-referential, JSDoc preservation)
- **All 916 existing tests continue to pass** with 0 failures
- `go vet` and `gofmt` clean

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `internal/analyzer/branded.go` | +2/-2 | Accept KindLiteral in tryDetectBranded |
| `internal/analyzer/type_walker.go` | +285/-10 | Core fixes: pendingName, fast-path, breadth isolation, Array extends, File/Blob |
| `internal/analyzer/type_walker_test.go` | +1505 | 25 new tests |
| `internal/openapi/schema.go` | +50/-10 | Alias propagation, buildUnionSchemaInline, constraints, File/Blob |
| `internal/openapi/schema_test.go` | +431 | 10 new tests |
| `internal/openapi/integration_test.go` | +670 | 3 integration tests |
| `internal/sdkgen/schema2ts.go` | +15 | Record → interface with index signature |
| `internal/sdkgen/schema2ts_test.go` | +62 | 3 new tests |
| `packages/types/src/tags.ts` | +96/-63 | Phantom type restructuring |