### PR TITLE
fix(codegen): query param coercion before type checks + array coercion

### DIFF
--- a/internal/analyzer/coercion_test.go
+++ b/internal/analyzer/coercion_test.go
@@ -1,0 +1,89 @@
+package analyzer_test
+
+import (
+	"testing"
+
+	"github.com/tsgonest/tsgonest/internal/analyzer"
+	"github.com/tsgonest/tsgonest/internal/metadata"
+)
+
+func TestAutoEnableCoercion_SetsCoerceOnArrayProperty(t *testing.T) {
+	m := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Properties: []metadata.Property{
+			{
+				Name: "ids",
+				Type: metadata.Metadata{
+					Kind:        metadata.KindArray,
+					ElementType: &metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "number"},
+				},
+			},
+		},
+	}
+
+	analyzer.AutoEnableCoercion(m)
+
+	prop := m.Properties[0]
+	if prop.Constraints == nil || prop.Constraints.Coerce == nil || !*prop.Constraints.Coerce {
+		t.Error("AutoEnableCoercion should set Coerce=true on array properties with coercible element types")
+	}
+}
+
+func TestAutoEnableCoercion_SetsCoerceOnArrayOfBooleans(t *testing.T) {
+	m := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Properties: []metadata.Property{
+			{
+				Name: "flags",
+				Type: metadata.Metadata{
+					Kind:        metadata.KindArray,
+					ElementType: &metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "boolean"},
+				},
+			},
+		},
+	}
+
+	analyzer.AutoEnableCoercion(m)
+
+	prop := m.Properties[0]
+	if prop.Constraints == nil || prop.Constraints.Coerce == nil || !*prop.Constraints.Coerce {
+		t.Error("AutoEnableCoercion should set Coerce=true on array properties with boolean elements")
+	}
+}
+
+func TestAutoEnableCoercion_NoCoerceOnArrayOfStrings(t *testing.T) {
+	m := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Properties: []metadata.Property{
+			{
+				Name: "tags",
+				Type: metadata.Metadata{
+					Kind:        metadata.KindArray,
+					ElementType: &metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "string"},
+				},
+			},
+		},
+	}
+
+	analyzer.AutoEnableCoercion(m)
+
+	prop := m.Properties[0]
+	// String arrays still need wrapping (single value → array), so Coerce should be set
+	if prop.Constraints == nil || prop.Constraints.Coerce == nil || !*prop.Constraints.Coerce {
+		t.Error("AutoEnableCoercion should set Coerce=true on array properties (for single-value wrapping)")
+	}
+}
+
+func TestAutoEnableCoercion_ArrayElementCoercion(t *testing.T) {
+	m := &metadata.Metadata{
+		Kind: metadata.KindArray,
+		ElementType: &metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "number"},
+	}
+
+	analyzer.AutoEnableCoercion(m)
+
+	// Element type should have coercion enabled
+	if m.ElementType.Constraints == nil || m.ElementType.Constraints.Coerce == nil || !*m.ElementType.Constraints.Coerce {
+		t.Error("AutoEnableCoercion should set Coerce=true on array element type when it's number")
+	}
+}

--- a/internal/analyzer/routes.go
+++ b/internal/analyzer/routes.go
@@ -1501,6 +1501,18 @@ func AutoEnableCoercion(m *metadata.Metadata) {
 					prop.Constraints.Coerce = &b
 				}
 			}
+			// Array properties need coercion for single-value wrapping
+			// (e.g., ?ids=1 arrives as "1", needs to become [1])
+			// and element coercion (e.g., ["1","2"] → [1,2]).
+			if prop.Type.Kind == metadata.KindArray {
+				if prop.Constraints == nil {
+					prop.Constraints = &metadata.Constraints{}
+				}
+				if prop.Constraints.Coerce == nil {
+					b := true
+					prop.Constraints.Coerce = &b
+				}
+			}
 			AutoEnableCoercion(&prop.Type)
 		}
 	}

--- a/internal/codegen/codegen_test.go
+++ b/internal/codegen/codegen_test.go
@@ -1912,6 +1912,288 @@ func TestAssertCoercion_StringToBoolean(t *testing.T) {
 	assertContains(t, code, `=== "0"`)
 }
 
+// --- Coercion ordering tests (validate must coerce BEFORE type checks) ---
+
+func TestValidateCoercion_CoercionBeforeTypeCheck_Number(t *testing.T) {
+	reg := metadata.NewTypeRegistry()
+	coerce := true
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Properties: []metadata.Property{
+			{
+				Name: "page", Required: true,
+				Type:        metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "number"},
+				Constraints: &metadata.Constraints{Coerce: &coerce},
+			},
+		},
+	}
+
+	code := GenerateCompanionSelective("Dto", meta, reg, true, false)
+
+	// Extract the validate function body (between "export function validateDto" and "export function assertDto")
+	validateStart := strings.Index(code, "export function validateDto")
+	assertStart := strings.Index(code, "export function assertDto")
+	if validateStart < 0 || assertStart < 0 {
+		t.Fatal("could not find validateDto or assertDto functions in generated code")
+	}
+	validateBody := code[validateStart:assertStart]
+
+	// In the validate function, coercion (+input.page) must appear BEFORE the type check
+	coercionIdx := strings.Index(validateBody, "+input.page")
+	typeCheckIdx := strings.Index(validateBody, `typeof input.page !== "number"`)
+	if coercionIdx < 0 {
+		t.Fatal("coercion code not found in validate function")
+	}
+	if typeCheckIdx < 0 {
+		t.Fatal("type check code not found in validate function")
+	}
+	if coercionIdx > typeCheckIdx {
+		t.Errorf("validate function: coercion (pos %d) must appear BEFORE type check (pos %d);\nquery params arrive as strings and must be coerced before typeof rejects them", coercionIdx, typeCheckIdx)
+	}
+}
+
+func TestValidateCoercion_CoercionBeforeTypeCheck_Boolean(t *testing.T) {
+	reg := metadata.NewTypeRegistry()
+	coerce := true
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Properties: []metadata.Property{
+			{
+				Name: "ascending", Required: true,
+				Type:        metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "boolean"},
+				Constraints: &metadata.Constraints{Coerce: &coerce},
+			},
+		},
+	}
+
+	code := GenerateCompanionSelective("Dto", meta, reg, true, false)
+
+	validateStart := strings.Index(code, "export function validateDto")
+	assertStart := strings.Index(code, "export function assertDto")
+	if validateStart < 0 || assertStart < 0 {
+		t.Fatal("could not find validateDto or assertDto functions in generated code")
+	}
+	validateBody := code[validateStart:assertStart]
+
+	// Boolean coercion (=== "true") must appear BEFORE the type check
+	coercionIdx := strings.Index(validateBody, `=== "true"`)
+	typeCheckIdx := strings.Index(validateBody, `typeof input.ascending !== "boolean"`)
+	if coercionIdx < 0 {
+		t.Fatal("boolean coercion code not found in validate function")
+	}
+	if typeCheckIdx < 0 {
+		t.Fatal("type check code not found in validate function")
+	}
+	if coercionIdx > typeCheckIdx {
+		t.Errorf("validate function: boolean coercion (pos %d) must appear BEFORE type check (pos %d);\nquery params arrive as strings and must be coerced before typeof rejects them", coercionIdx, typeCheckIdx)
+	}
+}
+
+func TestValidateCoercion_RuntimeBehavior_StringToNumber(t *testing.T) {
+	// This test verifies that the generated validate function, when coercion is
+	// enabled, would not produce errors for string values that can be coerced.
+	// We check this by ensuring the coercion block wraps the type check.
+	reg := metadata.NewTypeRegistry()
+	coerce := true
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Properties: []metadata.Property{
+			{
+				Name: "page", Required: true,
+				Type:        metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "number"},
+				Constraints: &metadata.Constraints{Coerce: &coerce},
+			},
+			{
+				Name: "limit", Required: true,
+				Type:        metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "number"},
+				Constraints: &metadata.Constraints{Coerce: &coerce},
+			},
+			{
+				Name: "ascending", Required: false,
+				Type:        metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "boolean", Optional: true},
+				Constraints: &metadata.Constraints{Coerce: &coerce},
+			},
+		},
+	}
+
+	code := GenerateCompanionSelective("PaginationQuery", meta, reg, true, false)
+
+	validateStart := strings.Index(code, "export function validatePaginationQuery")
+	assertStart := strings.Index(code, "export function assertPaginationQuery")
+	if validateStart < 0 || assertStart < 0 {
+		t.Fatal("could not find validatePaginationQuery or assertPaginationQuery functions")
+	}
+	validateBody := code[validateStart:assertStart]
+
+	// Verify coercion appears before type check for each property
+	for _, prop := range []struct {
+		name      string
+		coercion  string
+		typeCheck string
+	}{
+		{"page", "+input.page", `typeof input.page !== "number"`},
+		{"limit", "+input.limit", `typeof input.limit !== "number"`},
+		{"ascending", `=== "true"`, `typeof input.ascending !== "boolean"`},
+	} {
+		coercionIdx := strings.Index(validateBody, prop.coercion)
+		typeCheckIdx := strings.Index(validateBody, prop.typeCheck)
+		if coercionIdx < 0 {
+			t.Errorf("property %s: coercion code %q not found in validate function", prop.name, prop.coercion)
+			continue
+		}
+		if typeCheckIdx < 0 {
+			t.Errorf("property %s: type check code %q not found in validate function", prop.name, prop.typeCheck)
+			continue
+		}
+		if coercionIdx > typeCheckIdx {
+			t.Errorf("property %s: coercion (pos %d) must appear BEFORE type check (pos %d)", prop.name, coercionIdx, typeCheckIdx)
+		}
+	}
+}
+
+// --- Array coercion tests (single-value wrapping + element coercion) ---
+
+func TestValidateCoercion_ArrayOfNumbers_WrapsAndCoercesElements(t *testing.T) {
+	reg := metadata.NewTypeRegistry()
+	coerce := true
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Properties: []metadata.Property{
+			{
+				Name: "ids", Required: true,
+				Type: metadata.Metadata{
+					Kind: metadata.KindArray,
+					ElementType: &metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "number"},
+				},
+				Constraints: &metadata.Constraints{Coerce: &coerce},
+			},
+		},
+	}
+
+	code := GenerateCompanionSelective("Dto", meta, reg, true, false)
+
+	// Extract validate function body
+	validateStart := strings.Index(code, "export function validateDto")
+	assertStart := strings.Index(code, "export function assertDto")
+	if validateStart < 0 || assertStart < 0 {
+		t.Fatal("could not find validateDto or assertDto functions")
+	}
+	validateBody := code[validateStart:assertStart]
+
+	// Should wrap single value into an array (coercion code before the Array.isArray type check)
+	assertContainsIn(t, validateBody, "input.ids = [input.ids]", "validate function should wrap single value into array")
+	// Should coerce array elements from string to number
+	assertContainsIn(t, validateBody, "Number.isNaN", "validate function should coerce array elements with number coercion")
+}
+
+func TestAssertCoercion_ArrayOfNumbers_WrapsAndCoercesElements(t *testing.T) {
+	reg := metadata.NewTypeRegistry()
+	coerce := true
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Properties: []metadata.Property{
+			{
+				Name: "ids", Required: true,
+				Type: metadata.Metadata{
+					Kind: metadata.KindArray,
+					ElementType: &metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "number"},
+				},
+				Constraints: &metadata.Constraints{Coerce: &coerce},
+			},
+		},
+	}
+
+	code := GenerateCompanionSelective("Dto", meta, reg, true, false)
+
+	// Extract assert function body
+	assertStart := strings.Index(code, "export function assertDto")
+	if assertStart < 0 {
+		t.Fatal("could not find assertDto function")
+	}
+	assertBody := code[assertStart:]
+
+	// Should wrap single value into array and coerce elements
+	assertContainsIn(t, assertBody, "input.ids = [input.ids]", "assert function should wrap single value into array")
+	assertContainsIn(t, assertBody, "Number.isNaN", "assert function should coerce array elements with number coercion")
+}
+
+func TestValidateCoercion_ArrayOfBooleans_CoercesElements(t *testing.T) {
+	reg := metadata.NewTypeRegistry()
+	coerce := true
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Properties: []metadata.Property{
+			{
+				Name: "flags", Required: true,
+				Type: metadata.Metadata{
+					Kind: metadata.KindArray,
+					ElementType: &metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "boolean"},
+				},
+				Constraints: &metadata.Constraints{Coerce: &coerce},
+			},
+		},
+	}
+
+	code := GenerateCompanionSelective("Dto", meta, reg, true, false)
+
+	validateStart := strings.Index(code, "export function validateDto")
+	assertStart := strings.Index(code, "export function assertDto")
+	if validateStart < 0 || assertStart < 0 {
+		t.Fatal("could not find validateDto or assertDto functions")
+	}
+	validateBody := code[validateStart:assertStart]
+
+	// Should coerce boolean strings in array elements
+	assertContainsIn(t, validateBody, `=== "true"`, "validate function should coerce boolean strings in array elements")
+}
+
+func TestValidateCoercion_ArrayOfStrings_NoCoercion(t *testing.T) {
+	reg := metadata.NewTypeRegistry()
+	coerce := true
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Properties: []metadata.Property{
+			{
+				Name: "tags", Required: true,
+				Type: metadata.Metadata{
+					Kind: metadata.KindArray,
+					ElementType: &metadata.Metadata{Kind: metadata.KindAtomic, Atomic: "string"},
+				},
+				Constraints: &metadata.Constraints{Coerce: &coerce},
+			},
+		},
+	}
+
+	code := GenerateCompanionSelective("Dto", meta, reg, true, false)
+
+	validateStart := strings.Index(code, "export function validateDto")
+	assertStart := strings.Index(code, "export function assertDto")
+	if validateStart < 0 || assertStart < 0 {
+		t.Fatal("could not find validateDto or assertDto functions")
+	}
+	validateBody := code[validateStart:assertStart]
+
+	// String arrays should still wrap single values but not coerce elements
+	assertContainsIn(t, validateBody, "input.tags = [input.tags]", "validate should wrap single string into array")
+	assertNotContainsIn(t, validateBody, "Number.isNaN", "validate should not emit number coercion for string arrays")
+}
+
+// assertContainsIn checks that needle is found within the given code section.
+func assertContainsIn(t *testing.T, code string, needle string, msg string) {
+	t.Helper()
+	if !strings.Contains(code, needle) {
+		t.Errorf("%s: expected %q in generated code:\n%s", msg, needle, code)
+	}
+}
+
+// assertNotContainsIn checks that needle is NOT found within the given code section.
+func assertNotContainsIn(t *testing.T, code string, needle string, msg string) {
+	t.Helper()
+	if strings.Contains(code, needle) {
+		t.Errorf("%s: did NOT expect %q in generated code:\n%s", msg, needle, code)
+	}
+}
+
 // --- Validate<typeof fn> codegen tests ---
 
 func TestValidateCustomFn_EmitsFunctionCall(t *testing.T) {

--- a/internal/codegen/validate.go
+++ b/internal/codegen/validate.go
@@ -724,6 +724,9 @@ func generateObjectCheck(e *Emitter, accessor string, path string, meta *metadat
 			e.Line("errors.push({ path: %q, expected: \"%s\", received: \"undefined\" });", propPath, describeType(&prop.Type))
 			e.EndBlockSuffix(" else {")
 			e.indent++
+			// Emit transforms + coercion BEFORE type check so that string
+			// values from query/path params are coerced before typeof rejects them.
+			emitValidatePreChecks(e, propAccessor, &prop)
 			generateTypeCheck(e, propAccessor, propPath, &prop.Type, registry, depth+1, ctx)
 			// After type check, emit constraint checks.
 			// When the base type is atomic, the typeof check was already done
@@ -744,6 +747,7 @@ func generateObjectCheck(e *Emitter, accessor string, path string, meta *metadat
 			e.Line("errors.push({ path: %q, expected: \"%s (not undefined)\", received: \"undefined\" });", propPath, describeType(&prop.Type))
 			e.EndBlockSuffix(" else {")
 			e.indent++
+			emitValidatePreChecks(e, propAccessor, &prop)
 			generateTypeCheck(e, propAccessor, propPath, &prop.Type, registry, depth+1, ctx)
 			if prop.Constraints != nil {
 				if isAtomicType(&prop.Type) {
@@ -756,6 +760,7 @@ func generateObjectCheck(e *Emitter, accessor string, path string, meta *metadat
 			e.Line("}")
 			e.EndBlock()
 		} else {
+			emitValidatePreChecks(e, propAccessor, &prop)
 			generateTypeCheck(e, propAccessor, propPath, &prop.Type, registry, depth+1, ctx)
 			// After type check, emit constraint checks (only if value is present)
 			if prop.Constraints != nil {

--- a/internal/codegen/validate_constraints.go
+++ b/internal/codegen/validate_constraints.go
@@ -30,31 +30,66 @@ func generateTransforms(e *Emitter, accessor string, transforms []string) {
 // generateCoercion emits JS code to coerce string inputs to the declared type.
 // This runs before type checks so "123" becomes 123 before the typeof check.
 func generateCoercion(e *Emitter, accessor string, typeMeta *metadata.Metadata) {
-	if typeMeta.Kind != metadata.KindAtomic {
+	switch typeMeta.Kind {
+	case metadata.KindAtomic:
+		switch typeMeta.Atomic {
+		case "number":
+			// string → number: reject empty/whitespace-only strings and hex/octal/binary
+			// literals that unary + would silently coerce (e.g., +"" → 0, +"0xff" → 255).
+			// Only coerce strings that represent plain decimal numbers.
+			e.Block("if (typeof %s === \"string\" && %s.length > 0)", accessor, accessor)
+			e.Line("const _n = +%s;", accessor)
+			e.Block("if (!Number.isNaN(_n) && %s.trim() === %s && !/^0[xXoObB]/.test(%s))", accessor, accessor, accessor)
+			e.Line("%s = _n;", accessor)
+			e.EndBlock()
+			e.EndBlock()
+		case "boolean":
+			// "true"/"false"/"1"/"0" → boolean
+			e.Block("if (%s === \"true\" || %s === \"1\")", accessor, accessor)
+			e.Line("%s = true;", accessor)
+			e.EndBlockSuffix(fmt.Sprintf(" else if (%s === \"false\" || %s === \"0\") {", accessor, accessor))
+			e.indent++
+			e.Line("%s = false;", accessor)
+			e.EndBlock()
+		}
+		// Date coercion is handled at the type check level (KindNative "Date"),
+		// not at the constraint level, so it's omitted here.
+
+	case metadata.KindArray:
+		// Query params: ?ids=1 arrives as a single string, ?ids=1&ids=2 as string[].
+		// Wrap non-array values into a single-element array before the Array.isArray check.
+		e.Block("if (!Array.isArray(%s))", accessor)
+		e.Line("%s = [%s];", accessor, accessor)
+		e.EndBlock()
+		// Coerce each element if the element type is coercible (number/boolean).
+		if typeMeta.ElementType != nil && typeMeta.ElementType.Kind == metadata.KindAtomic {
+			atomic := typeMeta.ElementType.Atomic
+			if atomic == "number" || atomic == "boolean" {
+				idx := "_ci"
+				e.Block("for (let %s = 0; %s < %s.length; %s++)", idx, idx, accessor, idx)
+				elemAccessor := fmt.Sprintf("%s[%s]", accessor, idx)
+				generateCoercion(e, elemAccessor, typeMeta.ElementType)
+				e.EndBlock()
+			}
+		}
+	}
+}
+
+// emitValidatePreChecks emits transforms and coercion that must run BEFORE type checks.
+// Called at the property level before generateTypeCheck so that string values
+// are coerced to number/boolean before the typeof check rejects them.
+// This mirrors emitAssertPreChecks in validate_assert.go.
+func emitValidatePreChecks(e *Emitter, accessor string, prop *metadata.Property) {
+	c := prop.Constraints
+	if c == nil {
 		return
 	}
-	switch typeMeta.Atomic {
-	case "number":
-		// string → number: reject empty/whitespace-only strings and hex/octal/binary
-		// literals that unary + would silently coerce (e.g., +"" → 0, +"0xff" → 255).
-		// Only coerce strings that represent plain decimal numbers.
-		e.Block("if (typeof %s === \"string\" && %s.length > 0)", accessor, accessor)
-		e.Line("const _n = +%s;", accessor)
-		e.Block("if (!Number.isNaN(_n) && %s.trim() === %s && !/^0[xXoObB]/.test(%s))", accessor, accessor, accessor)
-		e.Line("%s = _n;", accessor)
-		e.EndBlock()
-		e.EndBlock()
-	case "boolean":
-		// "true"/"false"/"1"/"0" → boolean
-		e.Block("if (%s === \"true\" || %s === \"1\")", accessor, accessor)
-		e.Line("%s = true;", accessor)
-		e.EndBlockSuffix(fmt.Sprintf(" else if (%s === \"false\" || %s === \"0\") {", accessor, accessor))
-		e.indent++
-		e.Line("%s = false;", accessor)
-		e.EndBlock()
+	if len(c.Transforms) > 0 {
+		generateTransforms(e, accessor, c.Transforms)
 	}
-	// Date coercion is handled at the type check level (KindNative "Date"),
-	// not at the constraint level, so it's omitted here.
+	if c.Coerce != nil && *c.Coerce {
+		generateCoercion(e, accessor, &prop.Type)
+	}
 }
 
 // generateConstraintChecks emits JS validation checks for JSDoc constraints.
@@ -74,15 +109,10 @@ func generateConstraintChecksInner(e *Emitter, accessor string, path string, pro
 		return
 	}
 
-	// Emit transforms BEFORE validation checks
-	if len(c.Transforms) > 0 {
-		generateTransforms(e, accessor, c.Transforms)
-	}
-
-	// Emit coercion BEFORE type checks
-	if c.Coerce != nil && *c.Coerce {
-		generateCoercion(e, accessor, &prop.Type)
-	}
+	// NOTE: Transforms and coercion are emitted by emitValidatePreChecks (called
+	// BEFORE the type check in generateObjectCheck). They must NOT be emitted here,
+	// or they would run AFTER the type check — causing string→number/boolean coercion
+	// to fire too late for query/param values that arrive as strings.
 
 	// Helper: use per-constraint error if present, then global ErrorMessage, then default.
 	// constraintKey is the Constraints field name (e.g., "format", "minLength", "minimum").


### PR DESCRIPTION
## Summary

Fixes two bugs in query parameter coercion:

1. **`validateDto()` emitted type checks before coercion** — so string values from query params were rejected before they could be coerced to the declared type. The `assertDto()` function was unaffected (it already had correct ordering).
2. **No array coercion support** — array-typed query params (`?ids=1` or `?ids=1&ids=2`) had no single-value wrapping or element coercion.

## Problem

When a client sends query parameters, all values arrive as strings. tsgonest's `@Query()` coercion is supposed to convert `"5"` → `5` and `"true"` → `true` before validation. However, the `validate` function was generating code in the wrong order:

```js
// ❌ BEFORE (broken): type check runs first, rejects the string
export function validateDto(input) {
  // ...
  if (typeof input.page !== "number") {       // ← fires for "5", pushes error
    errors.push({ path: "input.page", ... });
  }
  if (typeof input.page === "string") {       // ← coercion runs too late
    const _n = +input.page;
    if (!Number.isNaN(_n)) input.page = _n;
  }
}
```

```js
// ✅ AFTER (fixed): coercion runs first, then type check sees a number
export function validateDto(input) {
  // ...
  if (typeof input.page === "string") {       // ← coercion runs first
    const _n = +input.page;
    if (!Number.isNaN(_n)) input.page = _n;
  }
  if (typeof input.page !== "number") {       // ← now sees 5, not "5"
    errors.push({ path: "input.page", ... });
  }
}
```

For arrays, there was no support at all:

```ts
// DTO with array query param
interface FilterQuery {
  ids: number[];    // ?ids=1 arrives as "1", ?ids=1&ids=2 as ["1","2"]
}
```

```js
// ✅ AFTER: wraps single values + coerces elements
if (!Array.isArray(input.ids)) {
  input.ids = [input.ids];              // "1" → ["1"]
}
for (let _ci = 0; _ci < input.ids.length; _ci++) {
  // coerce each element: "1" → 1
  if (typeof input.ids[_ci] === "string") { ... }
}
```

## Changes

### `internal/codegen/validate_constraints.go`
- Added `emitValidatePreChecks()` — mirrors `emitAssertPreChecks` from the assert path, emitting transforms + coercion before type checks
- Moved transforms/coercion out of `generateConstraintChecksInner()` (which ran after type checks) into the new pre-check function
- Extended `generateCoercion()` to handle `KindArray`: wraps single values into arrays and coerces each element if the element type is `number` or `boolean`

### `internal/codegen/validate.go`
- In `generateObjectCheck()`, added `emitValidatePreChecks()` calls before `generateTypeCheck()` in all three property branches (required, exactOptional, optional)

### `internal/analyzer/routes.go`
- In `AutoEnableCoercion()`, array-typed properties now get `Coerce=true` set on their constraints, enabling single-value wrapping and element coercion

## Tests added

### `internal/codegen/codegen_test.go` (7 new tests)

**Coercion ordering (validate must coerce BEFORE type checks):**
- `TestValidateCoercion_CoercionBeforeTypeCheck_Number` — verifies number coercion appears before typeof check in validate function
- `TestValidateCoercion_CoercionBeforeTypeCheck_Boolean` — same for boolean
- `TestValidateCoercion_RuntimeBehavior_StringToNumber` — multi-property test with page/limit/ascending verifying ordering for all coerced props

**Array coercion (single-value wrapping + element coercion):**
- `TestValidateCoercion_ArrayOfNumbers_WrapsAndCoercesElements` — validate wraps + coerces number[]
- `TestAssertCoercion_ArrayOfNumbers_WrapsAndCoercesElements` — assert wraps + coerces number[]
- `TestValidateCoercion_ArrayOfBooleans_CoercesElements` — boolean[] element coercion
- `TestValidateCoercion_ArrayOfStrings_NoCoercion` — string[] wraps but skips element coercion

### `internal/analyzer/coercion_test.go` (4 new tests)
- `TestAutoEnableCoercion_SetsCoerceOnArrayProperty` — number[] property gets Coerce=true
- `TestAutoEnableCoercion_SetsCoerceOnArrayOfBooleans` — boolean[] property gets Coerce=true
- `TestAutoEnableCoercion_NoCoerceOnArrayOfStrings` — string[] still gets wrapping (Coerce=true for array wrap)
- `TestAutoEnableCoercion_ArrayElementCoercion` — element types get coercion enabled

## Test plan

- [x] All 11 new tests pass
- [x] Full `go test ./internal/...` passes (580+ tests, 0 failures)
- [x] Verified generated JS output for multi-property DTO (page: number, limit: number, ids: number[], ascending?: boolean) — `const _n` is block-scoped (no conflicts), `_ci` loop var is isolated from `i{depth}` type-check vars
- [x] Verified `@Body()` params are NOT affected (only `@Query`/`@Param`/`@Headers`/FormData DTOs get coercion)
- [x] Verified `is()` function correctly excludes coercion (pure boolean, no mutations)