### PR TITLE
fix(runtime): handle ended streams in FormDataInterceptor on Node 24

### DIFF
--- a/packages/runtime/src/__tests__/form-data-body.test.ts
+++ b/packages/runtime/src/__tests__/form-data-body.test.ts
@@ -415,4 +415,147 @@ describe("FormDataInterceptor", () => {
     expect(stream.body.images[1]).toBeInstanceOf(File);
     expect(stream.body.images[1].name).toBe("b.png");
   });
+
+  it("parses via rawBody when stream is already ended (Node 24 body-parser scenario)", async () => {
+    // Simulate Node 24 + Express: body-parser middleware runs before the interceptor,
+    // consuming/ending the stream. The raw buffer is stored on req.rawBody via the
+    // verify callback (common NestJS pattern).
+    const formData = new FormData();
+    const file = new File(["avatar-data"], "photo.png", { type: "image/png" });
+    formData.append("avatar", file, file.name);
+    formData.append("username", "test-user");
+
+    const serializer = new Request("http://localhost/", { method: "POST", body: formData });
+    const contentType = serializer.headers.get("content-type")!;
+    const rawBody = Buffer.from(await serializer.arrayBuffer());
+
+    // Create a stream that's already ended (simulating body-parser consuming it)
+    const stream = new Readable({ read() {} }) as any;
+    stream.push(null);
+    const endPromise = new Promise<void>(resolve => stream.on("end", resolve));
+    stream.resume(); // switch to flowing mode so 'end' fires
+    await endPromise;
+    expect(stream.readableEnded).toBe(true);
+
+    stream.headers = { "content-type": contentType };
+    stream.method = "POST";
+    stream.url = "/upload";
+    stream.rawBody = rawBody; // set by bodyParser verify callback
+
+    const interceptor = new FormDataInterceptor();
+
+    class TestController {
+      upload(@FormDataBody() _body: any) {}
+    }
+
+    const context = {
+      getHandler: () => TestController.prototype.upload,
+      getClass: () => TestController,
+      switchToHttp: () => ({
+        getRequest: () => stream,
+        getResponse: () => ({}),
+      }),
+    };
+
+    await interceptor.intercept(context, { handle: () => ({}) });
+
+    expect(stream.body.username).toBe("test-user");
+    expect(stream.body.avatar).toBeInstanceOf(File);
+    expect(stream.body.avatar.name).toBe("photo.png");
+    expect(stream.body.avatar.type).toBe("image/png");
+    const text = await stream.body.avatar.text();
+    expect(text).toBe("avatar-data");
+  });
+
+  it("parses from internal buffer when stream ended but no rawBody", async () => {
+    // Simulate Node 24 where undici eagerly buffers the body and emits 'end',
+    // but no body-parser verify callback stored rawBody.
+    const formData = new FormData();
+    formData.append("name", "buffered-test");
+    formData.append("doc", new File(["doc-content"], "file.txt", { type: "text/plain" }), "file.txt");
+
+    const serializer = new Request("http://localhost/", { method: "POST", body: formData });
+    const contentType = serializer.headers.get("content-type")!;
+    const rawBody = Buffer.from(await serializer.arrayBuffer());
+
+    // Readable.from pushes all chunks into the internal buffer and ends
+    // the source — readableEnded becomes true, but read() still returns data.
+    const stream = Readable.from(rawBody) as any;
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    stream.headers = { "content-type": contentType };
+    stream.method = "POST";
+    stream.url = "/upload";
+
+    const interceptor = new FormDataInterceptor();
+
+    class TestController {
+      upload(@FormDataBody() _body: any) {}
+    }
+
+    const context = {
+      getHandler: () => TestController.prototype.upload,
+      getClass: () => TestController,
+      switchToHttp: () => ({
+        getRequest: () => stream,
+        getResponse: () => ({}),
+      }),
+    };
+
+    await interceptor.intercept(context, { handle: () => ({}) });
+
+    expect(stream.body.name).toBe("buffered-test");
+    expect(stream.body.doc).toBeInstanceOf(File);
+    expect(stream.body.doc.name).toBe("file.txt");
+  });
+
+  it("falls through to multer when stream ended and no data available", async () => {
+    // Edge case: stream ended, no rawBody, no buffered data — should fall through
+    // to multer without crashing.
+    const stream = new Readable({ read() {} }) as any;
+    stream.push(null);
+    const endPromise = new Promise<void>(resolve => stream.on("end", resolve));
+    stream.resume();
+    await endPromise;
+
+    stream.headers = { "content-type": "multipart/form-data; boundary=---test" };
+    stream.method = "POST";
+    stream.url = "/upload";
+
+    const multerFile = {
+      fieldname: "file",
+      originalname: "test.txt",
+      mimetype: "text/plain",
+      buffer: Buffer.from("multer-fallback"),
+    };
+    const mockMulter = {
+      any: () => (req: any, _res: any, cb: (err: any) => void) => {
+        req.files = [multerFile];
+        cb(null);
+      },
+    };
+    const factory = () => mockMulter;
+
+    const interceptor = new FormDataInterceptor();
+
+    class TestController {
+      upload(@FormDataBody(factory) _body: any) {}
+    }
+
+    const req = Object.assign(stream, { body: undefined, files: undefined });
+    const context = {
+      getHandler: () => TestController.prototype.upload,
+      getClass: () => TestController,
+      switchToHttp: () => ({
+        getRequest: () => req,
+        getResponse: () => ({}),
+      }),
+    };
+
+    await interceptor.intercept(context, { handle: () => ({}) });
+
+    // Multer fallback should have been used
+    expect(req.body.file).toBeInstanceOf(File);
+    expect(req.body.file.name).toBe("test.txt");
+  });
 });

--- a/packages/runtime/src/form-data-interceptor.ts
+++ b/packages/runtime/src/form-data-interceptor.ts
@@ -68,10 +68,13 @@ export class FormDataInterceptor {
     const stream = isFastify ? req.raw : req;
 
     // Primary path: web-native FormData parsing (Node 20+)
-    // Uses Request.formData() — immune to multer/busboy stream issues on Node 24+
-    if (canParseNative() && stream && typeof stream.pipe === 'function' && !stream.readableEnded) {
-      await parseFormDataNative(req, stream);
-      return next.handle();
+    // Uses Request.formData() — immune to multer/busboy stream issues on Node 24+.
+    // No readableEnded guard: on Node 24, the stream may be marked ended before
+    // the interceptor runs (undici buffers small bodies eagerly), but the data is
+    // still available in the internal buffer or via req.rawBody.
+    if (canParseNative() && stream && typeof stream.pipe === 'function') {
+      const parsed = await parseFormDataNative(req, stream);
+      if (parsed) return next.handle();
     }
 
     // Fallback: multer (Node < 20 or web APIs unavailable)
@@ -142,10 +145,14 @@ function canParseNative(): boolean {
  * and populates req.body with fields and File instances — same result as
  * multer + mergeMulterFiles, but without busboy stream dependencies.
  *
- * This approach is immune to the stream-timing issues that affect
- * multer/busboy on certain Node.js versions (notably Node 24 with multer < 2.1).
+ * Handles ended streams (Node 24+): when the stream is already ended (undici
+ * buffers small bodies eagerly, or body-parser middleware consumed it), falls
+ * back to req.rawBody or drains the internal buffer.
+ *
+ * Returns true if parsing succeeded, false if no data was available (caller
+ * should fall through to the multer path).
  */
-async function parseFormDataNative(req: any, stream: any): Promise<void> {
+async function parseFormDataNative(req: any, stream: any): Promise<boolean> {
   const { Readable } = require('node:stream') as typeof import('node:stream');
 
   const headers = new Headers();
@@ -155,14 +162,39 @@ async function parseFormDataNative(req: any, stream: any): Promise<void> {
     else if (Array.isArray(val)) for (const v of val) headers.append(key, v);
   }
 
-  const webRequest = new Request(`http://localhost${req.url || '/'}`, {
+  // Determine the request body source.
+  // On Node 24+, the stream may be marked ended before the interceptor runs
+  // because undici eagerly buffers small request bodies. The data is still
+  // available in the stream's internal buffer or via req.rawBody.
+  let body: BodyInit;
+  const requestInit: RequestInit & Record<string, unknown> = {
     method: req.method || 'POST',
     headers,
-    body: Readable.toWeb(stream) as ReadableStream,
-    // @ts-ignore — duplex required for streaming request bodies
-    duplex: 'half',
-  });
+  };
 
+  if (!stream.readableEnded) {
+    body = Readable.toWeb(stream) as ReadableStream;
+    requestInit.duplex = 'half';
+  } else {
+    // Stream ended — try rawBody (set by body-parser verify callback), then
+    // drain any remaining data from the internal buffer.
+    const rawBody = req.rawBody || stream.rawBody;
+    if (rawBody) {
+      body = rawBody;
+    } else {
+      const chunks: Buffer[] = [];
+      let chunk: Buffer | null;
+      while ((chunk = stream.read()) !== null) {
+        chunks.push(chunk);
+      }
+      if (chunks.length === 0) return false;
+      body = Buffer.concat(chunks);
+    }
+  }
+
+  requestInit.body = body;
+
+  const webRequest = new Request(`http://localhost${req.url || '/'}`, requestInit);
   const formData = await webRequest.formData();
 
   if (!req.body) req.body = {};
@@ -182,6 +214,8 @@ async function parseFormDataNative(req: any, stream: any): Promise<void> {
       req.body[key] = value;
     }
   }
+
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove `!stream.readableEnded` guard from `parseFormDataNative` path — on Node 24, undici eagerly buffers small request bodies, marking the stream as ended before the interceptor runs
- When stream is already ended, fall back to `req.rawBody` (body-parser verify callback) or drain the stream's internal buffer
- Return `false` when no data is available, allowing graceful fallback to multer

Closes #97

## Test plan
- [x] Existing native parsing tests still pass (17/17)
- [x] New test: rawBody path (Node 24 + body-parser verify scenario)
- [x] New test: internal buffer path (undici eager-buffering scenario)
- [x] New test: graceful fallback to multer when stream ended with no data