### PR TITLE
fix(sdkgen): use mapped type constraint in buildFormData for interface compatibility

### DIFF
--- a/internal/sdkgen/formdata.go
+++ b/internal/sdkgen/formdata.go
@@ -8,7 +8,7 @@ func generateFormData() string {
 export type FormDataValue = string | number | boolean | File | Blob | Date | null | undefined;
 export type FormDataCompatible = Record<string, FormDataValue | FormDataValue[]>;
 
-export function buildFormData<T extends FormDataCompatible>(data: T): FormData {
+export function buildFormData<T extends { [K in keyof T]: FormDataValue | FormDataValue[] }>(data: T): FormData {
   const formData = new FormData();
 
   function appendValue(key: string, value: unknown) {

--- a/internal/sdkgen/generate_test.go
+++ b/internal/sdkgen/generate_test.go
@@ -632,3 +632,33 @@ func TestGenerate_AdvancedTypes_TSEnums(t *testing.T) {
 	// Non-enum types should still be interfaces
 	assertContains(t, typesContent, "export interface Dog", "Dog should still be an interface")
 }
+
+func TestBuildFormData_InterfaceCompatibleConstraint(t *testing.T) {
+	// In TypeScript, interfaces lack an implicit index signature, so they don't
+	// satisfy Record<string, ...>. Since the SDK generator emits DTO types as
+	// interfaces, buildFormData's constraint must use a per-property mapped type
+	// ({ [K in keyof T]: ... }) instead of Record<string, ...>.
+	outputDir := t.TempDir()
+	inputPath := "../../testdata/sdkgen/file-uploads.openapi.json"
+
+	_, err := Generate(inputPath, outputDir)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	formDataContent := readFile(t, filepath.Join(outputDir, "form-data.ts"))
+
+	// The constraint should use a mapped type that checks per-property
+	assertContains(t, formDataContent, "[K in keyof T]",
+		"buildFormData constraint should use mapped type for interface compatibility")
+
+	// Must NOT use the Record-based constraint that breaks interfaces
+	assertNotContains(t, formDataContent, "extends FormDataCompatible",
+		"buildFormData should not use Record-based constraint (breaks interface types)")
+
+	// FormDataValue and FormDataCompatible should still be exported for consumers
+	assertContains(t, formDataContent, "export type FormDataValue",
+		"FormDataValue should still be exported")
+	assertContains(t, formDataContent, "export type FormDataCompatible",
+		"FormDataCompatible should still be exported for backwards compatibility")
+}


### PR DESCRIPTION
## Summary

- `buildFormData<T extends FormDataCompatible>` used `FormDataCompatible = Record<string, FormDataValue | FormDataValue[]>` as its generic constraint
- The SDK generator emits DTO types as `interface` (e.g., `export interface SingleFileUpload { file: File | Blob; }`)
- In TypeScript, interfaces don't satisfy `Record<string, ...>` because they lack an implicit index signature — only type aliases are "closed" enough
- This caused: `Index signature for type 'string' is missing in type 'SingleFileUpload'`

## Fix

Changed the generic constraint from `extends FormDataCompatible` to `extends { [K in keyof T]: FormDataValue | FormDataValue[] }` — a self-referential mapped type that validates each property individually without requiring an index signature. Works with both `interface` and `type` declarations.

`FormDataCompatible` remains exported for backwards compatibility.

## Tests

- Added `TestBuildFormData_InterfaceCompatibleConstraint` verifying the mapped type constraint is used and the Record-based constraint is not