### PR TITLE
feat: primitive return serialization, SDK prefix support, dev mode improvements

### DIFF
--- a/cmd/tsgonest/sdk.go
+++ b/cmd/tsgonest/sdk.go
@@ -22,32 +22,31 @@ func runSDK(args []string) int {
 	resolvedInput := *input
 	resolvedOutput := *output
 
-	// If input/output not specified, try loading from config
-	if resolvedInput == "" || resolvedOutput == "" {
-		cwd, _ := os.Getwd()
-		cfgResult, cfgErr := loadOrDiscoverConfig(*configPath, cwd)
-		if cfgErr != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", cfgErr)
-			return 1
-		}
+	// Always load config (needed for SDK options like globalPrefix)
+	cwd, _ := os.Getwd()
+	cfgResult, cfgErr := loadOrDiscoverConfig(*configPath, cwd)
+	if cfgErr != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", cfgErr)
+		return 1
+	}
 
-		if cfgResult.Config != nil {
-			cfg := cfgResult.Config
-			if resolvedInput == "" {
-				if cfg.SDK.Input != "" {
-					resolvedInput = cfg.SDK.Input
-				} else if cfg.OpenAPI.Output != "" {
-					resolvedInput = cfg.OpenAPI.Output
-				}
-				if resolvedInput != "" && !filepath.IsAbs(resolvedInput) {
-					resolvedInput = filepath.Join(cfgResult.Dir, resolvedInput)
-				}
+	// If input/output not specified, try loading from config
+	if cfgResult.Config != nil {
+		cfg := cfgResult.Config
+		if resolvedInput == "" {
+			if cfg.SDK.Input != "" {
+				resolvedInput = cfg.SDK.Input
+			} else if cfg.OpenAPI.Output != "" {
+				resolvedInput = cfg.OpenAPI.Output
 			}
-			if resolvedOutput == "" && cfg.SDK.Output != "" {
-				resolvedOutput = cfg.SDK.Output
-				if !filepath.IsAbs(resolvedOutput) {
-					resolvedOutput = filepath.Join(cfgResult.Dir, resolvedOutput)
-				}
+			if resolvedInput != "" && !filepath.IsAbs(resolvedInput) {
+				resolvedInput = filepath.Join(cfgResult.Dir, resolvedInput)
+			}
+		}
+		if resolvedOutput == "" && cfg.SDK.Output != "" {
+			resolvedOutput = cfg.SDK.Output
+			if !filepath.IsAbs(resolvedOutput) {
+				resolvedOutput = filepath.Join(cfgResult.Dir, resolvedOutput)
 			}
 		}
 	}
@@ -63,7 +62,19 @@ func runSDK(args []string) int {
 		return 1
 	}
 
-	if err := sdkgen.Generate(resolvedInput, resolvedOutput); err != nil {
+	// Build SDK generation options from config
+	var sdkOpts *sdkgen.GenerateOptions
+	if cfgResult.Config != nil {
+		cfg := cfgResult.Config
+		sdkOpts = &sdkgen.GenerateOptions{
+			GlobalPrefix: cfg.NestJS.GlobalPrefix,
+		}
+		if cfg.NestJS.Versioning != nil && cfg.NestJS.Versioning.Prefix != "" {
+			sdkOpts.VersionPrefix = cfg.NestJS.Versioning.Prefix
+		}
+	}
+
+	if err := sdkgen.Generate(resolvedInput, resolvedOutput, sdkOpts); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}

--- a/e2e/primitive-returns.test.ts
+++ b/e2e/primitive-returns.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { existsSync, readFileSync, rmSync } from "fs";
+import { resolve } from "path";
+import { runTsgonest, FIXTURES_DIR } from "./helpers";
+
+/**
+ * Tests for primitive return type JSON serialization.
+ *
+ * When a NestJS controller method returns a primitive type (string, number, boolean),
+ * the response Content-Type is set to application/json by the serialize interceptor.
+ * The response body MUST be valid JSON:
+ *   - string "hello" → "\"hello\"" (wrapped in JSON quotes)
+ *   - number 42 → "42"
+ *   - boolean true → "true"
+ *
+ * Without this fix, the response body contains the raw value which is NOT valid JSON
+ * for strings, causing SDK clients' response.json() to throw SyntaxError.
+ *
+ * Reference: nestia handles this via typia.json.stringify<T> which correctly
+ * serializes all types including primitives. See:
+ *   - nestia: packages/core/src/decorators/TypedRoute.ts
+ *   - typia: src/programmers/json/JsonStringifyProgrammer.ts
+ */
+describe("tsgonest primitive return type serialization", () => {
+  const fixtureDir = resolve(FIXTURES_DIR, "primitive-returns");
+  const distDir = resolve(fixtureDir, "dist");
+
+  beforeAll(() => {
+    if (existsSync(distDir)) {
+      rmSync(distDir, { recursive: true });
+    }
+  });
+
+  it("should build successfully", () => {
+    const { exitCode, stderr } = runTsgonest([
+      "--project",
+      "testdata/primitive-returns/tsconfig.json",
+      "--config",
+      "testdata/primitive-returns/tsgonest.config.json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("emitted");
+  });
+
+  it("should wrap string return values with JSON encoding", () => {
+    const controllerFile = resolve(distDir, "primitive.controller.js");
+    expect(existsSync(controllerFile)).toBe(true);
+
+    const content = readFileSync(controllerFile, "utf-8");
+
+    // The forgotPassword() method returns Promise<string>.
+    // Its return statement must be wrapped to produce valid JSON.
+    // Either via __s() (fast string serializer) or JSON.stringify().
+    const hasStringSerialize =
+      content.includes("__s(") || content.includes("JSON.stringify(");
+    expect(hasStringSerialize).toBe(true);
+  });
+
+  it("should wrap number return values with JSON encoding", () => {
+    const controllerFile = resolve(distDir, "primitive.controller.js");
+    const content = readFileSync(controllerFile, "utf-8");
+
+    // getCount() returns Promise<number> — must be serialized.
+    // Either Number.isFinite check or JSON.stringify.
+    const hasNumberSerialize =
+      content.includes("Number.isFinite") || content.includes("JSON.stringify(");
+    expect(hasNumberSerialize).toBe(true);
+  });
+
+  it("should wrap boolean return values with JSON encoding", () => {
+    const controllerFile = resolve(distDir, "primitive.controller.js");
+    const content = readFileSync(controllerFile, "utf-8");
+
+    // isEnabled() returns Promise<boolean> — must produce "true"/"false" strings
+    const hasBooleanSerialize =
+      content.includes('"true"') ||
+      content.includes('"false"') ||
+      content.includes("JSON.stringify(");
+    expect(hasBooleanSerialize).toBe(true);
+  });
+
+  it("should produce valid JSON when executing string return", () => {
+    const controllerFile = resolve(distDir, "primitive.controller.js");
+    if (!existsSync(controllerFile)) return;
+
+    const content = readFileSync(controllerFile, "utf-8");
+
+    // Find the forgotPassword or getVersion method and verify its return
+    // is wrapped — the raw string "1.0.0" is NOT valid JSON,
+    // but "\"1.0.0\"" is.
+    //
+    // Look for evidence that return statements in string-returning methods
+    // are transformed (not left as raw returns).
+    const lines = content.split("\n");
+    const versionMethodIdx = lines.findIndex((l) =>
+      l.includes("getVersion")
+    );
+
+    if (versionMethodIdx >= 0) {
+      const methodBody = lines
+        .slice(versionMethodIdx, versionMethodIdx + 10)
+        .join("\n");
+
+      // The return should NOT be a bare `return "1.0.0";`
+      // It should be wrapped: `return __s(await "1.0.0");` or similar
+      const isBareReturn =
+        methodBody.includes('return "1.0.0";') &&
+        !methodBody.includes("__s(") &&
+        !methodBody.includes("JSON.stringify(");
+
+      expect(isBareReturn).toBe(false);
+    }
+  });
+
+  it("should add TsgonestSerializeInterceptor for primitive returns", () => {
+    const controllerFile = resolve(distDir, "primitive.controller.js");
+    if (!existsSync(controllerFile)) return;
+
+    const content = readFileSync(controllerFile, "utf-8");
+
+    // The serialize interceptor must be injected even for primitive returns,
+    // because it sets Content-Type to application/json and sends the
+    // pre-serialized string directly (bypassing Express's default serialization).
+    expect(content).toContain("TsgonestSerializeInterceptor");
+  });
+});

--- a/internal/codegen/companion.go
+++ b/internal/codegen/companion.go
@@ -37,9 +37,9 @@ func GenerateCompanionFiles(sourceFileName string, types map[string]*metadata.Me
 			}
 		}
 
-		// Only generate companions for structured types (objects, unions, arrays, intersections)
+		// Only generate companions for structured types and atomics (for primitive return serialization)
 		switch resolved.Kind {
-		case metadata.KindObject, metadata.KindUnion, metadata.KindArray, metadata.KindIntersection:
+		case metadata.KindObject, metadata.KindUnion, metadata.KindArray, metadata.KindIntersection, metadata.KindAtomic:
 			// ok
 		default:
 			continue

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -30,6 +30,10 @@ type Info struct {
 	TermsOfService string   `json:"termsOfService,omitempty"`
 	Contact        *Contact `json:"contact,omitempty"`
 	License        *License `json:"license,omitempty"`
+
+	// Vendor extensions for SDK generation
+	XTsgonestGlobalPrefix  string `json:"x-tsgonest-global-prefix,omitempty"`
+	XTsgonestVersionPrefix string `json:"x-tsgonest-version-prefix,omitempty"`
 }
 
 // Contact holds API contact info.
@@ -725,6 +729,14 @@ func (g *Generator) GenerateWithOptions(controllers []analyzer.ControllerInfo, o
 			Version: "1.0.0",
 		},
 		Paths: make(map[string]*PathItem),
+	}
+
+	// Store prefix/versioning info as vendor extensions so SDK generator can strip them
+	if opts != nil && opts.GlobalPrefix != "" {
+		doc.Info.XTsgonestGlobalPrefix = opts.GlobalPrefix
+	}
+	if opts != nil && opts.VersionPrefix != "" {
+		doc.Info.XTsgonestVersionPrefix = opts.VersionPrefix
 	}
 
 	// Collect all unique tags

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -12,6 +12,12 @@ type Runner struct {
 	args    []string
 	workDir string
 
+	// DisableStdin prevents the child process from inheriting stdin.
+	// When true, the child's stdin is set to nil (os.DevNull).
+	// This is needed in dev mode so the parent can read stdin for
+	// manual restart ("rs") commands without the child consuming input.
+	DisableStdin bool
+
 	mu   sync.Mutex
 	cmd  *exec.Cmd
 	done chan struct{}
@@ -33,7 +39,9 @@ func (r *Runner) newCmd() *exec.Cmd {
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
+	if !r.DisableStdin {
+		cmd.Stdin = os.Stdin
+	}
 	return cmd
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -61,6 +61,39 @@ func TestRunner_Wait(t *testing.T) {
 	}
 }
 
+func TestRunner_DisableStdin(t *testing.T) {
+	// With DisableStdin=true, the child process should NOT receive stdin.
+	// We verify this by running "cat" which reads from stdin and checking
+	// that it exits immediately (no stdin = EOF = exit).
+	r := New("cat", nil, "")
+	r.DisableStdin = true
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		r.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// cat received EOF and exited — DisableStdin worked
+	case <-time.After(3 * time.Second):
+		r.Stop()
+		t.Fatal("cat should have exited immediately with no stdin (DisableStdin=true)")
+	}
+}
+
+func TestRunner_DisableStdin_DefaultFalse(t *testing.T) {
+	// By default, DisableStdin should be false
+	r := New("echo", []string{"hello"}, "")
+	if r.DisableStdin {
+		t.Error("expected DisableStdin to default to false")
+	}
+}
+
 func TestRunner_RunningAfterExit(t *testing.T) {
 	// Run a command that exits quickly
 	r := New("true", nil, "")

--- a/internal/sdkgen/generate.go
+++ b/internal/sdkgen/generate.go
@@ -10,9 +10,23 @@ import (
 	"unicode"
 )
 
+// GenerateOptions controls SDK generation behavior.
+type GenerateOptions struct {
+	// GlobalPrefix is the NestJS global prefix (e.g., "api") to strip from paths.
+	// If empty, the prefix is auto-detected from the OpenAPI x-tsgonest-global-prefix extension.
+	GlobalPrefix string
+	// VersionPrefix is the version prefix (e.g., "v") used in URI versioning.
+	// If empty, the prefix is auto-detected from the OpenAPI x-tsgonest-version-prefix extension.
+	VersionPrefix string
+}
+
 // Generate parses an OpenAPI spec and generates a TypeScript SDK.
-func Generate(inputPath, outputDir string) error {
-	doc, err := ParseOpenAPI(inputPath)
+func Generate(inputPath, outputDir string, opts ...*GenerateOptions) error {
+	var o *GenerateOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	doc, err := ParseOpenAPIWithOptions(inputPath, o)
 	if err != nil {
 		return fmt.Errorf("parsing: %w", err)
 	}

--- a/testdata/primitive-returns/src/primitive.controller.ts
+++ b/testdata/primitive-returns/src/primitive.controller.ts
@@ -1,0 +1,69 @@
+// Test fixture: controller methods returning primitive types.
+// These must be JSON-encoded in the response body.
+// nestia/typia handle this via typia.json.stringify<T> which wraps:
+//   string → "\"hello\""
+//   number → "42"
+//   boolean → "true"
+//
+// Without this, the response Content-Type is application/json but the body
+// is a raw value, causing SDK clients' response.json() to throw SyntaxError.
+
+function Controller(path: string): ClassDecorator {
+  return (target) => target;
+}
+function Get(path?: string): MethodDecorator {
+  return (target, key, descriptor) => descriptor;
+}
+function Post(path?: string): MethodDecorator {
+  return (target, key, descriptor) => descriptor;
+}
+function Body(): ParameterDecorator {
+  return () => {};
+}
+function Param(name: string): ParameterDecorator {
+  return () => {};
+}
+
+// DTO for body params
+export interface ForgotPasswordDto {
+  email: string;
+}
+
+@Controller("test")
+export class PrimitiveReturnController {
+  // Returns a plain string — must be JSON-encoded as "\"message\""
+  @Post("forgot-password")
+  async forgotPassword(@Body() body: ForgotPasswordDto): Promise<string> {
+    return "If an account with that email exists, a password reset link has been sent.";
+  }
+
+  // Returns a plain string with no body param
+  @Get("version")
+  async getVersion(): Promise<string> {
+    return "1.0.0";
+  }
+
+  // Returns a plain number — must be JSON-encoded as "42"
+  @Get("count")
+  async getCount(): Promise<number> {
+    return 42;
+  }
+
+  // Returns a plain boolean — must be JSON-encoded as "true" or "false"
+  @Get("enabled")
+  async isEnabled(): Promise<boolean> {
+    return true;
+  }
+
+  // Returns string | null — must handle null case
+  @Get("display-name")
+  async getDisplayName(): Promise<string | null> {
+    return null;
+  }
+
+  // Returns a number literal union — should still be serialized
+  @Get("status-code")
+  async getStatusCode(): Promise<200 | 404 | 500> {
+    return 200;
+  }
+}

--- a/testdata/primitive-returns/tsconfig.json
+++ b/testdata/primitive-returns/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/testdata/primitive-returns/tsgonest.config.json
+++ b/testdata/primitive-returns/tsgonest.config.json
@@ -1,0 +1,9 @@
+{
+  "controllers": {
+    "include": ["src/**/*.controller.ts"]
+  },
+  "transforms": {
+    "validation": true,
+    "serialization": true
+  }
+}


### PR DESCRIPTION
## Summary

- **Fix 0: Primitive return JSON serialization** — Controller methods returning `string`, `number`, `boolean`, or nullable primitives now get inline JSON serialization (`JSON.stringify`, numeric/boolean encoding), fixing SDK `response.json()` SyntaxError
- **Fix 1: SDK respects tsgonest.config.ts** — `tsgonest sdk` CLI now passes `globalPrefix` and `versionPrefix` from config to the SDK generator
- **Fix 3: Smart clean preserves incremental cache** — `deleteOutDir` no longer wipes `.tsbuildinfo` on every dev rebuild, fixing incremental compilation defeat
- **Fix 4/7: SDK respects globalPrefix and versioning** — Strips `globalPrefix` before version extraction; stores prefix in OpenAPI `x-tsgonest-global-prefix`/`x-tsgonest-version-prefix` extensions
- **Fix 5: manualRestart (rs) stdin fix** — `Runner.DisableStdin` prevents child process from stealing stdin in dev mode
- **Fix 6/9: In-memory incremental dev mode** — `devBuilder` retains `*incremental.Program` across rebuilds; watch rebuilds omit `--clean`; configurable watcher poll interval
- **Fix 8: SDK request function overrides** — Options interfaces include `responseType` and `contentType` override fields

## Test plan

- [x] All Go unit tests pass (16 packages)
- [x] All e2e tests pass (162 passed, 4 skipped in pre-existing config.test.ts issue)
- [x] New tests for primitive returns (6 e2e tests + unit tests)
- [x] New tests for SDK prefix stripping and version extraction
- [x] New tests for Runner DisableStdin
- [x] New tests for smart clean (preserves .tsbuildinfo)
- [x] New tests for SDK request overrides in options interfaces