### PR TITLE
feat: multi-output OpenAPI, controller filtering, and `tsgonest openapi` subcommand

### DIFF
--- a/apps/docs/content/docs/cli/index.mdx
+++ b/apps/docs/content/docs/cli/index.mdx
@@ -3,7 +3,7 @@ title: CLI Reference
 description: Complete reference for tsgonest build and dev commands, flags, and exit codes.
 ---
 
-tsgonest provides two subcommands: `build` for production compilation and `dev` for watch-mode development. If no subcommand is given, `build` is assumed.
+tsgonest provides several subcommands: `build` for production compilation, `dev` for watch-mode development, and `openapi` for standalone OpenAPI spec generation. If no subcommand is given, `build` is assumed.
 
 ## tsgonest build
 
@@ -119,6 +119,45 @@ tsgonest dev --project tsconfig.build.json --config tsgonest.config.json
 
 # Don't clear terminal on rebuild
 tsgonest dev --preserveWatchOutput
+```
+
+---
+
+## tsgonest openapi
+
+Generate OpenAPI documents without running a full build. Skips TypeScript emit, companion file generation, SDK generation, and asset copying. Useful for CI/CD pipelines, documentation publishing, and API diff checks.
+
+```bash
+tsgonest openapi [flags]
+```
+
+### Flags
+
+| Flag | Alias | Description | Default |
+| --- | --- | --- | --- |
+| `--config <path>` | | Path to `tsgonest.config.ts` or `.json` | auto-detect |
+| `--project <path>` | `-p` | Path to `tsconfig.json` | `tsconfig.json` |
+| `--output <path>` | | Override the output path (single-output mode only) | from config |
+| `--name <name>` | | Generate only the named output (multi-output mode) | all outputs |
+| `--no-check` | | Skip type checking (syntax errors still reported) | `false` |
+
+### Examples
+
+```bash
+# Generate from default config
+tsgonest openapi
+
+# Generate only the "public" output from a multi-output config
+tsgonest openapi --name public
+
+# Override output path
+tsgonest openapi --output dist/api-spec.json
+
+# Skip type checking for faster generation
+tsgonest openapi --no-check
+
+# Use a specific config
+tsgonest openapi --config tsgonest.public.config.ts
 ```
 
 ---

--- a/apps/docs/content/docs/openapi/config.mdx
+++ b/apps/docs/content/docs/openapi/config.mdx
@@ -33,6 +33,93 @@ This produces:
 }
 ```
 
+## Multiple Outputs
+
+Generate multiple OpenAPI documents from a single build, each with its own controller filters, metadata, and security configuration. Pass an array instead of a single object:
+
+```ts title="tsgonest.config.ts"
+import { defineConfig } from '@tsgonest/runtime';
+
+export default defineConfig({
+  controllers: {
+    include: ['src/**/*.controller.ts'],
+  },
+  openapi: [
+    {
+      name: 'public',
+      output: 'dist/public-api.json',
+      title: 'Public API',
+      version: '1.0.0',
+      controllers: {
+        include: ['src/public/**/*.controller.ts'],
+      },
+      securitySchemes: {
+        apiKey: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+      },
+    },
+    {
+      name: 'internal',
+      output: 'dist/internal-api.json',
+      title: 'Internal API',
+      version: '1.0.0',
+      // No controllers filter — inherits all from top-level
+    },
+  ],
+});
+```
+
+### Per-Output Controller Filtering
+
+Each output can filter controllers using file globs or route tags:
+
+```ts
+openapi: [
+  {
+    name: 'public',
+    output: 'dist/public-api.json',
+    // File-based: only include controllers from specific directories
+    controllers: {
+      include: ['src/public/**/*.controller.ts'],
+    },
+    // Tag-based: only include routes tagged "public", exclude "deprecated"
+    includeTags: ['public'],
+    excludeTags: ['deprecated'],
+  },
+]
+```
+
+File and tag filters compose as AND — a route must match both the file glob filter and the tag filter to be included.
+
+When a per-output `controllers` field is omitted, it inherits the top-level `controllers.include`/`exclude` patterns.
+
+### Tag-Based Filtering
+
+Use the `@tag` JSDoc annotation on your controllers to assign tags, then filter by tag in the config:
+
+```ts
+/** @tag public */
+@Controller('public/v1/meetings')
+export class PublicMeetingController { ... }
+
+/** @tag internal */
+@Controller('admin/meetings')
+export class AdminMeetingController { ... }
+```
+
+### Standalone Generation
+
+Use the `tsgonest openapi` subcommand to generate specs without a full build:
+
+```bash
+# Generate all configured outputs
+tsgonest openapi
+
+# Generate only the "public" output
+tsgonest openapi --name public
+```
+
+See [CLI Reference](/docs/cli#tsgonest-openapi) for all flags.
+
 ## Contact and License
 
 Add contact information and license details to the API info block:
@@ -168,9 +255,12 @@ findAll(): UserDto[] { ... }
 
 ### OpenAPI Fields
 
+The `openapi` field accepts a single object or an array of objects (for multiple outputs).
+
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `output` | `string` | Yes | Output path for the generated JSON file |
+| `name` | `string` | No | Logical name for this output (used with `--name` flag) |
 | `title` | `string` | Yes | API title in the info block |
 | `version` | `string` | Yes | API version in the info block |
 | `description` | `string` | No | API description |
@@ -178,6 +268,10 @@ findAll(): UserDto[] { ... }
 | `license` | `object` | No | License info (`name`, `url`) |
 | `servers` | `array` | No | Server URLs (`url`, `description`) |
 | `securitySchemes` | `object` | No | Named security scheme definitions |
+| `controllers` | `object` | No | Per-output controller filter (`include`, `exclude` globs) |
+| `includeTags` | `string[]` | No | Only include routes with these tags |
+| `excludeTags` | `string[]` | No | Exclude routes with these tags |
+| `sdk` | `object` | No | Per-output SDK generation settings (`output` directory) |
 
 ### NestJS Fields
 

--- a/cmd/tsgonest/build.go
+++ b/cmd/tsgonest/build.go
@@ -637,13 +637,38 @@ func runBuildWithIncrAndProgram(args []string, oldIncrProgram *shimincremental.P
 		allWarnings = append(allWarnings, sharedWalker.Warnings()...)
 	}
 
-	// Generate OpenAPI document (using pre-analyzed controllers)
+	// Generate OpenAPI documents (using pre-analyzed controllers)
 	openapiStart := time.Now()
-	if cfg != nil && cfg.OpenAPI.Output != "" && len(controllers) > 0 {
-		openapiErr := generateOpenAPIFromControllers(controllers, controllerRegistry, cfg, configDir)
-		if openapiErr != nil {
-			fmt.Fprintf(os.Stderr, "error generating OpenAPI: %v\n", openapiErr)
-			return 1
+	if cfg != nil && len(cfg.OpenAPIOutputs) > 0 && len(controllers) > 0 {
+		for i := range cfg.OpenAPIOutputs {
+			outputCfg := &cfg.OpenAPIOutputs[i]
+			if outputCfg.Output == "" {
+				continue
+			}
+			// Post-filter controllers for this output
+			filtered := controllers
+			if outputCfg.Controllers != nil || len(outputCfg.IncludeTags) > 0 || len(outputCfg.ExcludeTags) > 0 {
+				filterOpts := openapi.FilterOptions{
+					IncludeTags: outputCfg.IncludeTags,
+					ExcludeTags: outputCfg.ExcludeTags,
+				}
+				if outputCfg.Controllers != nil {
+					filterOpts.ControllerInclude = outputCfg.Controllers.Include
+					filterOpts.ControllerExclude = outputCfg.Controllers.Exclude
+				}
+				filtered = openapi.FilterControllers(controllers, filterOpts)
+			}
+			if len(filtered) == 0 {
+				continue
+			}
+			if err := generateOpenAPIFromOutput(filtered, controllerRegistry, outputCfg, cfg, configDir); err != nil {
+				label := outputCfg.Output
+				if outputCfg.Name != "" {
+					label = outputCfg.Name + " (" + outputCfg.Output + ")"
+				}
+				fmt.Fprintf(os.Stderr, "error generating OpenAPI %s: %v\n", label, err)
+				return 1
+			}
 		}
 	}
 	timing.OpenAPI = time.Since(openapiStart)
@@ -717,12 +742,17 @@ func runBuildWithIncrAndProgram(args []string, oldIncrProgram *shimincremental.P
 	// Record what we just built so the next incremental warm build can skip
 	// post-processing when nothing changed.
 	var cacheOutputs []string
-	if cfg != nil && cfg.OpenAPI.Output != "" {
-		openapiOutput := cfg.OpenAPI.Output
-		if !filepath.IsAbs(openapiOutput) {
-			openapiOutput = filepath.Join(configDir, openapiOutput)
+	if cfg != nil {
+		for _, oc := range cfg.OpenAPIOutputs {
+			if oc.Output == "" {
+				continue
+			}
+			p := oc.Output
+			if !filepath.IsAbs(p) {
+				p = filepath.Join(configDir, p)
+			}
+			cacheOutputs = append(cacheOutputs, p)
 		}
-		cacheOutputs = append(cacheOutputs, openapiOutput)
 	}
 	postCache := buildcache.New(configHash, cacheOutputs)
 	if saveErr := buildcache.Save(postCachePath, postCache); saveErr != nil {
@@ -820,10 +850,10 @@ func smartCleanDir(outDir string, tsbuildInfoPath string) error {
 	return nil
 }
 
-// generateOpenAPIFromControllers generates an OpenAPI 3.1 document from pre-analyzed controllers.
-// This avoids creating a duplicate type checker and re-analyzing controllers.
-func generateOpenAPIFromControllers(controllers []analyzer.ControllerInfo, registry *metadata.TypeRegistry, cfg *config.Config, configDir string) error {
-	// Generate OpenAPI document with versioning and prefix options
+// generateOpenAPIFromOutput generates an OpenAPI 3.2 document for a single output configuration.
+func generateOpenAPIFromOutput(controllers []analyzer.ControllerInfo, registry *metadata.TypeRegistry, outputCfg *config.OpenAPIOutputConfig, cfg *config.Config, configDir string) error {
+	// Each output gets its own generator (and SchemaGenerator) so only
+	// schemas referenced by its filtered controllers end up in components/schemas.
 	gen := openapi.NewGenerator(registry)
 
 	var genOpts *openapi.GenerateOptions
@@ -839,43 +869,42 @@ func generateOpenAPIFromControllers(controllers []analyzer.ControllerInfo, regis
 	}
 	doc := gen.GenerateWithOptions(controllers, genOpts)
 
-	// Apply document-level config (title, description, servers, security schemes)
+	// Apply document-level config from the per-output config
 	docCfg := openapi.DocumentConfig{
-		Title:          cfg.OpenAPI.Title,
-		Description:    cfg.OpenAPI.Description,
-		Version:        cfg.OpenAPI.Version,
-		TermsOfService: cfg.OpenAPI.TermsOfService,
-		Security:       cfg.OpenAPI.Security,
+		Title:          outputCfg.Title,
+		Description:    outputCfg.Description,
+		Version:        outputCfg.Version,
+		TermsOfService: outputCfg.TermsOfService,
+		Security:       outputCfg.Security,
 	}
-	// Map config tags to openapi tags
-	for _, t := range cfg.OpenAPI.Tags {
+	for _, t := range outputCfg.Tags {
 		docCfg.Tags = append(docCfg.Tags, openapi.Tag{
 			Name:        t.Name,
 			Description: t.Description,
 		})
 	}
-	if cfg.OpenAPI.Contact != nil {
+	if outputCfg.Contact != nil {
 		docCfg.Contact = &openapi.Contact{
-			Name:  cfg.OpenAPI.Contact.Name,
-			URL:   cfg.OpenAPI.Contact.URL,
-			Email: cfg.OpenAPI.Contact.Email,
+			Name:  outputCfg.Contact.Name,
+			URL:   outputCfg.Contact.URL,
+			Email: outputCfg.Contact.Email,
 		}
 	}
-	if cfg.OpenAPI.License != nil {
+	if outputCfg.License != nil {
 		docCfg.License = &openapi.License{
-			Name: cfg.OpenAPI.License.Name,
-			URL:  cfg.OpenAPI.License.URL,
+			Name: outputCfg.License.Name,
+			URL:  outputCfg.License.URL,
 		}
 	}
-	for _, s := range cfg.OpenAPI.Servers {
+	for _, s := range outputCfg.Servers {
 		docCfg.Servers = append(docCfg.Servers, openapi.Server{
 			URL:         s.URL,
 			Description: s.Description,
 		})
 	}
-	if len(cfg.OpenAPI.SecuritySchemes) > 0 {
+	if len(outputCfg.SecuritySchemes) > 0 {
 		docCfg.SecuritySchemes = make(map[string]*openapi.SecurityScheme)
-		for name, s := range cfg.OpenAPI.SecuritySchemes {
+		for name, s := range outputCfg.SecuritySchemes {
 			docCfg.SecuritySchemes[name] = &openapi.SecurityScheme{
 				Type:         s.Type,
 				Scheme:       s.Scheme,
@@ -895,7 +924,7 @@ func generateOpenAPIFromControllers(controllers []analyzer.ControllerInfo, regis
 	}
 
 	// Resolve output path relative to config file directory
-	outputPath := cfg.OpenAPI.Output
+	outputPath := outputCfg.Output
 	if !filepath.IsAbs(outputPath) {
 		outputPath = filepath.Join(configDir, outputPath)
 	}
@@ -911,7 +940,11 @@ func generateOpenAPIFromControllers(controllers []analyzer.ControllerInfo, regis
 		return fmt.Errorf("writing %s: %w", outputPath, err)
 	}
 
-	printStatus(os.Stderr, compiler.IsPrettyOutput(), "✓", "generated OpenAPI document: %s", cfg.OpenAPI.Output)
+	label := outputCfg.Output
+	if outputCfg.Name != "" {
+		label = outputCfg.Name + " → " + outputCfg.Output
+	}
+	printStatus(os.Stderr, compiler.IsPrettyOutput(), "✓", "generated OpenAPI document: %s", label)
 	return nil
 }
 

--- a/cmd/tsgonest/main.go
+++ b/cmd/tsgonest/main.go
@@ -23,6 +23,8 @@ func run() int {
 		return runBuild(os.Args[2:])
 	case "dev":
 		return runDev(os.Args[2:])
+	case "openapi":
+		return runOpenAPI(os.Args[2:])
 	case "migrate":
 		return runMigrate(os.Args[2:])
 	case "sdk":
@@ -51,6 +53,7 @@ func printUsage() {
 	fmt.Println("  tsgonest [flags]              Build project (default)")
 	fmt.Println("  tsgonest build [flags]        Build project")
 	fmt.Println("  tsgonest dev [flags]          Watch mode (build + start + reload)")
+	fmt.Println("  tsgonest openapi [flags]      Generate OpenAPI spec (no build/emit)")
 	fmt.Println("  tsgonest migrate [flags]      Migrate from class-validator/Nestia to tsgonest")
 	fmt.Println("  tsgonest sdk [flags]          Generate TypeScript SDK from OpenAPI spec")
 	fmt.Println()
@@ -66,6 +69,13 @@ func printUsage() {
 	fmt.Println("  --assets <glob>        Glob pattern for static assets to copy to output")
 	fmt.Println("  --no-check             Skip type checking (syntax errors still reported)")
 	fmt.Println("  [tsgo flags]           Any tsgo compiler flag (--strict, --noEmit, etc.)")
+	fmt.Println()
+	fmt.Println("OpenAPI Flags:")
+	fmt.Println("  --config <path>        Path to tsgonest config file")
+	fmt.Println("  --project, -p <path>   Path to tsconfig.json (default: tsconfig.json)")
+	fmt.Println("  --output <path>        Override output path (single-output mode)")
+	fmt.Println("  --name <name>          Generate only the named output (multi-output mode)")
+	fmt.Println("  --no-check             Skip type checking (syntax errors still reported)")
 	fmt.Println()
 	fmt.Println("Migrate Flags:")
 	fmt.Println("  --apply                Write changes to disk (default: dry-run preview)")
@@ -91,6 +101,8 @@ func printUsage() {
 	fmt.Println("  tsgonest migrate --apply --yes             # Apply all changes (non-interactive)")
 	fmt.Println("  tsgonest migrate --include 'src/**/*.ts'   # Scan all TS files")
 	fmt.Println("  tsgonest migrate --force                   # Skip git dirty check")
+	fmt.Println("  tsgonest openapi                           # Generate OpenAPI spec only")
+	fmt.Println("  tsgonest openapi --name public              # Generate only 'public' output")
 	fmt.Println("  tsgonest sdk --input dist/openapi.json     # Generate SDK")
 	fmt.Println("  tsgonest sdk --input api.json --output ./client  # Custom output dir")
 	fmt.Println()

--- a/cmd/tsgonest/openapi.go
+++ b/cmd/tsgonest/openapi.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/tsgonest/tsgonest/internal/analyzer"
+	"github.com/tsgonest/tsgonest/internal/compiler"
+	"github.com/tsgonest/tsgonest/internal/config"
+	"github.com/tsgonest/tsgonest/internal/openapi"
+)
+
+// runOpenAPI generates OpenAPI documents without a full build.
+// Skips: emit, companion files, SDK generation, asset copying.
+func runOpenAPI(args []string) int {
+	fs := flag.NewFlagSet("openapi", flag.ContinueOnError)
+	configPath := fs.String("config", "", "Path to tsgonest config file")
+	tsconfigPath := fs.String("project", "tsconfig.json", "Path to tsconfig.json")
+	fs.StringVar(tsconfigPath, "p", "tsconfig.json", "Path to tsconfig.json (shorthand)")
+	outputOverride := fs.String("output", "", "Override output path (single-output mode)")
+	nameFilter := fs.String("name", "", "Generate only the named output (multi-output mode)")
+	noCheck := fs.Bool("no-check", false, "Skip type checking (syntax errors still reported)")
+
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	start := time.Now()
+	pretty := compiler.IsPrettyOutput()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: could not get working directory: %v\n", err)
+		return 1
+	}
+
+	// Load config
+	cfgResult, err := loadOrDiscoverConfig(*configPath, cwd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	cfg := cfgResult.Config
+	configDir := cfgResult.Dir
+	if cfgResult.Path != "" {
+		printStatus(os.Stderr, pretty, "◆", "loaded config from %s", filepath.Base(cfgResult.Path))
+	}
+	if cfg == nil {
+		fmt.Fprintln(os.Stderr, "error: no tsgonest config found")
+		return 1
+	}
+	if len(cfg.OpenAPIOutputs) == 0 {
+		fmt.Fprintln(os.Stderr, "error: no OpenAPI outputs configured")
+		return 1
+	}
+
+	// Filter outputs by --name
+	outputs := cfg.OpenAPIOutputs
+	if *nameFilter != "" {
+		var found bool
+		for _, o := range outputs {
+			if o.Name == *nameFilter {
+				outputs = []config.OpenAPIOutputConfig{o}
+				found = true
+				break
+			}
+		}
+		if !found {
+			fmt.Fprintf(os.Stderr, "error: no OpenAPI output named %q\n", *nameFilter)
+			return 1
+		}
+	}
+
+	// Apply --output override (only valid for single output)
+	if *outputOverride != "" {
+		if len(outputs) > 1 {
+			fmt.Fprintln(os.Stderr, "error: --output cannot be used with multiple OpenAPI outputs; use --name to select one")
+			return 1
+		}
+		outputs[0].Output = *outputOverride
+	}
+
+	// Parse tsconfig
+	tsFS := compiler.CreateDefaultFS()
+	host := compiler.CreateDefaultHost(cwd, tsFS)
+	printStatus(os.Stderr, pretty, "◆", "parsing tsconfig: %s", *tsconfigPath)
+
+	parsedConfig, diags, err := compiler.ParseTSConfig(tsFS, cwd, *tsconfigPath, host, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	if len(diags) > 0 {
+		fmt.Fprint(os.Stderr, compiler.FormatDiagnostics(diags))
+		return 1
+	}
+
+	// Create program
+	program, programDiags, err := compiler.CreateProgramFromConfig(false, parsedConfig, host)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	if len(programDiags) > 0 {
+		fmt.Fprint(os.Stderr, compiler.FormatDiagnostics(programDiags))
+	}
+
+	// Gather diagnostics (default: --check)
+	diagStart := time.Now()
+	allDiags := compiler.GatherDiagnostics(program, *noCheck)
+	if len(allDiags) > 0 {
+		reportDiag := compiler.CreateDiagnosticReporter(os.Stderr, cwd, pretty)
+		for _, d := range allDiags {
+			reportDiag(d)
+		}
+	}
+	hasErrors := compiler.CountErrors(allDiags) > 0
+	printStatus(os.Stderr, pretty, "◆", "diagnostics: %s", time.Since(diagStart).Round(time.Millisecond))
+	if hasErrors {
+		return 1
+	}
+
+	// Get type checker for controller analysis
+	sharedChecker, release := program.GetTypeChecker(context.Background())
+	if sharedChecker == nil {
+		fmt.Fprintln(os.Stderr, "error: could not get type checker")
+		return 1
+	}
+	defer release()
+
+	sharedWalker := analyzer.NewTypeWalker(sharedChecker)
+
+	// Analyze controllers
+	ca := analyzer.NewControllerAnalyzerWithWalker(program, sharedChecker, sharedWalker)
+	controllers := ca.AnalyzeProgram(cfg.Controllers.Include, cfg.Controllers.Exclude)
+	controllerRegistry := ca.Registry()
+	printStatus(os.Stderr, pretty, "✓", "analyzed %d controller(s)", len(controllers))
+
+	if len(controllers) == 0 {
+		fmt.Fprintln(os.Stderr, "warning: no controllers found matching include patterns")
+		return 0
+	}
+
+	// Generate each output
+	for i := range outputs {
+		outputCfg := &outputs[i]
+		if outputCfg.Output == "" {
+			continue
+		}
+
+		// Post-filter controllers for this output
+		filtered := controllers
+		if outputCfg.Controllers != nil || len(outputCfg.IncludeTags) > 0 || len(outputCfg.ExcludeTags) > 0 {
+			filterOpts := openapi.FilterOptions{
+				IncludeTags: outputCfg.IncludeTags,
+				ExcludeTags: outputCfg.ExcludeTags,
+			}
+			if outputCfg.Controllers != nil {
+				filterOpts.ControllerInclude = outputCfg.Controllers.Include
+				filterOpts.ControllerExclude = outputCfg.Controllers.Exclude
+			}
+			filtered = openapi.FilterControllers(controllers, filterOpts)
+		}
+		if len(filtered) == 0 {
+			label := outputCfg.Output
+			if outputCfg.Name != "" {
+				label = outputCfg.Name
+			}
+			printStatus(os.Stderr, pretty, "·", "skipping %s: no controllers after filtering", label)
+			continue
+		}
+
+		if err := generateOpenAPIFromOutput(filtered, controllerRegistry, outputCfg, cfg, configDir); err != nil {
+			label := outputCfg.Output
+			if outputCfg.Name != "" {
+				label = outputCfg.Name + " (" + outputCfg.Output + ")"
+			}
+			fmt.Fprintf(os.Stderr, "error generating OpenAPI %s: %v\n", label, err)
+			return 1
+		}
+	}
+
+	// Print warnings
+	var allWarnings []string
+	for _, w := range ca.Warnings() {
+		allWarnings = append(allWarnings, w.Message)
+	}
+	allWarnings = append(allWarnings, sharedWalker.Warnings()...)
+	if len(allWarnings) > 0 {
+		fmt.Fprintln(os.Stderr)
+		for _, w := range allWarnings {
+			printStatus(os.Stderr, pretty, "●", "%s", w)
+		}
+	}
+
+	printStatus(os.Stderr, pretty, "✓", "done in %s", time.Since(start).Round(time.Millisecond))
+	return 0
+}

--- a/internal/analyzer/glob.go
+++ b/internal/analyzer/glob.go
@@ -72,11 +72,9 @@ func globMatch(filePath, pattern string) bool {
 				return true
 			}
 		} else {
-			// Pattern like src/**/*.controller.ts — find prefix in path, then match suffix
-			searchStr := "/" + prefix + "/"
-			idx := strings.Index(filePath, searchStr)
-			if idx >= 0 {
-				remaining := filePath[idx+len(searchStr):]
+			// Pattern like src/**/*.controller.ts — find prefix in path, then match suffix.
+			// Check both "/prefix/" (absolute paths) and "prefix/" at the start (relative paths).
+			matchRemaining := func(remaining string) bool {
 				if suffix == "" {
 					return true
 				}
@@ -85,6 +83,22 @@ func globMatch(filePath, pattern string) bool {
 					return true
 				}
 				if matched, _ := filepath.Match(suffix, remaining); matched {
+					return true
+				}
+				return false
+			}
+
+			// Check for /prefix/ anywhere in the path (handles absolute paths)
+			searchStr := "/" + prefix + "/"
+			if idx := strings.Index(filePath, searchStr); idx >= 0 {
+				if matchRemaining(filePath[idx+len(searchStr):]) {
+					return true
+				}
+			}
+
+			// Check for prefix/ at the start of the path (handles relative paths)
+			if strings.HasPrefix(filePath, prefix+"/") {
+				if matchRemaining(filePath[len(prefix)+1:]) {
 					return true
 				}
 			}

--- a/internal/analyzer/glob_test.go
+++ b/internal/analyzer/glob_test.go
@@ -2,6 +2,242 @@ package analyzer
 
 import "testing"
 
+func TestGlobMatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		pattern string
+		want    bool
+	}{
+		// ── Basic ** patterns with relative paths ────────────────────────
+		{
+			name:    "double-star with suffix matches relative path",
+			path:    "src/public/meeting.controller.ts",
+			pattern: "src/**/*.controller.ts",
+			want:    true,
+		},
+		{
+			name:    "double-star matches deeply nested relative path",
+			path:    "src/public/v1/controllers/meeting.controller.ts",
+			pattern: "src/**/*.controller.ts",
+			want:    true,
+		},
+		{
+			name:    "double-star with subdirectory prefix matches",
+			path:    "src/public/meeting.controller.ts",
+			pattern: "src/public/**/*.controller.ts",
+			want:    true,
+		},
+		{
+			name:    "double-star with subdirectory prefix rejects non-matching prefix",
+			path:    "src/internal/meeting.controller.ts",
+			pattern: "src/public/**/*.controller.ts",
+			want:    false,
+		},
+		{
+			name:    "double-star with no prefix",
+			path:    "src/public/meeting.controller.ts",
+			pattern: "**/*.controller.ts",
+			want:    true,
+		},
+
+		// ── Absolute paths (tsgo sf.FileName()) vs relative patterns ────
+		{
+			name:    "relative pattern matches absolute path",
+			path:    "/Users/dev/project/src/public/meeting.controller.ts",
+			pattern: "src/**/*.controller.ts",
+			want:    true,
+		},
+		{
+			name:    "relative pattern with subdirectory matches absolute path",
+			path:    "/Users/dev/project/src/public/meeting.controller.ts",
+			pattern: "src/public/**/*.controller.ts",
+			want:    true,
+		},
+		{
+			name:    "relative pattern rejects absolute path with wrong subdirectory",
+			path:    "/Users/dev/project/src/internal/admin.controller.ts",
+			pattern: "src/public/**/*.controller.ts",
+			want:    false,
+		},
+		{
+			name:    "deeply nested absolute path matches relative pattern",
+			path:    "/Users/dev/project/src/public/v1/controllers/meeting.controller.ts",
+			pattern: "src/public/**/*.controller.ts",
+			want:    true,
+		},
+		{
+			name:    "double-star no prefix matches absolute path",
+			path:    "/Users/dev/project/src/public/meeting.controller.ts",
+			pattern: "**/*.controller.ts",
+			want:    true,
+		},
+		{
+			name:    "suffix mismatch rejects absolute path",
+			path:    "/Users/dev/project/src/public/meeting.service.ts",
+			pattern: "src/public/**/*.controller.ts",
+			want:    false,
+		},
+
+		// ── No ** patterns (basename matching) ──────────────────────────
+		{
+			name:    "basename glob matches",
+			path:    "/Users/dev/project/src/meeting.controller.ts",
+			pattern: "*.controller.ts",
+			want:    true,
+		},
+		{
+			name:    "basename glob rejects non-matching suffix",
+			path:    "/Users/dev/project/src/meeting.service.ts",
+			pattern: "*.controller.ts",
+			want:    false,
+		},
+		{
+			name:    "exact path match",
+			path:    "src/meeting.controller.ts",
+			pattern: "src/meeting.controller.ts",
+			want:    true,
+		},
+
+		// ── Edge cases ──────────────────────────────────────────────────
+		{
+			name:    "double-star alone matches any file",
+			path:    "/some/deep/path/file.ts",
+			pattern: "**",
+			want:    true,
+		},
+		{
+			name:    "prefix appearing in username doesn't cause false match",
+			path:    "/Users/src/other/project/lib/foo.controller.ts",
+			pattern: "src/public/**/*.controller.ts",
+			want:    false,
+		},
+		{
+			name:    "node_modules path does not match src pattern",
+			path:    "/project/node_modules/src/public/foo.controller.ts",
+			pattern: "src/public/**/*.controller.ts",
+			want:    true, // globMatch only checks for /src/public/ substring
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := globMatch(tt.path, tt.pattern)
+			if got != tt.want {
+				t.Errorf("globMatch(%q, %q) = %v, want %v",
+					tt.path, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesGlob(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		include  []string
+		exclude  []string
+		want     bool
+	}{
+		// ── Include-only ─────────────────────────────────────────────────
+		{
+			name:     "matches include pattern",
+			filePath: "/Users/dev/project/src/public/meeting.controller.ts",
+			include:  []string{"src/**/*.controller.ts"},
+			want:     true,
+		},
+		{
+			name:     "no match for include pattern",
+			filePath: "/Users/dev/project/src/public/meeting.service.ts",
+			include:  []string{"src/**/*.controller.ts"},
+			want:     false,
+		},
+		{
+			name:     "empty include returns false",
+			filePath: "/Users/dev/project/src/public/meeting.controller.ts",
+			include:  []string{},
+			want:     false,
+		},
+		{
+			name:     "nil include returns false",
+			filePath: "/Users/dev/project/src/public/meeting.controller.ts",
+			include:  nil,
+			want:     false,
+		},
+		{
+			name:     "multiple include patterns — first matches",
+			filePath: "/Users/dev/project/src/public/meeting.controller.ts",
+			include:  []string{"src/public/**/*.controller.ts", "src/internal/**/*.controller.ts"},
+			want:     true,
+		},
+		{
+			name:     "multiple include patterns — second matches",
+			filePath: "/Users/dev/project/src/internal/admin.controller.ts",
+			include:  []string{"src/public/**/*.controller.ts", "src/internal/**/*.controller.ts"},
+			want:     true,
+		},
+		{
+			name:     "multiple include patterns — none match",
+			filePath: "/Users/dev/project/src/other/foo.controller.ts",
+			include:  []string{"src/public/**/*.controller.ts", "src/internal/**/*.controller.ts"},
+			want:     false,
+		},
+
+		// ── Include + Exclude ────────────────────────────────────────────
+		{
+			name:     "exclude overrides include",
+			filePath: "/Users/dev/project/src/public/deprecated.controller.ts",
+			include:  []string{"src/**/*.controller.ts"},
+			exclude:  []string{"src/**/deprecated.controller.ts"},
+			want:     false,
+		},
+		{
+			name:     "exclude does not affect non-matching files",
+			filePath: "/Users/dev/project/src/public/meeting.controller.ts",
+			include:  []string{"src/**/*.controller.ts"},
+			exclude:  []string{"src/**/deprecated.controller.ts"},
+			want:     true,
+		},
+		{
+			name:     "broad exclude pattern",
+			filePath: "/Users/dev/project/src/internal/admin.controller.ts",
+			include:  []string{"src/**/*.controller.ts"},
+			exclude:  []string{"src/internal/**/*.controller.ts"},
+			want:     false,
+		},
+
+		// ── The exact issue scenario ─────────────────────────────────────
+		{
+			name:     "issue #71: narrow include for public controllers",
+			filePath: "/Users/dev/project/src/public/clients/public.clients.controller.ts",
+			include:  []string{"src/public/**/*.controller.ts"},
+			want:     true,
+		},
+		{
+			name:     "issue #71: narrow include rejects internal controllers",
+			filePath: "/Users/dev/project/src/clients/clients.controller.ts",
+			include:  []string{"src/public/**/*.controller.ts"},
+			want:     false,
+		},
+		{
+			name:     "issue #71: narrow include rejects other module controllers",
+			filePath: "/Users/dev/project/src/calendar/controllers/calendar.controller.ts",
+			include:  []string{"src/public/**/*.controller.ts"},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MatchesGlob(tt.filePath, tt.include, tt.exclude)
+			if got != tt.want {
+				t.Errorf("MatchesGlob(%q, include=%v, exclude=%v) = %v, want %v",
+					tt.filePath, tt.include, tt.exclude, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMatchesTypeNamePattern(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,9 +15,21 @@ import (
 type Config struct {
 	Controllers ControllersConfig `json:"controllers"`
 	Transforms  TransformsConfig  `json:"transforms"`
-	OpenAPI     OpenAPIConfig     `json:"openapi"`
-	SDK         SDKConfig         `json:"sdk,omitempty"`
-	NestJS      NestJSConfig      `json:"nestjs,omitempty"`
+
+	// OpenAPI is the legacy single-output config, populated from the first element
+	// of OpenAPIOutputs for backward compatibility. Not directly JSON-deserialized.
+	OpenAPI OpenAPIConfig `json:"-"`
+
+	// OpenAPIOutputs is the resolved list of OpenAPI output configurations.
+	// Populated by resolveOpenAPI() from OpenAPIRaw after JSON unmarshaling.
+	OpenAPIOutputs []OpenAPIOutputConfig `json:"-"`
+
+	// OpenAPIRaw holds the raw JSON for the "openapi" field.
+	// Can be a single object or an array. Resolved by resolveOpenAPI().
+	OpenAPIRaw json.RawMessage `json:"openapi,omitempty"`
+
+	SDK    SDKConfig    `json:"sdk,omitempty"`
+	NestJS NestJSConfig `json:"nestjs,omitempty"`
 
 	// Dev/build settings (matching nest-cli.json conventions)
 	EntryFile     string `json:"entryFile,omitempty"`     // Entry point name without extension (default: "main")
@@ -41,12 +53,12 @@ type ControllersConfig struct {
 
 // TransformsConfig specifies which code transformations to apply.
 type TransformsConfig struct {
-	Validation        bool     `json:"validation"`
-	Serialization     bool     `json:"serialization"`
-	StandardSchema    bool     `json:"standardSchema,omitempty"`    // Generate Standard Schema v1 wrappers (default: false)
+	Validation         bool     `json:"validation"`
+	Serialization      bool     `json:"serialization"`
+	StandardSchema     bool     `json:"standardSchema,omitempty"`     // Generate Standard Schema v1 wrappers (default: false)
 	ResponseSerializer string   `json:"responseSerializer,omitempty"` // "guard" (default), "safe", or "none" — controls type checking on response serialization
-	Include           []string `json:"include,omitempty"`           // Glob patterns for source files to generate companions for (e.g., ["src/**/*.dto.ts"])
-	Exclude           []string `json:"exclude,omitempty"`           // Type name patterns to exclude from codegen (e.g., "Legacy*", "SomeInternalDto")
+	Include            []string `json:"include,omitempty"`            // Glob patterns for source files to generate companions for (e.g., ["src/**/*.dto.ts"])
+	Exclude            []string `json:"exclude,omitempty"`            // Type name patterns to exclude from codegen (e.g., "Legacy*", "SomeInternalDto")
 }
 
 // OpenAPIConfig specifies OpenAPI generation settings.
@@ -67,6 +79,47 @@ type OpenAPIConfig struct {
 	Tags []OpenAPITag `json:"tags,omitempty"`
 	// TermsOfService is the URL to the API terms of service.
 	TermsOfService string `json:"termsOfService,omitempty"`
+}
+
+// OpenAPIOutputConfig represents a single OpenAPI output specification.
+// Used in both single-output and multi-output modes.
+type OpenAPIOutputConfig struct {
+	// Name is the logical name for this output (e.g., "public", "internal").
+	// Optional for single-output; useful for --name flag in multi-output mode.
+	Name string `json:"name,omitempty"`
+
+	// Output path for the generated OpenAPI document.
+	Output string `json:"output"`
+
+	// Controllers overrides the top-level controllers.include/exclude for this output.
+	// When nil, inherits from the top-level controllers config.
+	Controllers *ControllersConfig `json:"controllers,omitempty"`
+
+	// IncludeTags keeps only routes matching at least one of these tags.
+	IncludeTags []string `json:"includeTags,omitempty"`
+	// ExcludeTags removes routes matching any of these tags.
+	ExcludeTags []string `json:"excludeTags,omitempty"`
+
+	// SDK configures per-output SDK generation. When set, SDK is generated
+	// from this output's OpenAPI spec.
+	SDK *SDKOutputConfig `json:"sdk,omitempty"`
+
+	// Document metadata (same fields as OpenAPIConfig).
+	Title           string                           `json:"title,omitempty"`
+	Description     string                           `json:"description,omitempty"`
+	Version         string                           `json:"version,omitempty"`
+	Contact         *OpenAPIContact                  `json:"contact,omitempty"`
+	License         *OpenAPILicense                  `json:"license,omitempty"`
+	Servers         []OpenAPIServer                  `json:"servers,omitempty"`
+	SecuritySchemes map[string]OpenAPISecurityScheme `json:"securitySchemes,omitempty"`
+	Security        []map[string][]string            `json:"security,omitempty"`
+	Tags            []OpenAPITag                     `json:"tags,omitempty"`
+	TermsOfService  string                           `json:"termsOfService,omitempty"`
+}
+
+// SDKOutputConfig specifies per-output SDK generation settings.
+type SDKOutputConfig struct {
+	Output string `json:"output"` // SDK output directory for this OpenAPI output
 }
 
 // OpenAPITag represents a tag with an optional description in the OpenAPI document.
@@ -118,19 +171,21 @@ type VersioningConfig struct {
 }
 
 // DefaultConfig returns a config with sensible defaults.
+// When loading from JSON/TS, resolveOpenAPI() overrides OpenAPI/OpenAPIOutputs
+// from the raw JSON. For non-loading use cases, defaults are pre-populated.
 func DefaultConfig() Config {
+	defaultOutput := OpenAPIOutputConfig{Output: "dist/openapi.json"}
 	return Config{
 		Controllers: ControllersConfig{
 			Include: []string{"src/**/*.controller.ts"},
 		},
 		Transforms: TransformsConfig{
-			Validation:        true,
-			Serialization:     true,
+			Validation:         true,
+			Serialization:      true,
 			ResponseSerializer: "guard",
 		},
-		OpenAPI: OpenAPIConfig{
-			Output: "dist/openapi.json",
-		},
+		OpenAPI:        outputToLegacyConfig(defaultOutput),
+		OpenAPIOutputs: []OpenAPIOutputConfig{defaultOutput},
 	}
 }
 
@@ -175,6 +230,10 @@ func LoadJSON(path string) (*Config, error) {
 	config := DefaultConfig()
 	if err := json.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse config file %q: %w", path, err)
+	}
+
+	if err := config.resolveOpenAPI(); err != nil {
+		return nil, fmt.Errorf("invalid config in %q: %w", path, err)
 	}
 
 	if err := config.Validate(); err != nil {
@@ -239,6 +298,10 @@ func LoadTS(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config from %q: %w", path, err)
 	}
 
+	if err := config.resolveOpenAPI(); err != nil {
+		return nil, fmt.Errorf("invalid config in %q: %w", path, err)
+	}
+
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config in %q: %w", path, err)
 	}
@@ -283,18 +346,85 @@ func execRuntime(runtime string, dir string, args []string) ([]byte, error) {
 	}
 }
 
+// resolveOpenAPI parses the raw JSON "openapi" field into OpenAPIOutputs.
+// Supports both a single object (backward-compatible) and an array of outputs.
+// Must be called after JSON unmarshaling and before Validate().
+func (c *Config) resolveOpenAPI() error {
+	if len(c.OpenAPIRaw) == 0 || string(c.OpenAPIRaw) == "null" {
+		// No openapi specified — use default single output
+		c.OpenAPIOutputs = []OpenAPIOutputConfig{{Output: "dist/openapi.json"}}
+		c.OpenAPI = outputToLegacyConfig(c.OpenAPIOutputs[0])
+		return nil
+	}
+
+	trimmed := bytes.TrimSpace(c.OpenAPIRaw)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		// Array mode: multiple outputs
+		var outputs []OpenAPIOutputConfig
+		if err := json.Unmarshal(c.OpenAPIRaw, &outputs); err != nil {
+			return fmt.Errorf("parsing openapi array: %w", err)
+		}
+		c.OpenAPIOutputs = outputs
+	} else {
+		// Single object mode (backward-compatible)
+		var output OpenAPIOutputConfig
+		if err := json.Unmarshal(c.OpenAPIRaw, &output); err != nil {
+			return fmt.Errorf("parsing openapi config: %w", err)
+		}
+		c.OpenAPIOutputs = []OpenAPIOutputConfig{output}
+	}
+
+	// Populate legacy OpenAPI from first output for backward compat
+	if len(c.OpenAPIOutputs) > 0 {
+		c.OpenAPI = outputToLegacyConfig(c.OpenAPIOutputs[0])
+	}
+
+	return nil
+}
+
+// outputToLegacyConfig converts an OpenAPIOutputConfig to the legacy OpenAPIConfig struct.
+func outputToLegacyConfig(o OpenAPIOutputConfig) OpenAPIConfig {
+	return OpenAPIConfig{
+		Output:          o.Output,
+		Title:           o.Title,
+		Description:     o.Description,
+		Version:         o.Version,
+		Contact:         o.Contact,
+		License:         o.License,
+		Servers:         o.Servers,
+		SecuritySchemes: o.SecuritySchemes,
+		Security:        o.Security,
+		Tags:            o.Tags,
+		TermsOfService:  o.TermsOfService,
+	}
+}
+
 // Validate checks the config for logical errors.
 func (c *Config) Validate() error {
 	if len(c.Controllers.Include) == 0 {
 		return fmt.Errorf("controllers.include must have at least one pattern")
 	}
 
-	// OpenAPI output is optional — empty string means "no OpenAPI generation".
-	// When set, ensure the output path has a .json extension.
-	if c.OpenAPI.Output != "" {
-		ext := filepath.Ext(c.OpenAPI.Output)
+	// Validate each OpenAPI output
+	outputPaths := make(map[string]bool)
+	outputNames := make(map[string]bool)
+	for i, o := range c.OpenAPIOutputs {
+		if o.Output == "" {
+			continue // empty output means "skip this output"
+		}
+		ext := filepath.Ext(o.Output)
 		if ext != ".json" {
-			return fmt.Errorf("openapi.output must have a .json extension, got %q", ext)
+			return fmt.Errorf("openapi[%d].output must have a .json extension, got %q", i, ext)
+		}
+		if outputPaths[o.Output] {
+			return fmt.Errorf("duplicate openapi output path: %q", o.Output)
+		}
+		outputPaths[o.Output] = true
+		if o.Name != "" {
+			if outputNames[o.Name] {
+				return fmt.Errorf("duplicate openapi output name: %q", o.Name)
+			}
+			outputNames[o.Name] = true
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -152,7 +152,7 @@ func TestValidateCompanionsOnlyNoOpenAPI(t *testing.T) {
 
 func TestValidateNonJSONOpenAPIOutput(t *testing.T) {
 	cfg := DefaultConfig()
-	cfg.OpenAPI.Output = "dist/openapi.yaml"
+	cfg.OpenAPIOutputs = []OpenAPIOutputConfig{{Output: "dist/openapi.yaml"}}
 
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("expected validation error for non-json openapi output")
@@ -708,5 +708,159 @@ func TestLoadTS_ViaLoadDispatch(t *testing.T) {
 	}
 	if cfg.Controllers.Include[0] != "src/**/*.controller.ts" {
 		t.Fatalf("unexpected include: %v", cfg.Controllers.Include)
+	}
+}
+
+// ── Multi-output OpenAPI config tests ────────────────────────────────
+
+func TestOpenAPISingleObjectBackwardCompat(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "tsgonest.config.json")
+	content := `{
+		"controllers": { "include": ["src/**/*.controller.ts"] },
+		"openapi": {
+			"output": "dist/openapi.json",
+			"title": "My API",
+			"version": "1.0.0"
+		}
+	}`
+	os.WriteFile(configPath, []byte(content), 0o644)
+
+	cfg, err := LoadJSON(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Legacy field should be populated
+	if cfg.OpenAPI.Output != "dist/openapi.json" {
+		t.Fatalf("expected legacy output 'dist/openapi.json', got %q", cfg.OpenAPI.Output)
+	}
+	if cfg.OpenAPI.Title != "My API" {
+		t.Fatalf("expected legacy title 'My API', got %q", cfg.OpenAPI.Title)
+	}
+
+	// OpenAPIOutputs should have one entry
+	if len(cfg.OpenAPIOutputs) != 1 {
+		t.Fatalf("expected 1 output, got %d", len(cfg.OpenAPIOutputs))
+	}
+	if cfg.OpenAPIOutputs[0].Output != "dist/openapi.json" {
+		t.Fatalf("expected output 'dist/openapi.json', got %q", cfg.OpenAPIOutputs[0].Output)
+	}
+}
+
+func TestOpenAPIArrayMultiOutput(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "tsgonest.config.json")
+	content := `{
+		"controllers": { "include": ["src/**/*.controller.ts"] },
+		"openapi": [
+			{
+				"name": "public",
+				"output": "dist/public-api.json",
+				"title": "Public API",
+				"controllers": {
+					"include": ["src/public/**/*.controller.ts"]
+				},
+				"includeTags": ["public"]
+			},
+			{
+				"name": "internal",
+				"output": "dist/internal-api.json",
+				"title": "Internal API",
+				"excludeTags": ["deprecated"]
+			}
+		]
+	}`
+	os.WriteFile(configPath, []byte(content), 0o644)
+
+	cfg, err := LoadJSON(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.OpenAPIOutputs) != 2 {
+		t.Fatalf("expected 2 outputs, got %d", len(cfg.OpenAPIOutputs))
+	}
+
+	// Check first output
+	pub := cfg.OpenAPIOutputs[0]
+	if pub.Name != "public" {
+		t.Fatalf("expected name 'public', got %q", pub.Name)
+	}
+	if pub.Output != "dist/public-api.json" {
+		t.Fatalf("expected output 'dist/public-api.json', got %q", pub.Output)
+	}
+	if pub.Controllers == nil || len(pub.Controllers.Include) != 1 {
+		t.Fatal("expected per-output controllers config")
+	}
+	if len(pub.IncludeTags) != 1 || pub.IncludeTags[0] != "public" {
+		t.Fatalf("expected includeTags ['public'], got %v", pub.IncludeTags)
+	}
+
+	// Check second output
+	internal := cfg.OpenAPIOutputs[1]
+	if internal.Name != "internal" {
+		t.Fatalf("expected name 'internal', got %q", internal.Name)
+	}
+	if len(internal.ExcludeTags) != 1 || internal.ExcludeTags[0] != "deprecated" {
+		t.Fatalf("expected excludeTags ['deprecated'], got %v", internal.ExcludeTags)
+	}
+
+	// Legacy field should be populated from first output
+	if cfg.OpenAPI.Output != "dist/public-api.json" {
+		t.Fatalf("expected legacy output from first entry, got %q", cfg.OpenAPI.Output)
+	}
+	if cfg.OpenAPI.Title != "Public API" {
+		t.Fatalf("expected legacy title from first entry, got %q", cfg.OpenAPI.Title)
+	}
+}
+
+func TestOpenAPIValidationDuplicateOutputPaths(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.OpenAPIOutputs = []OpenAPIOutputConfig{
+		{Output: "dist/api.json"},
+		{Output: "dist/api.json"},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for duplicate output paths")
+	} else if !strings.Contains(err.Error(), "duplicate openapi output path") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOpenAPIValidationDuplicateNames(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.OpenAPIOutputs = []OpenAPIOutputConfig{
+		{Name: "api", Output: "dist/api1.json"},
+		{Name: "api", Output: "dist/api2.json"},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for duplicate output names")
+	} else if !strings.Contains(err.Error(), "duplicate openapi output name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOpenAPINoOutputMeansDefault(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "tsgonest.config.json")
+	// No openapi field at all — should get default
+	content := `{
+		"controllers": { "include": ["src/**/*.controller.ts"] }
+	}`
+	os.WriteFile(configPath, []byte(content), 0o644)
+
+	cfg, err := LoadJSON(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.OpenAPIOutputs) != 1 {
+		t.Fatalf("expected 1 default output, got %d", len(cfg.OpenAPIOutputs))
+	}
+	if cfg.OpenAPIOutputs[0].Output != "dist/openapi.json" {
+		t.Fatalf("expected default output 'dist/openapi.json', got %q", cfg.OpenAPIOutputs[0].Output)
 	}
 }

--- a/internal/openapi/filter.go
+++ b/internal/openapi/filter.go
@@ -1,0 +1,97 @@
+package openapi
+
+import "github.com/tsgonest/tsgonest/internal/analyzer"
+
+// FilterOptions controls which controllers/routes appear in an OpenAPI output.
+type FilterOptions struct {
+	// ControllerInclude keeps only controllers from source files matching these globs.
+	ControllerInclude []string
+	// ControllerExclude removes controllers from source files matching these globs.
+	ControllerExclude []string
+	// IncludeTags keeps only routes where at least one tag is in this set.
+	IncludeTags []string
+	// ExcludeTags removes routes where any tag is in this set.
+	ExcludeTags []string
+}
+
+// FilterControllers returns a filtered copy of the controllers list.
+// File glob filters are applied first, then tag filters (AND composition).
+// Controllers with zero routes after filtering are excluded.
+func FilterControllers(controllers []analyzer.ControllerInfo, opts FilterOptions) []analyzer.ControllerInfo {
+	hasGlobFilter := len(opts.ControllerInclude) > 0 || len(opts.ControllerExclude) > 0
+	hasTagFilter := len(opts.IncludeTags) > 0 || len(opts.ExcludeTags) > 0
+
+	if !hasGlobFilter && !hasTagFilter {
+		return controllers
+	}
+
+	// Build tag lookup sets
+	includeSet := toSet(opts.IncludeTags)
+	excludeSet := toSet(opts.ExcludeTags)
+
+	var result []analyzer.ControllerInfo
+	for _, ctrl := range controllers {
+		// Step 1: File glob filter
+		if hasGlobFilter {
+			if !analyzer.MatchesGlob(ctrl.SourceFile, opts.ControllerInclude, opts.ControllerExclude) {
+				continue
+			}
+		}
+
+		// Step 2: Tag filter on routes
+		if hasTagFilter {
+			var filteredRoutes []analyzer.Route
+			for _, route := range ctrl.Routes {
+				if matchesTags(route.Tags, includeSet, excludeSet) {
+					filteredRoutes = append(filteredRoutes, route)
+				}
+			}
+			if len(filteredRoutes) == 0 {
+				continue
+			}
+			// Copy controller with filtered routes
+			filtered := ctrl
+			filtered.Routes = filteredRoutes
+			result = append(result, filtered)
+		} else {
+			result = append(result, ctrl)
+		}
+	}
+
+	return result
+}
+
+// matchesTags checks if a route's tags pass include/exclude filters.
+func matchesTags(tags []string, includeSet, excludeSet map[string]bool) bool {
+	// ExcludeTags: reject if any tag matches
+	if len(excludeSet) > 0 {
+		for _, tag := range tags {
+			if excludeSet[tag] {
+				return false
+			}
+		}
+	}
+
+	// IncludeTags: accept if at least one tag matches
+	if len(includeSet) > 0 {
+		for _, tag := range tags {
+			if includeSet[tag] {
+				return true
+			}
+		}
+		return false // no tag matched the include set
+	}
+
+	return true
+}
+
+func toSet(items []string) map[string]bool {
+	if len(items) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(items))
+	for _, item := range items {
+		set[item] = true
+	}
+	return set
+}

--- a/internal/openapi/filter_test.go
+++ b/internal/openapi/filter_test.go
@@ -1,0 +1,194 @@
+package openapi
+
+import (
+	"testing"
+
+	"github.com/tsgonest/tsgonest/internal/analyzer"
+)
+
+func makeControllers() []analyzer.ControllerInfo {
+	return []analyzer.ControllerInfo{
+		{
+			Name:       "PublicUsersController",
+			SourceFile: "/project/src/public/users.controller.ts",
+			Routes: []analyzer.Route{
+				{MethodName: "list", Tags: []string{"public", "users"}},
+				{MethodName: "get", Tags: []string{"public", "users"}},
+			},
+		},
+		{
+			Name:       "InternalUsersController",
+			SourceFile: "/project/src/internal/users.controller.ts",
+			Routes: []analyzer.Route{
+				{MethodName: "listAll", Tags: []string{"internal", "users"}},
+				{MethodName: "delete", Tags: []string{"internal", "users", "admin"}},
+			},
+		},
+		{
+			Name:       "MixedController",
+			SourceFile: "/project/src/mixed/mixed.controller.ts",
+			Routes: []analyzer.Route{
+				{MethodName: "publicEndpoint", Tags: []string{"public"}},
+				{MethodName: "internalEndpoint", Tags: []string{"internal"}},
+				{MethodName: "deprecatedEndpoint", Tags: []string{"public", "deprecated"}},
+			},
+		},
+	}
+}
+
+func TestFilterControllers_NoFilters(t *testing.T) {
+	controllers := makeControllers()
+	result := FilterControllers(controllers, FilterOptions{})
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 controllers, got %d", len(result))
+	}
+}
+
+func TestFilterControllers_GlobInclude(t *testing.T) {
+	controllers := makeControllers()
+	result := FilterControllers(controllers, FilterOptions{
+		ControllerInclude: []string{"src/public/**/*.controller.ts"},
+	})
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 controller, got %d", len(result))
+	}
+	if result[0].Name != "PublicUsersController" {
+		t.Fatalf("expected PublicUsersController, got %s", result[0].Name)
+	}
+}
+
+func TestFilterControllers_GlobExclude(t *testing.T) {
+	controllers := makeControllers()
+	result := FilterControllers(controllers, FilterOptions{
+		ControllerInclude: []string{"src/**/*.controller.ts"},
+		ControllerExclude: []string{"src/internal/**/*.controller.ts"},
+	})
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 controllers, got %d", len(result))
+	}
+	for _, c := range result {
+		if c.Name == "InternalUsersController" {
+			t.Fatal("InternalUsersController should have been excluded")
+		}
+	}
+}
+
+func TestFilterControllers_IncludeTags(t *testing.T) {
+	controllers := makeControllers()
+	result := FilterControllers(controllers, FilterOptions{
+		IncludeTags: []string{"public"},
+	})
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 controllers (PublicUsers + Mixed), got %d", len(result))
+	}
+
+	// MixedController should only have public routes
+	for _, c := range result {
+		if c.Name == "MixedController" {
+			if len(c.Routes) != 2 {
+				t.Fatalf("MixedController should have 2 public routes, got %d", len(c.Routes))
+			}
+		}
+	}
+}
+
+func TestFilterControllers_ExcludeTags(t *testing.T) {
+	controllers := makeControllers()
+	result := FilterControllers(controllers, FilterOptions{
+		ExcludeTags: []string{"deprecated"},
+	})
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 controllers, got %d", len(result))
+	}
+
+	// MixedController should have 2 routes (deprecatedEndpoint removed)
+	for _, c := range result {
+		if c.Name == "MixedController" {
+			if len(c.Routes) != 2 {
+				t.Fatalf("MixedController should have 2 routes after excluding deprecated, got %d", len(c.Routes))
+			}
+			for _, r := range c.Routes {
+				if r.MethodName == "deprecatedEndpoint" {
+					t.Fatal("deprecatedEndpoint should have been excluded")
+				}
+			}
+		}
+	}
+}
+
+func TestFilterControllers_IncludeAndExcludeTags(t *testing.T) {
+	controllers := makeControllers()
+	result := FilterControllers(controllers, FilterOptions{
+		IncludeTags: []string{"public"},
+		ExcludeTags: []string{"deprecated"},
+	})
+
+	// MixedController should only have publicEndpoint (not deprecated)
+	for _, c := range result {
+		if c.Name == "MixedController" {
+			if len(c.Routes) != 1 {
+				t.Fatalf("MixedController should have 1 route, got %d", len(c.Routes))
+			}
+			if c.Routes[0].MethodName != "publicEndpoint" {
+				t.Fatalf("expected publicEndpoint, got %s", c.Routes[0].MethodName)
+			}
+		}
+	}
+}
+
+func TestFilterControllers_GlobAndTags(t *testing.T) {
+	controllers := makeControllers()
+	result := FilterControllers(controllers, FilterOptions{
+		ControllerInclude: []string{"src/mixed/**/*.controller.ts"},
+		IncludeTags:       []string{"public"},
+	})
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 controller, got %d", len(result))
+	}
+	if result[0].Name != "MixedController" {
+		t.Fatalf("expected MixedController, got %s", result[0].Name)
+	}
+	// Should have 2 public routes (publicEndpoint + deprecatedEndpoint which is also tagged public)
+	if len(result[0].Routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(result[0].Routes))
+	}
+}
+
+func TestFilterControllers_TagFilterRemovesEmptyControllers(t *testing.T) {
+	controllers := makeControllers()
+	result := FilterControllers(controllers, FilterOptions{
+		IncludeTags: []string{"admin"},
+	})
+
+	// Only InternalUsersController has an "admin" tag (on the delete route)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 controller with admin tag, got %d", len(result))
+	}
+	if result[0].Name != "InternalUsersController" {
+		t.Fatalf("expected InternalUsersController, got %s", result[0].Name)
+	}
+	if len(result[0].Routes) != 1 {
+		t.Fatalf("expected 1 admin route, got %d", len(result[0].Routes))
+	}
+}
+
+func TestFilterControllers_DoesNotMutateOriginal(t *testing.T) {
+	controllers := makeControllers()
+	originalRouteCount := len(controllers[2].Routes) // MixedController has 3 routes
+
+	_ = FilterControllers(controllers, FilterOptions{
+		IncludeTags: []string{"public"},
+	})
+
+	// Original should be unchanged
+	if len(controllers[2].Routes) != originalRouteCount {
+		t.Fatalf("original controller was mutated: expected %d routes, got %d",
+			originalRouteCount, len(controllers[2].Routes))
+	}
+}

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -41,6 +41,58 @@ export interface SDKConfig {
   input?: string;
 }
 
+/** Per-output SDK generation settings. */
+export interface SDKOutputConfig {
+  /** SDK output directory for this OpenAPI output. */
+  output: string;
+}
+
+/**
+ * Per-output OpenAPI configuration.
+ * Used in array mode for generating multiple OpenAPI documents from a single build.
+ */
+export interface OpenAPIOutputConfig {
+  /** Logical name for this output (e.g., "public", "internal"). Used with --name flag. */
+  name?: string;
+  /** Output path for the generated OpenAPI document. Empty string disables generation. */
+  output: string;
+  /** Controller filters specific to this output. Overrides top-level controllers config. */
+  controllers?: {
+    include?: string[];
+    exclude?: string[];
+  };
+  /** Only include routes matching at least one of these tags. */
+  includeTags?: string[];
+  /** Exclude routes matching any of these tags. */
+  excludeTags?: string[];
+  /** Per-output SDK generation. When set, SDK is generated from this output's OpenAPI spec. */
+  sdk?: SDKOutputConfig;
+  /** API title for the OpenAPI info section. */
+  title?: string;
+  /** API version for the OpenAPI info section. */
+  version?: string;
+  /** API description for the OpenAPI info section. */
+  description?: string;
+  /** Contact info for the OpenAPI info section. */
+  contact?: OpenAPIContact;
+  /** License info for the OpenAPI info section. */
+  license?: OpenAPILicense;
+  /** Server list for the OpenAPI document. */
+  servers?: OpenAPIServer[];
+  /** Named security schemes for the OpenAPI document. */
+  securitySchemes?: Record<string, OpenAPISecurityScheme>;
+  /**
+   * Global security requirements applied to all operations.
+   * Routes with @public JSDoc opt out.
+   * @example [{ bearer: [] }]
+   */
+  security?: Array<Record<string, string[]>>;
+  /** Tag descriptions for the OpenAPI document. Tags referenced by controllers are auto-collected. */
+  tags?: OpenAPITag[];
+  /** URL to the API terms of service. */
+  termsOfService?: string;
+}
+
 /** API versioning settings. */
 export interface VersioningConfig {
   /** Versioning strategy: "URI" (default), "HEADER", "MEDIA_TYPE", "CUSTOM". */
@@ -97,35 +149,25 @@ export interface TsgonestConfig {
     exclude?: string[];
   };
 
-  /** OpenAPI document generation settings. Omit or set output to "" to disable. */
-  openapi?: {
-    /** Output path for the generated OpenAPI document. Empty string disables generation. */
-    output?: string;
-    /** API title for the OpenAPI info section. */
-    title?: string;
-    /** API version for the OpenAPI info section. */
-    version?: string;
-    /** API description for the OpenAPI info section. */
-    description?: string;
-    /** Contact info for the OpenAPI info section. */
-    contact?: OpenAPIContact;
-    /** License info for the OpenAPI info section. */
-    license?: OpenAPILicense;
-    /** Server list for the OpenAPI document. */
-    servers?: OpenAPIServer[];
-    /** Named security schemes for the OpenAPI document. */
-    securitySchemes?: Record<string, OpenAPISecurityScheme>;
-    /**
-     * Global security requirements applied to all operations.
-     * Routes with @public JSDoc opt out.
-     * @example [{ bearer: [] }]
-     */
-    security?: Array<Record<string, string[]>>;
-    /** Tag descriptions for the OpenAPI document. Tags referenced by controllers are auto-collected. */
-    tags?: OpenAPITag[];
-    /** URL to the API terms of service. */
-    termsOfService?: string;
-  };
+  /**
+   * OpenAPI document generation settings.
+   * Accepts a single output config (backward-compatible) or an array for multiple outputs.
+   * Omit or set output to "" to disable generation.
+   *
+   * @example Single output:
+   * ```ts
+   * openapi: { output: "dist/openapi.json", title: "My API" }
+   * ```
+   *
+   * @example Multiple outputs:
+   * ```ts
+   * openapi: [
+   *   { name: "public", output: "dist/public-api.json", includeTags: ["public"] },
+   *   { name: "internal", output: "dist/internal-api.json" },
+   * ]
+   * ```
+   */
+  openapi?: OpenAPIOutputConfig | OpenAPIOutputConfig[];
 
   /** TypeScript SDK generation settings. */
   sdk?: SDKConfig;


### PR DESCRIPTION
## Summary

Closes #71 (PR 1 of 2)

- **Fix glob matching bug**: relative paths starting with the prefix directory (e.g., `src/public/**/*.controller.ts`) were not matched — added relative-path-start check in `globMatch`
- **Multi-output OpenAPI config**: `openapi` field now accepts a single object (backward-compat) or an array of `OpenAPIOutputConfig`, each with `name`, `controllers` (include/exclude), `includeTags`, `excludeTags`, and full metadata
- **Controller/tag filtering**: new `FilterControllers` function with file glob + tag-based filtering (AND composition) for per-output controller subsetting
- **`tsgonest openapi` subcommand**: standalone spec generation that skips emit, companions, SDK, and assets. Supports `--name` flag for selective output generation
- **Docs**: multi-output config guide, `tsgonest openapi` CLI reference

### New CLI

```
tsgonest openapi                    # generate all configured outputs
tsgonest openapi --name public      # generate only the "public" output
tsgonest openapi --no-check         # skip type checking for speed
```

### New Config

```ts
export default defineConfig({
  openapi: [
    {
      name: 'public',
      output: 'dist/public-api.json',
      controllers: { include: ['src/public/**/*.controller.ts'] },
      includeTags: ['public'],
    },
    {
      name: 'internal',
      output: 'dist/internal-api.json',
      title: 'Internal API',
    },
  ],
});
```

## Test plan

- [x] `go test ./internal/...` — all 600+ tests pass
- [x] `go build ./cmd/tsgonest/` — compiles clean
- [x] `pnpm --filter @tsgonest/runtime build` — TS types compile
- [x] E2E: multi-output config generates both specs with correct paths/schemas
- [x] E2E: `tsgonest openapi --name` selects correct output
- [x] E2E: `--name` with nonexistent name exits 1

E2E tests added in PR #73 (stacked on this branch): `e2e/openapi.test.ts` with 5 tests covering multi-output generation, per-output filtering, and `--name` flag.