### PR TITLE
feat: improve migration command and add migration docs

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -9,6 +9,7 @@
     "serialization-runtime",
     "openapi",
     "rules",
+    "migration",
     "---",
     "comparisons",
     "---",

--- a/apps/docs/content/docs/migration/class-validator.mdx
+++ b/apps/docs/content/docs/migration/class-validator.mdx
@@ -1,0 +1,152 @@
+---
+title: class-validator Migration
+description: How tsgonest migrate converts class-validator DTOs to interfaces with branded types.
+---
+
+`tsgonest migrate` converts class-validator DTO classes into TypeScript interfaces with branded types from `@tsgonest/types`. This page explains how each decorator is handled and what to watch for.
+
+## Class-to-Interface Conversion
+
+Any file that imports from `class-validator` is processed. Each class (that isn't a NestJS framework class or ORM entity) is converted to an interface.
+
+### Before
+
+```ts
+import { IsEmail, IsNotEmpty, MinLength, IsOptional } from 'class-validator';
+
+export class CreateUserDto {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @MinLength(6)
+  password: string;
+
+  @IsOptional()
+  @IsNotEmpty()
+  nickname?: string;
+}
+```
+
+### After
+
+```ts
+import { tags } from '@tsgonest/types';
+
+export interface CreateUserDto {
+  email: string & tags.Email & tags.MinLength<1>;
+  password: string & tags.MinLength<6>;
+  nickname?: string & tags.MinLength<1>;
+}
+```
+
+## Decorator Mapping Table
+
+### Constraint Decorators (mapped to branded types)
+
+| class-validator | tsgonest branded type |
+| --- | --- |
+| `@Min(n)` | `tags.Minimum<n>` |
+| `@Max(n)` | `tags.Maximum<n>` |
+| `@MinLength(n)` | `tags.MinLength<n>` |
+| `@MaxLength(n)` | `tags.MaxLength<n>` |
+| `@Length(min, max)` | `tags.MinLength<min> & tags.MaxLength<max>` |
+| `@IsEmail()` | `tags.Email` |
+| `@IsUUID()` | `tags.Uuid` |
+| `@IsUrl()` / `@IsURL()` | `tags.Url` |
+| `@Matches(/pattern/)` | `tags.Pattern<"pattern">` |
+| `@IsNotEmpty()` | `tags.MinLength<1>` |
+| `@IsDateString()` | `tags.Format<"date-time">` |
+| `@IsDate()` | `tags.Format<"date-time">` |
+| `@IsISO8601()` | `tags.Format<"date-time">` |
+| `@IsPositive()` | `tags.Positive` |
+| `@IsNegative()` | `tags.Negative` |
+| `@IsInt()` | `tags.Int` |
+| `@IsIP()` | `tags.Format<"ipv4">` |
+| `@ArrayMinSize(n)` | `tags.MinItems<n>` |
+| `@ArrayMaxSize(n)` | `tags.MaxItems<n>` |
+| `@ArrayNotEmpty()` | `tags.MinItems<1>` |
+
+### Behavior Decorators (removed, functionality handled by tsgonest)
+
+| class-validator | Action |
+| --- | --- |
+| `@IsOptional()` | Adds `?` to the property |
+| `@IsString()`, `@IsNumber()`, `@IsBoolean()`, `@IsArray()` | Removed (redundant with TS types) |
+| `@IsObject()`, `@IsEnum()`, `@IsDefined()` | Removed |
+| `@ValidateNested()`, `@ValidateIf()`, `@Validate()` | Removed |
+| `@Allow()` | Removed silently |
+| `@IsNotEmptyObject()`, `@IsEmpty()`, `@Equals()`, `@NotEquals()` | Removed |
+| `@IsInstance()` | Removed |
+
+### Recognized but no branded type equivalent
+
+These decorators are removed without adding a branded type. The validation is recognized but has no direct `@tsgonest/types` counterpart:
+
+`@IsJSON`, `@IsTimeZone`, `@IsCreditCard`, `@IsPhoneNumber`, `@IsHexColor`, `@IsMACAddress`, `@IsPort`, `@IsMimeType`, `@IsSemVer`, `@IsAlpha`, `@IsAlphanumeric`, `@IsNumberString`, `@IsBase64`, `@IsMongoId`, `@IsCurrency`, `@Contains`, `@NotContains`, `@IsHash`, `@IsLatitude`, `@IsLongitude`, `@IsLatLong`
+
+### Unknown decorators
+
+Custom validators (e.g., `@IsUniqueName()`) are flagged as TODOs in the migration report. The decorator is left in place so your code still compiles.
+
+## class-transformer Handling
+
+`tsgonest migrate` also processes `class-transformer` decorators found on properties:
+
+| class-transformer | tsgonest branded type | Notes |
+| --- | --- | --- |
+| `@Type(() => Number)` | `tags.Coerce` | Enables string-to-number coercion for `@Query`/`@Param` |
+| `@Type(() => Boolean)` | `tags.Coerce` | Enables string-to-boolean coercion |
+| `@Type(() => Date)` | `tags.Coerce` | Enables string-to-date coercion |
+| `@Transform(({ value }) => value?.trim())` | `tags.Trim` | Whitespace trimming |
+| `@Transform(({ value }) => value?.toLowerCase())` | `tags.ToLowerCase` | Case conversion |
+| `@Transform(({ value }) => value?.toUpperCase())` | `tags.ToUpperCase` | Case conversion |
+| `@Exclude()` | Removed + TODO | Manual review needed — use TypeScript `Omit<>` or separate types |
+| `@Expose()` | Removed | All properties are exposed by default in tsgonest |
+| Other `@Transform(...)` | Removed + TODO | Complex transforms need manual migration |
+
+## Mapped Types (OmitType, PickType, etc.)
+
+Classes that extend `OmitType()`, `PickType()`, `PartialType()`, or `IntersectionType()` **cannot** be converted to interfaces — interfaces can't extend function calls. These classes are kept as classes, but their class-validator decorators are still stripped and branded types are added.
+
+```ts
+// Before
+export class UpdateUserDto extends PickType(CreateUserDto, ['email']) {
+  @IsNotEmpty()
+  email: string;
+}
+
+// After — remains a class, decorators stripped, types updated
+export class UpdateUserDto extends PickType(CreateUserDto, ['email']) {
+  email: string & tags.MinLength<1>;
+}
+```
+
+The `@nestjs/swagger` import for mapped-type helpers is automatically rewritten to `@nestjs/mapped-types` when no other swagger imports remain.
+
+## Skipped Classes
+
+The following classes are detected and **skipped** entirely (not converted):
+
+### NestJS Framework Classes
+
+Classes with any of these decorators are skipped: `@Controller`, `@Module`, `@Injectable`, `@Guard`, `@Interceptor`, `@Pipe`, `@Filter`
+
+### ORM Entity Classes
+
+Classes with any of these decorators are skipped: `@Entity`, `@Schema`, `@Table`, `@Document`, `@Model`, `@ViewEntity`, `@ChildEntity`, `@Embeddable`
+
+Entity classes often use class-validator decorators alongside ORM decorators. Since entities have their own lifecycle and aren't DTOs, they're left unchanged.
+
+### Non-class-validator Files
+
+Files that don't import from `class-validator` are skipped entirely.
+
+## What Needs Manual Review
+
+After migration, check the `tsgonest-migrate-report.md` for:
+
+- **Unknown decorators** — Custom validators that couldn't be mapped automatically
+- **`@Exclude` properties** — Decide whether to use `Omit<>`, separate types, or `@tsgonest/types` exclusion
+- **Complex `@Transform` patterns** — Only `trim()`, `toLowerCase()`, and `toUpperCase()` are auto-mapped
+- **`@IsIn(['a', 'b'])` constraints** — Consider using TypeScript union types (`'a' | 'b'`) instead

--- a/apps/docs/content/docs/migration/index.mdx
+++ b/apps/docs/content/docs/migration/index.mdx
@@ -1,0 +1,82 @@
+---
+title: Migration Overview
+description: Migrate from class-validator, Nestia, Typia, and @nestjs/swagger to tsgonest with a single command.
+---
+
+`tsgonest migrate` is an AST-based codemod that rewrites your NestJS project to use tsgonest. It handles decorator replacement, class-to-interface conversion, branded type insertion, import cleanup, and dependency management — all in one pass.
+
+## Supported Migration Sources
+
+| Source | What gets migrated |
+| --- | --- |
+| **class-validator** | Class DTOs → interfaces with branded types (`tags.Email`, `tags.MinLength<N>`, etc.) |
+| **class-transformer** | `@Type(() => Number)` → `tags.Coerce`, `@Transform` trim/case → `tags.Trim`/`tags.ToLowerCase` |
+| **@nestjs/swagger** | Removes redundant decorators (`@ApiProperty`, `@ApiTags`, etc.), auto-detects security schemes |
+| **Nestia** | `@TypedRoute.Get()` → `@Get()`, `@TypedBody()` → `@Body()`, `@TypedFormData.Body()` → `@FormDataBody()` |
+| **Typia** | `import { tags } from 'typia'` → `import { tags } from '@tsgonest/types'`, removes `typia.assert<T>()` calls |
+
+## Quick Start
+
+### 1. Preview changes (dry-run)
+
+```bash
+npx tsgonest migrate
+```
+
+This scans your project and shows a diff of all proposed changes without modifying any files.
+
+### 2. Apply changes (interactive)
+
+```bash
+npx tsgonest migrate --apply
+```
+
+You'll be prompted for each migration step (dependency removal, script updates, config generation).
+
+### 3. Apply changes (non-interactive)
+
+```bash
+npx tsgonest migrate --apply --yes
+```
+
+Accepts all defaults and writes all changes. Best for CI or when you trust the migration output.
+
+## CLI Flags
+
+| Flag | Description |
+| --- | --- |
+| `--apply` | Write changes to disk (default: dry-run preview) |
+| `--include <glob>` | Glob pattern for files to migrate (repeatable). Default: `src/**/*.ts` |
+| `--tsconfig <path>` | Path to tsconfig.json. Default: `tsconfig.json` |
+| `--cwd <path>` | Working directory. Default: current directory |
+| `--force` | Run even if git working directory has uncommitted changes |
+| `--yes`, `-y` | Accept all prompts (non-interactive mode) |
+
+## What Happens During Migration
+
+1. **Git check** — Requires a clean working directory (use `--force` to skip)
+2. **Detection** — Scans imports to determine which sources are present
+3. **Migration plan** — In interactive mode, asks for confirmation on each step
+4. **baseUrl import rewriting** — If `tsconfig.json` has `baseUrl`, bare imports like `src/users/dto/user.dto` are rewritten to relative paths before `baseUrl` is removed
+5. **Source transforms** — Runs AST codemods for each detected source
+6. **Import cleanup** — Removes empty/unused imports left by transforms
+7. **Dependency management** — Removes old packages, adds tsgonest packages
+8. **Script updates** — Updates `build` and `dev` scripts in `package.json`
+9. **Config generation** — Creates `tsgonest.config.ts` with auto-detected settings
+10. **tsconfig cleanup** — Removes `baseUrl` and compiler plugins
+
+## Migration Report
+
+After `--apply`, a `tsgonest-migrate-report.md` file is written to your project root. It contains:
+
+- **Summary** — Transform counts by category
+- **Auto-generated changes** — Config files created, tsconfig modifications
+- **Package changes** — Dependencies added/removed, scripts updated
+- **Manual TODOs** — Items that need human review (custom validators, `@Exclude`, `SwaggerModule`, etc.)
+- **Warnings** — Non-critical issues (packages still imported, parse errors)
+
+## Guides
+
+- [class-validator Migration](/docs/migration/class-validator) — Decorator mapping, class-to-interface conversion, entity handling
+- [Nestia/Typia Migration](/docs/migration/nestia-typia) — Route decorators, parameter decorators, branded types
+- [Post-Migration Checklist](/docs/migration/post-migration) — Steps to complete after running migrate

--- a/apps/docs/content/docs/migration/meta.json
+++ b/apps/docs/content/docs/migration/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Migration",
+  "pages": ["index", "class-validator", "nestia-typia", "post-migration"]
+}

--- a/apps/docs/content/docs/migration/nestia-typia.mdx
+++ b/apps/docs/content/docs/migration/nestia-typia.mdx
@@ -1,0 +1,179 @@
+---
+title: Nestia & Typia Migration
+description: How tsgonest migrate converts Nestia route decorators and Typia branded types.
+---
+
+`tsgonest migrate` converts Nestia's `@nestia/core` decorators to standard NestJS decorators and rewrites Typia's branded type imports to `@tsgonest/types`. Since tsgonest mirrors Typia's tag names, your type annotations remain unchanged.
+
+## Route Decorator Replacements
+
+| Nestia | NestJS (after migration) |
+| --- | --- |
+| `@TypedRoute.Get()` | `@Get()` |
+| `@TypedRoute.Post()` | `@Post()` |
+| `@TypedRoute.Put()` | `@Put()` |
+| `@TypedRoute.Patch()` | `@Patch()` |
+| `@TypedRoute.Delete()` | `@Delete()` |
+
+Path arguments are preserved: `@TypedRoute.Get(':id')` becomes `@Get(':id')`.
+
+## Parameter Decorator Replacements
+
+| Nestia | NestJS (after migration) |
+| --- | --- |
+| `@TypedBody()` | `@Body()` |
+| `@TypedQuery()` | `@Query()` |
+| `@TypedParam<T>('name')` | `@Param('name')` |
+| `@TypedHeaders()` | `@Headers()` |
+
+Type parameters are dropped since tsgonest infers types from the parameter's TypeScript type annotation.
+
+## FormData Handling
+
+Nestia's `@TypedFormData.Body()` is converted to `@FormDataBody()` from `@tsgonest/runtime`, with a `@UseInterceptors(FormDataInterceptor)` added to the method:
+
+### Before
+
+```ts
+import { TypedFormData } from '@nestia/core';
+
+@Controller('upload')
+export class UploadController {
+  @Post()
+  upload(@TypedFormData.Body() body: UploadDto) {}
+}
+```
+
+### After
+
+```ts
+import { FormDataBody, FormDataInterceptor } from '@tsgonest/runtime';
+import { Controller, Post, UseInterceptors } from '@nestjs/common';
+
+@Controller('upload')
+export class UploadController {
+  @UseInterceptors(FormDataInterceptor)
+  @Post()
+  upload(@FormDataBody() body: UploadDto) {}
+}
+```
+
+Multer factory arguments are preserved: `@TypedFormData.Body(() => multer())` becomes `@FormDataBody(() => multer())`.
+
+## Typia Call Removal
+
+Runtime Typia calls are removed or replaced, since tsgonest handles validation and serialization at compile time:
+
+| Typia call | Replacement | Notes |
+| --- | --- | --- |
+| `typia.assert<T>(input)` | `input` | Validation is handled by tsgonest's compile-time transforms |
+| `typia.is<T>(input)` | `input` | Same as above |
+| `typia.json.stringify<T>(data)` | `JSON.stringify(data)` | tsgonest generates fast serializers automatically |
+| `typia.json.assertStringify<T>(data)` | `JSON.stringify(data)` | Validation + serialization handled by tsgonest |
+| `typia.json.assertParse<T>(input)` | `JSON.parse(input)` | TODO added — add manual validation if needed |
+
+## Branded Types Import Rewrite
+
+tsgonest's `@tsgonest/types` package mirrors Typia's tag names, so type annotations don't change — only the import source is rewritten:
+
+```ts
+// Before
+import { tags } from 'typia';
+
+// After
+import { tags } from '@tsgonest/types';
+```
+
+Your branded type annotations (`tags.MinLength<1>`, `tags.Format<"email">`, etc.) remain exactly the same.
+
+### tags.TagBase (Custom Validators)
+
+If your code uses `tags.TagBase<>` for custom Typia validators, a TODO is added to the migration report. Custom validators need manual migration to tsgonest's `Validate<typeof fn>` pattern.
+
+## @SwaggerCustomizer
+
+Nestia's `@SwaggerCustomizer()` decorator is removed with a TODO. Configure OpenAPI customizations in `tsgonest.config.ts` or via JSDoc tags instead.
+
+## Config and Tooling Changes
+
+### ts-patch Removal
+
+Nestia/Typia projects use `ts-patch` to hook into the TypeScript compiler. Since tsgonest replaces the compiler entirely, `ts-patch` is no longer needed.
+
+The migration removes `ts-patch` and `typescript-transform-paths` from `package.json` and strips plugin entries from `tsconfig.json`.
+
+### Nestia Config
+
+Nestia config files (`nestia.config.ts`, `nestia.config.js`, etc.) are removed. Their equivalent settings are generated in `tsgonest.config.ts`:
+
+| Nestia config | tsgonest config |
+| --- | --- |
+| `input` (controllers glob) | `controllers.include` |
+| `output` (SDK output) | Not applicable (tsgonest doesn't generate SDK) |
+| `swagger.output` | `openapi.output` |
+| `swagger.security` | `openapi.securitySchemes` (auto-detected from decorators) |
+
+## Full Before/After Example
+
+### Before (Nestia + Typia)
+
+```ts
+import { TypedRoute, TypedBody, TypedQuery } from '@nestia/core';
+import { Controller } from '@nestjs/common';
+import { tags } from 'typia';
+
+interface SearchQuery {
+  q: string & tags.MinLength<1>;
+  page: number & tags.Minimum<1>;
+}
+
+interface CreateUserInput {
+  email: string & tags.Format<'email'>;
+  name: string & tags.MinLength<1>;
+}
+
+@Controller('users')
+export class UsersController {
+  @TypedRoute.Get()
+  findAll(@TypedQuery() query: SearchQuery) {
+    return this.usersService.findAll(query);
+  }
+
+  @TypedRoute.Post()
+  create(@TypedBody() body: CreateUserInput) {
+    return this.usersService.create(body);
+  }
+}
+```
+
+### After (tsgonest)
+
+```ts
+import { Controller, Get, Post, Query, Body } from '@nestjs/common';
+import { tags } from '@tsgonest/types';
+
+interface SearchQuery {
+  q: string & tags.MinLength<1>;
+  page: number & tags.Minimum<1>;
+}
+
+interface CreateUserInput {
+  email: string & tags.Format<'email'>;
+  name: string & tags.MinLength<1>;
+}
+
+@Controller('users')
+export class UsersController {
+  @Get()
+  findAll(@Query() query: SearchQuery) {
+    return this.usersService.findAll(query);
+  }
+
+  @Post()
+  create(@Body() body: CreateUserInput) {
+    return this.usersService.create(body);
+  }
+}
+```
+
+The type annotations are identical — only imports and decorators changed.

--- a/apps/docs/content/docs/migration/post-migration.mdx
+++ b/apps/docs/content/docs/migration/post-migration.mdx
@@ -1,0 +1,151 @@
+---
+title: Post-Migration Checklist
+description: Steps to complete after running tsgonest migrate.
+---
+
+After running `tsgonest migrate --apply`, follow this checklist to verify your project builds and runs correctly.
+
+## 1. Install Dependencies
+
+The migration adds `tsgonest`, `@tsgonest/runtime`, and `@tsgonest/types` to your `package.json` and removes old packages. Sync your lockfile:
+
+```bash
+npm install
+# or
+pnpm install
+# or
+yarn install
+```
+
+## 2. Review the Migration Report
+
+Open `tsgonest-migrate-report.md` in your project root. Pay attention to:
+
+- **Manual TODOs** — These items need human action. Common ones:
+  - `@Exclude()` properties that need manual type restructuring
+  - `SwaggerModule.setup()` calls to remove from `main.ts`
+  - Custom validators (`@MyValidator()`) that need manual migration
+  - Complex `@Transform()` patterns
+  - `tags.TagBase<>` custom validators from Typia
+- **Warnings** — Dependencies that were kept because they're still imported somewhere
+
+## 3. Verify tsconfig.json
+
+The migration removes `baseUrl` and compiler plugins. Check that:
+
+- Path aliases still work — if you were using `paths` with `baseUrl`, the path mappings should still resolve via tsgonest's built-in path alias support
+- No leftover `ts-patch` or `typia` plugin entries remain in `compilerOptions.plugins`
+
+## 4. Verify tsgonest.config.ts
+
+A `tsgonest.config.ts` file was generated with auto-detected settings:
+
+```ts
+import { defineConfig } from "@tsgonest/runtime";
+
+export default defineConfig({
+  controllers: { include: ["src/**/*.controller.ts"] },
+  transforms: { validation: true, serialization: true },
+  openapi: {
+    output: "dist/openapi.json",
+    // Security schemes auto-detected from @ApiBearerAuth, etc.
+  },
+});
+```
+
+Review the settings and adjust as needed. See [Configuration](/docs/config) for all options.
+
+## 5. Remove SwaggerModule Setup
+
+If your `main.ts` had Swagger UI setup, remove it:
+
+```ts
+// Remove all of this from main.ts:
+const config = new DocumentBuilder()
+  .setTitle('My API')
+  .addBearerAuth()
+  .build();
+const document = SwaggerModule.createDocument(app, config);
+SwaggerModule.setup('api', app, document);
+```
+
+tsgonest generates OpenAPI at build time. To serve the spec, configure `openapi.output` in `tsgonest.config.ts` and serve the generated JSON file statically or use a tool like [Swagger UI](https://swagger.io/tools/swagger-ui/) pointed at the output file.
+
+## 6. Remove Old Pipes and Interceptors
+
+If you had validation pipes or serialization interceptors from Nestia or class-validator:
+
+```ts
+// Remove these from main.ts:
+app.useGlobalPipes(new ValidationPipe({ transform: true }));
+app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
+```
+
+tsgonest injects validation and serialization at compile time — no runtime pipes or interceptors are needed for `@Body()`, `@Query()`, `@Param()`, and `@Headers()` parameters.
+
+## 7. Build and Test
+
+```bash
+# Build with tsgonest
+npx tsgonest build
+
+# Or if scripts were updated:
+npm run build
+```
+
+Fix any type errors that surface. Common issues:
+
+### Import errors after baseUrl removal
+
+If you see module-not-found errors for bare imports like `src/users/dto/user.dto`, the migration should have rewritten these to relative paths. If any were missed:
+
+```ts
+// Change this:
+import { UserDto } from 'src/users/dto/user.dto';
+
+// To this:
+import { UserDto } from '../users/dto/user.dto';
+```
+
+### Entity files with class-validator decorators
+
+Entity classes (`@Entity()`, `@Schema()`, etc.) are intentionally skipped by the migration. If you have class-validator decorators on entity properties, they'll remain. This is expected — entity validation is typically handled by the ORM, not by tsgonest.
+
+### Mapped types still importing from @nestjs/swagger
+
+If `OmitType`, `PickType`, `PartialType`, or `IntersectionType` are your only imports from `@nestjs/swagger`, the migration rewrites the import source to `@nestjs/mapped-types`. Make sure `@nestjs/mapped-types` is installed:
+
+```bash
+npm install @nestjs/mapped-types
+```
+
+### class-transformer still imported
+
+If `plainToInstance()`, `instanceToPlain()`, or other runtime class-transformer utilities are still used in your code, the `class-transformer` package is kept in `package.json`. Remove the remaining usages manually if you want to fully uninstall it.
+
+## 8. Run Your Test Suite
+
+```bash
+npm test
+```
+
+The migration changes DTOs from classes to interfaces, which may affect:
+
+- Tests that use `new CreateUserDto()` — interfaces can't be instantiated. Use object literals instead:
+  ```ts
+  // Before
+  const dto = new CreateUserDto();
+  dto.email = 'test@example.com';
+
+  // After
+  const dto: CreateUserDto = { email: 'test@example.com', password: '123456' };
+  ```
+- Tests that use `instanceof CreateUserDto` — interfaces don't exist at runtime. Use type guards or duck typing instead.
+- Tests that use `plainToInstance(CreateUserDto, data)` — replace with plain object assignment.
+
+## Next Steps
+
+- [Configuration Reference](/docs/config) — Fine-tune tsgonest settings
+- [Validation](/docs/validation) — How tsgonest validates `@Body()`, `@Query()`, etc.
+- [OpenAPI](/docs/openapi) — Configure OpenAPI generation
+- [Rules & Limitations](/docs/rules) — What tsgonest can and cannot analyze at compile time

--- a/packages/core/src/migrate/report.ts
+++ b/packages/core/src/migrate/report.ts
@@ -26,6 +26,7 @@ export interface TransformStats {
   classValidator: number;
   classTransformer: number;
   swagger: number;
+  baseUrlRewrites: number;
 }
 
 export interface PackageJsonChanges {
@@ -43,6 +44,7 @@ export class MigrateReport {
     classValidator: 0,
     classTransformer: 0,
     swagger: 0,
+    baseUrlRewrites: 0,
   };
   filesChanged = new Set<string>();
   packageJsonChanges: PackageJsonChanges = {
@@ -80,7 +82,8 @@ export class MigrateReport {
       this.stats.typia +
       this.stats.classValidator +
       this.stats.classTransformer +
-      this.stats.swagger
+      this.stats.swagger +
+      this.stats.baseUrlRewrites
     );
   }
 
@@ -103,6 +106,7 @@ export class MigrateReport {
     if (this.stats.classValidator > 0) console.log(`    class-validator → tsgonest: ${this.stats.classValidator}`);
     if (this.stats.classTransformer > 0) console.log(`    class-transformer → tsgonest: ${this.stats.classTransformer}`);
     if (this.stats.swagger > 0) console.log(`    @nestjs/swagger cleanup:    ${this.stats.swagger}`);
+    if (this.stats.baseUrlRewrites > 0) console.log(`    baseUrl import rewrites:    ${this.stats.baseUrlRewrites}`);
     console.log(`    total:                      ${this.totalTransforms}`);
     console.log(`    files changed:              ${this.filesChanged.size}`);
 
@@ -155,6 +159,7 @@ export class MigrateReport {
     if (this.stats.classValidator > 0) lines.push(`| class-validator → tsgonest | ${this.stats.classValidator} |`);
     if (this.stats.classTransformer > 0) lines.push(`| class-transformer → tsgonest | ${this.stats.classTransformer} |`);
     if (this.stats.swagger > 0) lines.push(`| @nestjs/swagger cleanup | ${this.stats.swagger} |`);
+    if (this.stats.baseUrlRewrites > 0) lines.push(`| baseUrl import rewrites | ${this.stats.baseUrlRewrites} |`);
     lines.push(`| **Total** | **${this.totalTransforms}** |`);
     lines.push(`| Files changed | ${this.filesChanged.size} |`);
     lines.push("");

--- a/packages/core/src/migrate/transforms/baseurl-imports.ts
+++ b/packages/core/src/migrate/transforms/baseurl-imports.ts
@@ -1,0 +1,97 @@
+/**
+ * baseUrl-relative import rewriting.
+ *
+ * When tsconfig.json has `"baseUrl": "."`, projects often use bare imports like:
+ *   import { X } from 'src/users/dto/user.dto'
+ *
+ * Since tsgonest migrate removes `baseUrl` (tsgo doesn't support it), these
+ * imports break. This transform rewrites them to relative paths before other
+ * transforms run.
+ */
+
+import { SourceFile } from "ts-morph";
+import { resolve, relative, dirname, sep } from "path";
+import { existsSync } from "fs";
+import { MigrateReport } from "../report.js";
+
+const TS_EXTENSIONS = [".ts", ".tsx", "/index.ts", "/index.tsx"];
+
+/**
+ * Rewrite baseUrl-relative imports to relative paths.
+ * Must run BEFORE other transforms — operates on raw import specifiers.
+ *
+ * @param file       The source file to transform
+ * @param baseDir    The absolute directory that baseUrl resolves to (e.g., project root)
+ * @param report     Migration report for tracking changes
+ * @param fileExists Optional file existence checker (defaults to fs.existsSync, injectable for tests)
+ * @returns Number of rewrites applied
+ */
+export function rewriteBaseUrlImports(
+  file: SourceFile,
+  baseDir: string,
+  report: MigrateReport,
+  fileExists: (path: string) => boolean = existsSync,
+): number {
+  let count = 0;
+  const filePath = file.getFilePath();
+  const fileDir = dirname(filePath);
+
+  for (const imp of file.getImportDeclarations()) {
+    const specifier = imp.getModuleSpecifierValue();
+
+    // Skip relative imports (already correct)
+    if (specifier.startsWith(".")) continue;
+
+    // Skip scoped packages (@nestjs/common, @tsgonest/types, etc.)
+    if (specifier.startsWith("@")) continue;
+
+    // Skip node built-ins and obvious package names (no slash or starts with known prefix)
+    // We only care about specifiers that look like project paths (e.g., 'src/users/dto/...')
+    // Heuristic: try to resolve against baseDir
+    const candidate = resolve(baseDir, specifier);
+
+    let resolvedPath: string | null = null;
+
+    // Try exact path first (e.g., 'src/utils' → 'src/utils.ts')
+    for (const ext of TS_EXTENSIONS) {
+      const tryPath = candidate + ext;
+      if (fileExists(tryPath)) {
+        resolvedPath = tryPath;
+        break;
+      }
+    }
+
+    // Also try if the candidate itself exists (e.g., .js files, though rare in TS projects)
+    if (!resolvedPath && fileExists(candidate)) {
+      resolvedPath = candidate;
+    }
+
+    if (!resolvedPath) continue;
+
+    // Compute relative path from the importing file's directory
+    let relativePath = relative(fileDir, resolvedPath);
+
+    // Normalize to forward slashes (Windows)
+    relativePath = relativePath.split(sep).join("/");
+
+    // Strip .ts/.tsx extension (TypeScript import convention)
+    relativePath = relativePath.replace(/\.tsx?$/, "");
+
+    // Strip /index suffix (TypeScript resolves index files automatically)
+    relativePath = relativePath.replace(/\/index$/, "");
+
+    // Ensure ./ prefix for same-directory or child imports
+    if (!relativePath.startsWith(".")) {
+      relativePath = "./" + relativePath;
+    }
+
+    imp.setModuleSpecifier(relativePath);
+    count++;
+
+    report.info(filePath, "general",
+      `Rewrote baseUrl import '${specifier}' → '${relativePath}'`,
+    );
+  }
+
+  return count;
+}

--- a/packages/core/src/migrate/transforms/swagger.ts
+++ b/packages/core/src/migrate/transforms/swagger.ts
@@ -70,41 +70,74 @@ export function transformSwagger(file: SourceFile, report: MigrateReport): numbe
     );
   }
 
-  // Remove swagger decorators
+  // Collect swagger decorators first, then remove in reverse order
+  // (removing during forEachDescendant corrupts the AST tree)
+  const decoratorsToRemove: Node[] = [];
+
   file.forEachDescendant((node) => {
     if (!Node.isDecorator(node)) return;
 
     const name = node.getName();
 
     if (REMOVABLE_DECORATORS.has(name)) {
-      node.remove();
-      count++;
+      decoratorsToRemove.push(node);
       return;
     }
 
     if (name in SECURITY_DECORATORS) {
       const schemeInfo = SECURITY_DECORATORS[name];
-      // Auto-detect and collect the security scheme for config generation
       report.detectedSecuritySchemes.set(schemeInfo.name, schemeInfo.config);
       report.info(filePath, "swagger",
         `Auto-detected ${name} → securitySchemes.${schemeInfo.name} (will be added to tsgonest.config.ts)`,
         node.getStartLineNumber(),
       );
-      node.remove();
-      count++;
+      decoratorsToRemove.push(node);
     }
   });
 
-  // Remove @nestjs/swagger import if no identifiers still referenced
-  if (count > 0) {
+  // Remove in reverse source order to avoid position invalidation
+  for (const node of decoratorsToRemove.reverse()) {
+    (node as import("ts-morph").Decorator).remove();
+    count++;
+  }
+
+  // NestJS mapped-type helpers that exist in both @nestjs/swagger and @nestjs/mapped-types
+  const MAPPED_TYPE_HELPERS = new Set([
+    "OmitType", "PickType", "PartialType", "IntersectionType",
+  ]);
+
+  // Always clean up @nestjs/swagger import — other transforms (e.g., class-validator
+  // class→interface conversion) may have removed decorator usages before us.
+  {
     const remainingText = file.getFullText();
-    const namedImports = swaggerImport.getNamedImports().map((n) => n.getName());
     const importText = swaggerImport.getText();
     const withoutImport = remainingText.replace(importText, "");
-    const stillUsed = namedImports.some((name) => withoutImport.includes(name));
 
-    if (!stillUsed) {
+    // Remove individual named imports that are no longer referenced
+    const namedImports = swaggerImport.getNamedImports();
+    const toRemove = namedImports.filter((n) => !withoutImport.includes(n.getName()));
+
+    if (toRemove.length === namedImports.length) {
+      // All imports unused — remove the entire import declaration
       swaggerImport.remove();
+      count++;
+    } else if (toRemove.length > 0) {
+      // Remove only unused named imports (in reverse to preserve positions)
+      for (const imp of toRemove.reverse()) {
+        imp.remove();
+        count++;
+      }
+
+      // After pruning, check if remaining imports are all mapped-type helpers.
+      // If so, rewrite the import source from @nestjs/swagger → @nestjs/mapped-types
+      const remaining = swaggerImport.getNamedImports();
+      if (remaining.length > 0 && remaining.every((n) => MAPPED_TYPE_HELPERS.has(n.getName()))) {
+        swaggerImport.setModuleSpecifier("@nestjs/mapped-types");
+        report.info(filePath, "swagger",
+          `Rewrote mapped-type import from @nestjs/swagger → @nestjs/mapped-types`,
+        );
+        count++;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **baseUrl import rewriting**: New transform rewrites `src/`-prefixed bare imports to relative paths before `baseUrl` is removed from tsconfig, fixing the 51-file breakage seen in biil-backend
- **Remove `.dto.ts` filename filter**: class-validator transform now processes any file that imports from `class-validator`, not just `*.dto.ts` files. Entity/ORM classes (`@Entity`, `@Schema`, `@Table`, etc.) are skipped via decorator detection
- **Fix `@Length(min, max)`**: Now emits both `tags.MinLength<min>` and `tags.MaxLength<max>` instead of silently dropping the max argument
- **Mapped-type import rewrite**: When only `OmitType`/`PickType`/`PartialType`/`IntersectionType` remain in a `@nestjs/swagger` import, the source is rewritten to `@nestjs/mapped-types`
- **Migration docs**: 4-page documentation section (overview, class-validator guide, nestia-typia guide, post-migration checklist)
- **Tests**: 10 new tests (66 total, all passing)

## Test plan

- [x] All 66 unit tests pass (`cd packages/core && pnpm vitest run src/migrate/__tests__/transforms.test.ts`)
- [x] Docs build successfully (`pnpm --filter docs build`)
- [ ] Test `tsgonest migrate` against biil-backend — verify no `src/` import breakage
- [ ] Test `tsgonest migrate` against outlet-backend — verify `.request.ts`/`.model.ts` files processed