### PR TITLE
fix(codegen): guard undefined before wrapping optional array @Query() params

### DIFF
--- a/internal/codegen/validate_constraints.go
+++ b/internal/codegen/validate_constraints.go
@@ -58,7 +58,7 @@ func generateCoercion(e *Emitter, accessor string, typeMeta *metadata.Metadata) 
 	case metadata.KindArray:
 		// Query params: ?ids=1 arrives as a single string, ?ids=1&ids=2 as string[].
 		// Wrap non-array values into a single-element array before the Array.isArray check.
-		e.Block("if (!Array.isArray(%s))", accessor)
+		e.Block("if (%s !== undefined && %s !== null && !Array.isArray(%s))", accessor, accessor, accessor)
 		e.Line("%s = [%s];", accessor, accessor)
 		e.EndBlock()
 		// Coerce each element if the element type is coercible (number/boolean).


### PR DESCRIPTION
Fixes #40

## Summary

Optional array `@Query()` params (e.g. `teams?: string[]`) returned `400 Bad Request` when the parameter was not sent in the request. This PR fixes the coercion guard in `generateCoercion()` to skip wrapping when the value is `undefined`.

## Problem

When a query param is absent, NestJS sets the field to `undefined` in `req.query`. The generated coercion code was:

```js
// BEFORE (broken)
if (!Array.isArray(input.teams)) {
    input.teams = [input.teams]; // undefined becomes [undefined]
}
// string check on [undefined][0] then fails with 400
```

## Fix

```js
// AFTER (fixed)
if (input.teams !== undefined && input.teams !== null && !Array.isArray(input.teams)) {
    input.teams = [input.teams]; // only wraps present values
}
```

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| `?teams=` absent, field optional | 400 | 200 |
| `?teams=engineering` single value | 200 | 200 |
| `?teams=eng&teams=ops` multiple values | 200 | 200 |
| `teams: string[]` required, absent | 400 | 400 |

## Comparison with nestia/typia

nestia handles this via `URLSearchParams.getAll(key)` which returns `[]` for absent keys, then `_httpQueryReadArray([], undefined)` returns `undefined` so absent params arrive at validation already as `undefined`. This fix produces the same outcome via tsgonest's in-place coercion path.

## Test plan

- [ ] `go test ./internal/... -count=1` passes
- [ ] `go build -o tsgonest ./cmd/tsgonest` succeeds
- [ ] `pnpm build:packages` succeeds
- [ ] `pnpm test:e2e` passes