### PR TITLE
fix(rewrite): locate chained-assignment classes and surface load-bearing rewrite misses

### DIFF
--- a/cmd/tsgonest/build.go
+++ b/cmd/tsgonest/build.go
@@ -504,6 +504,21 @@ func runBuildWithIncrAndProgram(args []string, oldIncrProgram *shimincremental.P
 		reportDiag(d)
 	}
 
+	// Drain rewrite diagnostics (controller class/method not located in emit).
+	// Errors are load-bearing — silent miss = unvalidated input hits handlers
+	// (issue #114). Warnings are recoverable degradations on individual methods.
+	var rewriteErrors []rewrite.RewriteDiagnostic
+	var rewriteWarnings []string
+	if rewriteCtx != nil {
+		for _, d := range rewriteCtx.Diagnostics() {
+			if d.IsError() {
+				rewriteErrors = append(rewriteErrors, d)
+			} else {
+				rewriteWarnings = append(rewriteWarnings, d.Format())
+			}
+		}
+	}
+
 	// Error summary (pretty mode only)
 	if pretty {
 		compiler.WriteErrorSummary(os.Stderr, allDiagnostics, cwd)
@@ -532,6 +547,21 @@ func runBuildWithIncrAndProgram(args []string, oldIncrProgram *shimincremental.P
 	// ── Early exit on diagnostic errors ──────────────────────────────────
 	// Path aliases were already resolved in the WriteFile callback.
 	if hasErrors {
+		timing.Total = time.Since(buildStart)
+		timing.Print()
+		return 1
+	}
+
+	// Rewrite errors fail the whole build. These mean the analyzer recognized
+	// a controller but the rewriter couldn't locate its class in emitted JS,
+	// so validation/serialization injection was skipped — not safe to ship.
+	if len(rewriteErrors) > 0 {
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintf(os.Stderr, "✗ %d controller rewrite error(s) — these are load-bearing injections that were skipped:\n", len(rewriteErrors))
+		for _, e := range rewriteErrors {
+			fmt.Fprintf(os.Stderr, "  %s\n", e.Format())
+		}
+		fmt.Fprintln(os.Stderr)
 		timing.Total = time.Since(buildStart)
 		timing.Print()
 		return 1
@@ -626,6 +656,7 @@ func runBuildWithIncrAndProgram(args []string, oldIncrProgram *shimincremental.P
 	if sharedWalker != nil {
 		allWarnings = append(allWarnings, sharedWalker.Warnings()...)
 	}
+	allWarnings = append(allWarnings, rewriteWarnings...)
 
 	// Generate OpenAPI documents (using pre-analyzed controllers)
 	openapiStart := time.Now()

--- a/internal/rewrite/bug_regressions_test.go
+++ b/internal/rewrite/bug_regressions_test.go
@@ -238,7 +238,7 @@ func TestBugRegressions_Rewrite(t *testing.T) {
 			}},
 		}}
 
-		got := rewriteController(input, "/dist/user.controller.js", controllers, map[string]string{}, "esm")
+		got := rewriteController(input, "/dist/user.controller.js", controllers, map[string]string{}, "esm", nil)
 		if !strings.Contains(got, "throw new __e") {
 			t.Fatalf("expected invalid boolean value guard to throw validation error, got:\n%s", got)
 		}
@@ -264,7 +264,7 @@ func TestBugRegressions_Rewrite(t *testing.T) {
 			}},
 		}}
 
-		got := rewriteController(input, "/dist/user.controller.js", controllers, map[string]string{}, "esm")
+		got := rewriteController(input, "/dist/user.controller.js", controllers, map[string]string{}, "esm", nil)
 		if !strings.Contains(got, `=== ""`) {
 			t.Fatalf("expected empty-string guard before numeric coercion, got:\n%s", got)
 		}
@@ -316,7 +316,7 @@ exports.AuthController = AuthController = __decorate([
 			"LoginResponse": "/dist/dto/auth.dto.LoginResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/auth.controller.js", controllers, companionMap, "cjs")
+		result := rewriteController(input, "/dist/auth.controller.js", controllers, companionMap, "cjs", nil)
 
 		if !strings.Contains(result, "UseInterceptors)(TsgonestSerializeInterceptor)") {
 			t.Fatalf("expected interceptor injection for CJS chained assignment, got:\n%s", result)
@@ -358,7 +358,7 @@ UserController = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "cjs")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "cjs", nil)
 
 		// "use strict" must remain the very first statement
 		if !strings.HasPrefix(result, `"use strict";`) {
@@ -399,7 +399,7 @@ UserController = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		// Import should be at the very beginning (no "use strict" to skip past)
 		if !strings.HasPrefix(result, `import {`) {
@@ -499,7 +499,7 @@ exports.RefundsController = RefundsController = __decorate([
 		}
 
 		// Should not panic. Each controller's findAll must be wrapped with its own DTO.
-		result := rewriteController(input, "/dist/payments.controller.js", controllers, companionMap, "cjs")
+		result := rewriteController(input, "/dist/payments.controller.js", controllers, companionMap, "cjs", nil)
 		if !strings.Contains(result, "stringifyPaymentDto") {
 			t.Errorf("expected PaymentDto stringify in result, got:\n%s", result)
 		}
@@ -565,7 +565,7 @@ exports.RefundsController = RefundsController = __decorate([
 			"CreateRefundInput":  "/dist/refund.dto.CreateRefundInput.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/payments.controller.js", controllers, companionMap, "cjs")
+		result := rewriteController(input, "/dist/payments.controller.js", controllers, companionMap, "cjs", nil)
 		// Use service-call positions as anchors: paymentsService precedes refundsService in
 		// the file. assertCreatePaymentInput must appear before paymentsService (i.e. injected
 		// at the start of PaymentsController.create). assertCreateRefundInput must appear after
@@ -628,7 +628,7 @@ exports.RefundsController = RefundsController = __decorate([
 		}
 
 		// Should not panic. Each controller's getStatus must be wrapped independently.
-		result := rewriteController(input, "/dist/payments.controller.js", controllers, map[string]string{}, "cjs")
+		result := rewriteController(input, "/dist/payments.controller.js", controllers, map[string]string{}, "cjs", nil)
 		if strings.Count(result, "JSON.stringify") != 2 {
 			t.Errorf("expected two JSON.stringify wrappings (one per controller), got:\n%s", result)
 		}
@@ -687,7 +687,7 @@ exports.WebhooksController = WebhooksController = __decorate([
 			"WebhookPayload": "/dist/webhook.dto.WebhookPayload.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/payments.controller.js", controllers, companionMap, "cjs")
+		result := rewriteController(input, "/dist/payments.controller.js", controllers, companionMap, "cjs", nil)
 		// TsgonestSerializeInterceptor must appear only once — in PaymentsController's
 		// __decorate. WebhooksController has no return transforms and must not get it.
 		count := strings.Count(result, "UseInterceptors)(TsgonestSerializeInterceptor)")
@@ -782,7 +782,7 @@ ControllerB = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		if !strings.Contains(result, "stringifyUserResponse") {
 			t.Fatalf("expected stringifyUserResponse in result, got:\n%s", result)
@@ -816,7 +816,7 @@ ControllerB = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		if !strings.Contains(result, "stringifyUserResponse(await") {
 			t.Fatalf("expected direct stringifyUserResponse(await ...) for non-nullable return, got:\n%s", result)
@@ -854,7 +854,7 @@ ControllerB = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		// Must handle null before calling .map()
 		if !strings.Contains(result, `== null`) && !strings.Contains(result, `=== null`) {
@@ -887,7 +887,7 @@ ControllerB = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		// Must insert async
 		if !strings.Contains(result, "async getDefault") {
@@ -922,7 +922,7 @@ ControllerB = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		if !strings.Contains(result, "stringifyUserResponse") {
 			t.Fatalf("expected stringifyUserResponse in result, got:\n%s", result)
@@ -953,7 +953,7 @@ ControllerB = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		// Must guard against both null and undefined
 		if !strings.Contains(result, `== null`) && !strings.Contains(result, `=== null`) {
@@ -993,7 +993,7 @@ ControllerB = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		// Both return paths must have the null guard wrapper
 		nullCheckCount := strings.Count(result, `== null`)
@@ -1028,7 +1028,7 @@ exports.UserController = UserController = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "cjs")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "cjs", nil)
 
 		if !strings.Contains(result, "stringifyUserResponse") {
 			t.Fatalf("expected stringifyUserResponse in CJS result, got:\n%s", result)
@@ -1075,7 +1075,7 @@ exports.UserController = UserController = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		// getById: must have null guard
 		getByIdIdx := strings.Index(result, "getById")
@@ -1128,7 +1128,7 @@ exports.UserController = UserController = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		// The .map() callback must have a null guard for each element
 		if !strings.Contains(result, `== null`) {
@@ -1170,7 +1170,7 @@ exports.UserController = UserController = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		// Non-nullable elements: .map(_v => serializeUserResponse(_v)) without null guard
 		if strings.Contains(result, `== null`) {
@@ -1207,7 +1207,7 @@ exports.UserController = UserController = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		// Must guard the array-level null AND element-level null
 		nullChecks := strings.Count(result, `== null`)
@@ -1373,7 +1373,7 @@ exports.UserController = UserController = __decorate([
 			"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+		result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 		// Nested arrays must NOT be serialized — the .map() wrapper can't handle them.
 		// The output should be unchanged (no serialize/stringify injection).
@@ -1427,7 +1427,7 @@ exports.EventController = EventController = __decorate([
 			"UserDto": "/dist/user.dto.UserDto.tsgonest.js",
 		}
 
-		result := rewriteController(input, "/dist/event.controller.js", controllers, companionMap, "cjs")
+		result := rewriteController(input, "/dist/event.controller.js", controllers, companionMap, "cjs", nil)
 
 		// The "deleted" event has nullable data → assert and stringify must be wrapped
 		if !strings.Contains(result, `_d == null ? _d : assertUserDto(_d)`) {

--- a/internal/rewrite/controllers.go
+++ b/internal/rewrite/controllers.go
@@ -42,7 +42,17 @@ type prioritizedEdit struct {
 // For @EventStream routes: injects Reflect.defineMetadata with per-event assert/stringify.
 //
 // Uses AST-based position extraction (LocateJS) and bulk edits for a single-pass rewrite.
-func rewriteController(text string, outputFile string, controllers []analyzer.ControllerInfo, companionMap map[string]string, moduleFormat string) string {
+//
+// report is called for each rewrite the function intended to apply but couldn't
+// (controller class missing from emit, method missing on located class, etc.).
+// Pass nil to discard diagnostics — tests use nil, production threads diagnostics
+// back to RewriteContext via MakeWriteFile.
+func rewriteController(text string, outputFile string, controllers []analyzer.ControllerInfo, companionMap map[string]string, moduleFormat string, report func(RewriteDiagnostic)) string {
+	emit := func(d RewriteDiagnostic) {
+		if report != nil {
+			report(d)
+		}
+	}
 	// ── Phase 1: Collect transform specifications (unchanged metadata logic) ──
 
 	type bodyValidation struct {
@@ -54,12 +64,12 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 		isDestructured bool // true if the JS param is a destructured pattern
 	}
 	type returnTransform struct {
-		className        string
-		methodName       string
-		typeName         string
-		isArray          bool
-		nullable         bool
-		elementNullable  bool
+		className       string
+		methodName      string
+		typeName        string
+		isArray         bool
+		nullable        bool
+		elementNullable bool
 	}
 	type primitiveReturnTransform struct {
 		className  string
@@ -250,9 +260,50 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 		return text
 	}
 
+	// Track which controllers had at least one piece of injection work, so we
+	// only error on classes whose absence actually drops a load-bearing
+	// rewrite (vs. a controller that happened to need nothing).
+	controllersWithWork := make(map[string]bool)
+	for _, v := range validations {
+		controllersWithWork[v.className] = true
+	}
+	for _, sc := range scalarCoercions {
+		controllersWithWork[sc.className] = true
+	}
+	for _, tr := range transforms {
+		controllersWithWork[tr.className] = true
+	}
+	for _, pt := range primitiveTransforms {
+		controllersWithWork[pt.className] = true
+	}
+	for _, st := range sseTransforms {
+		controllersWithWork[st.className] = true
+	}
+	for name := range controllersWithEventStream {
+		controllersWithWork[name] = true
+	}
+
 	// ── Phase 2: Parse JS and extract AST locations ──
 
 	locs := LocateJS(text)
+
+	// Class-not-located is the catastrophic miss (issue #114): a controller
+	// the analyzer recognized has zero injections applied because we couldn't
+	// find its class in the emitted JS. Silent no-op = unvalidated input
+	// reaches handlers, so this must fail the build.
+	for _, ctrl := range controllers {
+		if !controllersWithWork[ctrl.Name] {
+			continue
+		}
+		if _, ok := locs.Classes[ctrl.Name]; !ok {
+			emit(RewriteDiagnostic{
+				Severity:   DiagnosticError,
+				OutputFile: outputFile,
+				Class:      ctrl.Name,
+				Reason:     "controller class not found in emitted JS — validation/serialization injection was skipped (likely an unrecognized tsgo emit shape)",
+			})
+		}
+	}
 
 	// Build method lookup: className → methodName → *MethodLoc
 	// Keyed by class name so same-named methods in different controllers
@@ -272,6 +323,23 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 		return nil
 	}
 
+	// warnMethodMissing emits a warning when a method-level rewrite couldn't
+	// be applied. Suppressed if the class itself wasn't located — that case
+	// already produced a class-level error and per-method warnings would just
+	// be noise on top of it.
+	warnMethodMissing := func(className, methodName, kind string) {
+		if _, classFound := classMethodLookup[className]; !classFound {
+			return
+		}
+		emit(RewriteDiagnostic{
+			Severity:   DiagnosticWarning,
+			OutputFile: outputFile,
+			Class:      className,
+			Method:     methodName,
+			Reason:     kind + " rewrite skipped — method not found on located class (unrecognized tsgo emit shape: getter/setter, computed name, accessor, etc.)",
+		})
+	}
+
 	// ── Phase 3: Build prioritized edits ──
 
 	var edits []prioritizedEdit
@@ -280,6 +348,7 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 	for _, v := range validations {
 		ml := lookupMethod(v.className, v.methodName)
 		if ml == nil {
+			warnMethodMissing(v.className, v.methodName, "body/query/param validation")
 			continue
 		}
 		assertFunc := companionFuncName("assert", v.typeName)
@@ -321,6 +390,7 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 	for _, sc := range scalarCoercions {
 		ml := lookupMethod(sc.className, sc.methodName)
 		if ml == nil {
+			warnMethodMissing(sc.className, sc.methodName, "query/param scalar coercion")
 			continue
 		}
 		var coercionCode string
@@ -346,6 +416,7 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 	for _, tr := range transforms {
 		ml := lookupMethod(tr.className, tr.methodName)
 		if ml == nil {
+			warnMethodMissing(tr.className, tr.methodName, "return-value DTO transform")
 			continue
 		}
 		isAsync := ml.IsAsync
@@ -388,6 +459,7 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 	for _, pt := range primitiveTransforms {
 		ml := lookupMethod(pt.className, pt.methodName)
 		if ml == nil {
+			warnMethodMissing(pt.className, pt.methodName, "return-value primitive transform")
 			continue
 		}
 		isAsync := ml.IsAsync
@@ -532,6 +604,7 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 	for _, st := range sseTransforms {
 		dc := findMethodLevelDecorate(locs, st.className, st.methodName)
 		if dc == nil {
+			warnMethodMissing(st.className, st.methodName, "SSE event-stream metadata")
 			continue
 		}
 		var entries []string

--- a/internal/rewrite/controllers_test.go
+++ b/internal/rewrite/controllers_test.go
@@ -41,7 +41,7 @@ func TestRewriteController_BodyValidation(t *testing.T) {
 		"CreateUserDto": "/dist/user.dto.CreateUserDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, "assertCreateUserDto(body)") {
 		t.Errorf("expected assert call injection, got:\n%s", result)
@@ -97,7 +97,7 @@ func TestRewriteController_MultipleRoutes(t *testing.T) {
 		"UpdateUserDto": "/dist/user.dto.UpdateUserDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, "assertCreateUserDto(body)") {
 		t.Errorf("expected assertCreateUserDto, got:\n%s", result)
@@ -130,7 +130,7 @@ func TestRewriteController_NoBody(t *testing.T) {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	// Should be unchanged since there are no body params
 	if result != input {
@@ -170,7 +170,7 @@ func TestRewriteController_RawResponse(t *testing.T) {
 		"DownloadDto": "/dist/dto.DownloadDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	// Raw response routes should be skipped
 	if result != input {
@@ -215,7 +215,7 @@ func TestRewriteController_ReturnTransform(t *testing.T) {
 		"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, "stringifyUserResponse(await this.service.findAll())") {
 		t.Errorf("expected return stringify wrapping, got:\n%s", result)
@@ -253,7 +253,7 @@ func TestRewriteController_ArrayReturn(t *testing.T) {
 		"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, `"[" + (await this.service.findAll()).map((_i) => serializeUserResponse(_i)).join(",") + "]"`) {
 		t.Errorf("expected array return serialize, got:\n%s", result)
@@ -283,7 +283,7 @@ func TestRewriteController_VoidReturn(t *testing.T) {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	// Void return should be unchanged
 	if result != input {
@@ -324,7 +324,7 @@ func TestRewriteController_BodyAndReturn(t *testing.T) {
 		"UserResponse":  "/dist/user.dto.UserResponse.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, "assertCreateUserDto(body)") {
 		t.Errorf("expected body validation, got:\n%s", result)
@@ -358,7 +358,7 @@ func TestRewriteController_NoReturnCompanion(t *testing.T) {
 	// No companion for SomeExternalType
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	// Should be unchanged — no companion available for return type
 	if result != input {
@@ -444,7 +444,7 @@ func TestRewriteController_WholeObjectQuery(t *testing.T) {
 		"PaginationQuery": "/dist/pagination.dto.PaginationQuery.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/order.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/order.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, "assertPaginationQuery(query)") {
 		t.Errorf("expected assert call for @Query() injection, got:\n%s", result)
@@ -484,7 +484,7 @@ func TestRewriteController_ScalarParamCoercion(t *testing.T) {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, "id = +id") {
 		t.Errorf("expected number coercion for @Param('id'), got:\n%s", result)
@@ -527,7 +527,7 @@ func TestRewriteController_StringParamNoCoercion(t *testing.T) {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	// String-typed scalar param should have no injection
 	if result != input {
@@ -579,7 +579,7 @@ func TestRewriteController_MixedBodyQueryParam(t *testing.T) {
 		"OrderOptions":   "/dist/order.dto.OrderOptions.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/order.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/order.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, "assertCreateOrderDto(body)") {
 		t.Errorf("expected body validation, got:\n%s", result)
@@ -624,7 +624,7 @@ func TestRewriteController_WholeObjectParam(t *testing.T) {
 		"RouteParams": "/dist/route.dto.RouteParams.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, "assertRouteParams(params)") {
 		t.Errorf("expected assert call for whole-object @Param(), got:\n%s", result)
@@ -661,7 +661,7 @@ func TestRewriteController_BooleanParamCoercion(t *testing.T) {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, `=== "true"`) {
 		t.Errorf("expected boolean coercion for @Query('active'), got:\n%s", result)
@@ -714,7 +714,7 @@ class UserEventController {
 		"DeletePayload": "/dist/dto.DeletePayload.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/event.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/event.controller.js", controllers, companionMap, "esm", nil)
 
 	// Should inject Reflect.defineMetadata after the method-level __decorate
 	if !strings.Contains(result, `Reflect.defineMetadata("__tsgonest_sse_transforms__"`) {
@@ -799,7 +799,7 @@ class GenericController {
 		"UserDto": "/dist/dto.UserDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/generic.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/generic.controller.js", controllers, companionMap, "esm", nil)
 
 	// Should use "*" as the wildcard key
 	if !strings.Contains(result, `"*"`) {
@@ -840,7 +840,7 @@ func TestRewriteController_SSENoReturnWrapping(t *testing.T) {
 		"UserDto": "/dist/dto.UserDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/event.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/event.controller.js", controllers, companionMap, "esm", nil)
 
 	// Should NOT contain stringify wrapping of return
 	if strings.Contains(result, "stringifyUserDto(await") {
@@ -896,7 +896,7 @@ class MixedController {
 		"StatusDto":      "/dist/dto.StatusDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/mixed.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/mixed.controller.js", controllers, companionMap, "esm", nil)
 
 	// Should have return wrapping for getHealth
 	if !strings.Contains(result, "stringifyHealthResponse(await") {
@@ -958,7 +958,7 @@ class NotificationEventsController {
 	// Empty companion map — NotificationSSEEvent is a union type with no companion
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/notification.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/notification.controller.js", controllers, companionMap, "esm", nil)
 
 	// Must inject TsgonestSseInterceptor import
 	if !strings.Contains(result, "TsgonestSseInterceptor") {
@@ -995,10 +995,10 @@ class ChatEventsController {
 			SourceFile: "/src/chat.controller.ts",
 			Routes: []analyzer.Route{
 				{
-					OperationID: "Chat_streamChat",
-					MethodName:  "streamChat",
-					Method:      "GET",
-					IsSSE:       true,
+					OperationID:   "Chat_streamChat",
+					MethodName:    "streamChat",
+					Method:        "GET",
+					IsSSE:         true,
 					IsEventStream: true,
 					// No SSEEventVariants — data is Record<string, unknown>
 					SSEEventVariants: nil,
@@ -1009,7 +1009,7 @@ class ChatEventsController {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/chat.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/chat.controller.js", controllers, companionMap, "esm", nil)
 
 	// Must inject TsgonestSseInterceptor import
 	if !strings.Contains(result, "TsgonestSseInterceptor") {
@@ -1064,7 +1064,7 @@ class MixedEventController {
 		"TypedDto": "/dist/dto.TypedDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/mixed-event.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/mixed-event.controller.js", controllers, companionMap, "esm", nil)
 
 	// Must inject TsgonestSseInterceptor regardless
 	if !strings.Contains(result, "TsgonestSseInterceptor") {
@@ -1140,7 +1140,7 @@ class OAuthController {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/controllers.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/controllers.js", controllers, companionMap, "esm", nil)
 
 	// Both controllers should get the interceptor
 	// Count occurrences of UseInterceptors(TsgonestSseInterceptor)
@@ -1195,7 +1195,7 @@ func TestRewriteController_FormDataBodyValidation(t *testing.T) {
 		"UploadDto": "/dist/upload.dto.UploadDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/upload.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/upload.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, "assertUploadDto(body)") {
 		t.Errorf("expected assert call injection for @FormDataBody(), got:\n%s", result)
@@ -1247,7 +1247,7 @@ func TestRewriteController_FormDataBody_InlineTypeWithSyntheticName(t *testing.T
 		"__UploadController_upload_Body": "/dist/upload.controller.__UploadController_upload_Body.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/upload.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/upload.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, "assert__UploadController_upload_Body(body)") {
 		t.Errorf("expected assert call for inline FormData body with synthetic name, got:\n%s", result)
@@ -1291,7 +1291,7 @@ func TestRewriteController_FormDataBodyWithCompanionImport(t *testing.T) {
 		"UploadDto": "/dist/upload.dto.UploadDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/upload.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/upload.controller.js", controllers, companionMap, "esm", nil)
 
 	if !strings.Contains(result, `import { assertUploadDto } from "./upload.dto.UploadDto.tsgonest.js"`) {
 		t.Errorf("expected companion import for FormData body type, got:\n%s", result)
@@ -1339,7 +1339,7 @@ func TestRewriteController_StringReturn(t *testing.T) {
 		"ForgotPasswordDto": "/dist/auth.dto.ForgotPasswordDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/auth.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/auth.controller.js", controllers, companionMap, "esm", nil)
 
 	// The return value must be JSON-stringified — a raw string like:
 	//   If an account exists, a reset link has been sent.
@@ -1374,7 +1374,7 @@ func TestRewriteController_StringReturnOnly(t *testing.T) {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/health.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/health.controller.js", controllers, companionMap, "esm", nil)
 
 	// Must wrap return with JSON encoding for string
 	if !strings.Contains(result, "JSON.stringify(") && !strings.Contains(result, "__s(") {
@@ -1407,7 +1407,7 @@ func TestRewriteController_NumberReturn(t *testing.T) {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/stats.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/stats.controller.js", controllers, companionMap, "esm", nil)
 
 	// Number returns should be serialized (e.g., "" + value or Number.isFinite check)
 	if !strings.Contains(result, "Number.isFinite") && !strings.Contains(result, "JSON.stringify") {
@@ -1439,7 +1439,7 @@ func TestRewriteController_BooleanReturn(t *testing.T) {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/feature.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/feature.controller.js", controllers, companionMap, "esm", nil)
 
 	// Boolean should be serialized
 	if !strings.Contains(result, `"true"`) && !strings.Contains(result, `"false"`) && !strings.Contains(result, "JSON.stringify") {
@@ -1471,7 +1471,7 @@ func TestRewriteController_NullableStringReturn(t *testing.T) {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
 
 	// Must wrap — nullable string needs null check + JSON encoding
 	if !strings.Contains(result, "null") || result == input {
@@ -1584,7 +1584,7 @@ func TestRewriteController_OverlappingEditsDoNotPanic(t *testing.T) {
 	}
 
 	// This must not panic — it should gracefully handle any edge cases
-	result := rewriteController(input, "/dist/test.controller.js", controllers, companionMap, "cjs")
+	result := rewriteController(input, "/dist/test.controller.js", controllers, companionMap, "cjs", nil)
 
 	// Basic validation: body assertion should be injected for at least one method
 	if !strings.Contains(result, "assertDtoA(body)") && !strings.Contains(result, "assertDtoB(body)") {
@@ -1689,7 +1689,7 @@ class UserController {
 		"UserResponse": "/dist/user.dto.UserResponse.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "cjs")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "cjs", nil)
 
 	// Must inject the interceptor import
 	if !strings.Contains(result, "TsgonestSerializeInterceptor") {
@@ -1737,7 +1737,7 @@ class HealthController {
 
 	companionMap := map[string]string{}
 
-	result := rewriteController(input, "/dist/health.controller.js", controllers, companionMap, "cjs")
+	result := rewriteController(input, "/dist/health.controller.js", controllers, companionMap, "cjs", nil)
 
 	// Must inject the interceptor even for primitive returns
 	if !strings.Contains(result, "UseInterceptors)(TsgonestSerializeInterceptor)") {
@@ -1790,7 +1790,7 @@ class UserController {
 		"CreateUserDto": "/dist/user.dto.CreateUserDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "cjs")
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "cjs", nil)
 
 	// Body validation should still be injected
 	if !strings.Contains(result, "assertCreateUserDto(body)") {
@@ -1845,7 +1845,7 @@ func TestRewriteController_BodyNotFirstParam_Destructured(t *testing.T) {
 		"UpdateDTO": "/dist/dto.UpdateDTO.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/prompt.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/prompt.controller.js", controllers, companionMap, "esm", nil)
 
 	// Must NOT assert the wrong parameter
 	if strings.Contains(result, "companyID = assertUpdateDTO(companyID)") {
@@ -1902,7 +1902,7 @@ func TestRewriteController_BodyNotFirstParam_DestructuredWithDefaults(t *testing
 		"SomeDto": "/dist/dto.SomeDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/my.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/my.controller.js", controllers, companionMap, "esm", nil)
 
 	// Must NOT assert the wrong parameter
 	if strings.Contains(result, "id = assertSomeDto(id)") {
@@ -1959,7 +1959,7 @@ func TestRewriteController_BodyNotFirstParam_SimpleLocalName(t *testing.T) {
 		"UpdateDTO": "/dist/dto.UpdateDTO.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/item.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/item.controller.js", controllers, companionMap, "esm", nil)
 
 	// LocalName is present → no destructured rewrite needed, simple assertion
 	if !strings.Contains(result, "body = assertUpdateDTO(body)") {
@@ -2007,7 +2007,7 @@ func TestRewriteController_BodyThirdParam_Destructured(t *testing.T) {
 		"MemberDto": "/dist/dto.MemberDto.tsgonest.js",
 	}
 
-	result := rewriteController(input, "/dist/team.controller.js", controllers, companionMap, "esm")
+	result := rewriteController(input, "/dist/team.controller.js", controllers, companionMap, "esm", nil)
 
 	// Must assert the body, not orgId or teamId
 	if strings.Contains(result, "orgId = assertMemberDto") || strings.Contains(result, "teamId = assertMemberDto") {

--- a/internal/rewrite/diagnostics_test.go
+++ b/internal/rewrite/diagnostics_test.go
@@ -1,0 +1,265 @@
+package rewrite
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsgonest/tsgonest/internal/analyzer"
+	"github.com/tsgonest/tsgonest/internal/metadata"
+)
+
+// TestRewriteController_ErrorWhenClassNotLocated covers the issue #114 footprint:
+// the analyzer recognizes a controller and there's injection work to do, but
+// the locator can't find the class in emitted JS. This must surface as an
+// error so the build fails — silently skipping means unvalidated input hits
+// the handler.
+func TestRewriteController_ErrorWhenClassNotLocated(t *testing.T) {
+	// Emitted JS with no class at all — controller name won't be located.
+	input := `"use strict";
+const someValue = 42;
+`
+
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "GhostController",
+			SourceFile: "/src/ghost.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					MethodName: "create",
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "body",
+							LocalName: "body",
+							Type:      metadata.Metadata{Kind: metadata.KindRef, Ref: "CreateGhostDto"},
+						},
+					},
+				},
+			},
+		},
+	}
+	companionMap := map[string]string{
+		"CreateGhostDto": "/dist/ghost.dto.CreateGhostDto.tsgonest.js",
+	}
+
+	var diags []RewriteDiagnostic
+	report := func(d RewriteDiagnostic) { diags = append(diags, d) }
+
+	rewriteController(input, "/dist/ghost.controller.js", controllers, companionMap, "esm", report)
+
+	var errors []RewriteDiagnostic
+	for _, d := range diags {
+		if d.IsError() {
+			errors = append(errors, d)
+		}
+	}
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error diagnostic, got %d (all diagnostics: %+v)", len(errors), diags)
+	}
+	if errors[0].Class != "GhostController" {
+		t.Errorf("expected error for GhostController, got class=%q", errors[0].Class)
+	}
+	if !strings.Contains(errors[0].Reason, "controller class not found") {
+		t.Errorf("expected reason to mention class-not-found, got: %s", errors[0].Reason)
+	}
+}
+
+// TestRewriteController_ChainedAssignmentClassFound is the regression for #114
+// itself: when a class is emitted as `let X = X_1 = class X { ... }`, the
+// locator must find it and validation injection must succeed.
+func TestRewriteController_ChainedAssignmentClassFound(t *testing.T) {
+	input := `"use strict";
+var FooController_1;
+let FooController = FooController_1 = class FooController {
+    logger = new Logger(FooController_1.name);
+    async listThings(query) {
+        return this.svc.list(query);
+    }
+};`
+
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "FooController",
+			SourceFile: "/src/foo.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					MethodName: "listThings",
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "query",
+							TypeName:  "ListThingsQueryDTO",
+							LocalName: "query",
+							Type:      metadata.Metadata{Kind: metadata.KindRef, Ref: "ListThingsQueryDTO"},
+						},
+					},
+				},
+			},
+		},
+	}
+	companionMap := map[string]string{
+		"ListThingsQueryDTO": "/dist/foo.dto.ListThingsQueryDTO.tsgonest.js",
+	}
+
+	var diags []RewriteDiagnostic
+	result := rewriteController(input, "/dist/foo.controller.js", controllers, companionMap, "esm", func(d RewriteDiagnostic) {
+		diags = append(diags, d)
+	})
+
+	for _, d := range diags {
+		if d.IsError() {
+			t.Errorf("unexpected error diagnostic: %s", d.Format())
+		}
+	}
+	if !strings.Contains(result, "assertListThingsQueryDTO(query)") {
+		t.Errorf("expected validation injection inside chained-assignment class, got:\n%s", result)
+	}
+}
+
+// TestRewriteController_WarnWhenMethodNotLocated covers the recoverable
+// degradation case: the class is found but the route's method isn't (e.g.
+// emitted as a getter, computed name, or some other shape we don't recognize).
+// Other methods keep working; a warning surfaces so operators see it.
+func TestRewriteController_WarnWhenMethodNotLocated(t *testing.T) {
+	// Class is present and one method is found, but the route refers to a
+	// method name that doesn't exist in the emitted JS.
+	input := `"use strict";
+class UserController {
+    async create(body) {
+        return this.service.create(body);
+    }
+}`
+
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "UserController",
+			SourceFile: "/src/user.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					MethodName: "ghostMethod", // not in the JS
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "body",
+							LocalName: "body",
+							Type:      metadata.Metadata{Kind: metadata.KindRef, Ref: "CreateUserDto"},
+						},
+					},
+				},
+			},
+		},
+	}
+	companionMap := map[string]string{
+		"CreateUserDto": "/dist/user.dto.CreateUserDto.tsgonest.js",
+	}
+
+	var diags []RewriteDiagnostic
+	rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", func(d RewriteDiagnostic) {
+		diags = append(diags, d)
+	})
+
+	var errors, warnings int
+	for _, d := range diags {
+		if d.IsError() {
+			errors++
+		} else {
+			warnings++
+		}
+	}
+	if errors != 0 {
+		t.Errorf("expected 0 errors, got %d (diags: %+v)", errors, diags)
+	}
+	if warnings != 1 {
+		t.Fatalf("expected 1 warning, got %d (diags: %+v)", warnings, diags)
+	}
+	w := diags[0]
+	if w.Class != "UserController" || w.Method != "ghostMethod" {
+		t.Errorf("expected warning for UserController.ghostMethod, got class=%q method=%q", w.Class, w.Method)
+	}
+}
+
+// TestRewriteController_NoMethodWarningsWhenClassMissing ensures that when a
+// class itself is missing (an error), we don't drown the user in per-method
+// warnings on top of the class-level error.
+func TestRewriteController_NoMethodWarningsWhenClassMissing(t *testing.T) {
+	input := `"use strict";
+const noClassHere = true;
+`
+
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name: "GhostController",
+			Routes: []analyzer.Route{
+				{
+					MethodName: "a",
+					Parameters: []analyzer.RouteParameter{
+						{Category: "body", LocalName: "body",
+							Type: metadata.Metadata{Kind: metadata.KindRef, Ref: "Dto"}},
+					},
+				},
+				{
+					MethodName: "b",
+					Parameters: []analyzer.RouteParameter{
+						{Category: "body", LocalName: "body",
+							Type: metadata.Metadata{Kind: metadata.KindRef, Ref: "Dto"}},
+					},
+				},
+			},
+		},
+	}
+	companionMap := map[string]string{
+		"Dto": "/dist/dto.tsgonest.js",
+	}
+
+	var diags []RewriteDiagnostic
+	rewriteController(input, "/dist/ghost.controller.js", controllers, companionMap, "esm", func(d RewriteDiagnostic) {
+		diags = append(diags, d)
+	})
+
+	var errors, warnings int
+	for _, d := range diags {
+		if d.IsError() {
+			errors++
+		} else {
+			warnings++
+		}
+	}
+	if errors != 1 {
+		t.Errorf("expected exactly 1 class-level error, got %d", errors)
+	}
+	if warnings != 0 {
+		t.Errorf("expected no per-method warnings when class is missing, got %d (diags: %+v)", warnings, diags)
+	}
+}
+
+// TestRewriteContext_DiagnosticThreadSafety ensures concurrent appends from
+// the WriteFile callback don't race or corrupt the diagnostic slice.
+func TestRewriteContext_DiagnosticThreadSafety(t *testing.T) {
+	ctx := &RewriteContext{}
+	const goroutines = 50
+	const perGoroutine = 20
+
+	done := make(chan struct{}, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(gi int) {
+			for j := 0; j < perGoroutine; j++ {
+				ctx.addDiagnostic(RewriteDiagnostic{
+					Severity:   DiagnosticWarning,
+					OutputFile: "/dist/x.js",
+					Class:      "C",
+					Method:     "m",
+					Reason:     "r",
+				})
+			}
+			done <- struct{}{}
+		}(i)
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+	got := ctx.Diagnostics()
+	want := goroutines * perGoroutine
+	if len(got) != want {
+		t.Fatalf("expected %d diagnostics, got %d", want, len(got))
+	}
+	if ctx.HasErrors() {
+		t.Error("expected no errors among warnings")
+	}
+}

--- a/internal/rewrite/jslocate.go
+++ b/internal/rewrite/jslocate.go
@@ -96,8 +96,15 @@ func extractClassDecl(text string, node *ast.Node, locs *JSLocations) {
 	extractClassMembers(text, className, node.Members(), locs)
 }
 
-// extractClassFromVarStmt handles: let ClassName = class ClassName { ... }
-// This is the pattern tsgo emits for class declarations.
+// extractClassFromVarStmt handles class-as-initializer patterns tsgo emits:
+//
+//	let X = class X { ... }                    // simple form
+//	let X = X_1 = class X { ... }              // chained form, used when the class
+//	                                           // body references X (e.g.
+//	                                           // `new Logger(X.name)` field initializer)
+//	                                           // — tsgo binds X_1 first so the body
+//	                                           // can read it before the outer let
+//	                                           // is initialized.
 func extractClassFromVarStmt(text string, stmt *ast.Node, locs *JSLocations) {
 	vs := stmt.AsVariableStatement()
 	if vs.DeclarationList == nil {
@@ -112,7 +119,8 @@ func extractClassFromVarStmt(text string, stmt *ast.Node, locs *JSLocations) {
 			continue
 		}
 		vd := decl.AsVariableDeclaration()
-		if vd.Initializer == nil || vd.Initializer.Kind != ast.KindClassExpression {
+		classExpr := unwrapClassExpression(vd.Initializer)
+		if classExpr == nil {
 			continue
 		}
 		// Use the variable name as the class name (matches __decorate references)
@@ -124,8 +132,28 @@ func extractClassFromVarStmt(text string, stmt *ast.Node, locs *JSLocations) {
 		if className == "" {
 			continue
 		}
-		extractClassMembers(text, className, vd.Initializer.Members(), locs)
+		extractClassMembers(text, className, classExpr.Members(), locs)
 	}
+}
+
+// unwrapClassExpression walks down nested simple-assignment BinaryExpression
+// initializers to find a ClassExpression. Returns the ClassExpression node, or
+// nil if the chain ends in something else.
+func unwrapClassExpression(node *ast.Node) *ast.Node {
+	for node != nil {
+		if node.Kind == ast.KindClassExpression {
+			return node
+		}
+		if node.Kind != ast.KindBinaryExpression {
+			return nil
+		}
+		bin := node.AsBinaryExpression()
+		if bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindEqualsToken {
+			return nil
+		}
+		node = bin.Right
+	}
+	return nil
 }
 
 // extractClassMembers extracts methods from a class's member list.

--- a/internal/rewrite/jslocate_test.go
+++ b/internal/rewrite/jslocate_test.go
@@ -329,6 +329,28 @@ func TestLocateJS_ClassLevelDecorate_ChainedAssignment(t *testing.T) {
 	}
 }
 
+func TestLocateJS_SelfReferencingClass(t *testing.T) {
+	// tsgo emits `let X = X_1 = class X { ... }` when the class body references
+	// the class itself (e.g. `new Logger(X.name)` instance field initializer).
+	// The locator must walk through the chained assignment to find the inner
+	// ClassExpression — see issue #114.
+	input := `var FooController_1;
+let FooController = FooController_1 = class FooController {
+    logger = new Logger(FooController_1.name);
+    async listThings(companyId, query) {
+        return this.svc.list(companyId, query);
+    }
+};`
+	locs := LocateJS(input)
+	cls, ok := locs.Classes["FooController"]
+	if !ok {
+		t.Fatal("expected to find class FooController via chained-assignment initializer")
+	}
+	if _, ok := cls.Methods["listThings"]; !ok {
+		t.Fatal("expected to find method listThings on chained-assigned class")
+	}
+}
+
 func TestLocateJS_MultipleParams(t *testing.T) {
 	input := `class Foo {
     bar(a, b, c) {

--- a/internal/rewrite/rewrite.go
+++ b/internal/rewrite/rewrite.go
@@ -5,11 +5,59 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/tsgonest/tsgonest/internal/analyzer"
 	"github.com/tsgonest/tsgonest/internal/pathalias"
 )
+
+// DiagnosticSeverity classifies a rewrite diagnostic.
+//
+// Error means the rewriter was supposed to inject something load-bearing
+// (validation, serialization) but couldn't locate the target. Silent no-op
+// here = unvalidated input hitting handlers, so the build must fail.
+//
+// Warning means a recoverable degradation: the file still works correctly
+// without the missed injection (e.g. a single method couldn't be located,
+// other methods still got their injections).
+type DiagnosticSeverity int
+
+const (
+	DiagnosticWarning DiagnosticSeverity = iota
+	DiagnosticError
+)
+
+// RewriteDiagnostic is a single message produced by the rewriter when it
+// couldn't apply an intended injection.
+type RewriteDiagnostic struct {
+	Severity   DiagnosticSeverity
+	OutputFile string // emit-time JS path (where the rewrite was attempted)
+	Class      string // controller class name
+	Method     string // route method name; empty for class-level diagnostics
+	Reason     string // human-readable explanation
+}
+
+// IsError returns true if the diagnostic should fail the build.
+func (d RewriteDiagnostic) IsError() bool {
+	return d.Severity == DiagnosticError
+}
+
+// Format returns a single-line human-readable form.
+func (d RewriteDiagnostic) Format() string {
+	prefix := "warning"
+	if d.Severity == DiagnosticError {
+		prefix = "error"
+	}
+	target := d.Class
+	if d.Method != "" {
+		target = d.Class + "." + d.Method
+	}
+	if target == "" {
+		return fmt.Sprintf("%s: %s — %s", prefix, d.OutputFile, d.Reason)
+	}
+	return fmt.Sprintf("%s: %s (%s) — %s", prefix, d.OutputFile, target, d.Reason)
+}
 
 // normalizeSlashes converts all backslashes to forward slashes regardless of OS.
 // filepath.ToSlash only converts os.PathSeparator (no-op on Linux for '\').
@@ -50,6 +98,40 @@ type RewriteContext struct {
 	// HelpersPath is the absolute path to the _tsgonest_helpers.js file.
 	// Used for inline scalar coercion imports in controllers.
 	HelpersPath string
+
+	// diagMu guards diagnostics. WriteFile callbacks may run concurrently
+	// across goroutines during emit, so appends must be synchronized.
+	diagMu      sync.Mutex
+	diagnostics []RewriteDiagnostic
+}
+
+// addDiagnostic appends a diagnostic in a thread-safe way.
+func (ctx *RewriteContext) addDiagnostic(d RewriteDiagnostic) {
+	ctx.diagMu.Lock()
+	ctx.diagnostics = append(ctx.diagnostics, d)
+	ctx.diagMu.Unlock()
+}
+
+// Diagnostics returns a copy of all diagnostics collected during emit.
+// Safe to call after emit completes.
+func (ctx *RewriteContext) Diagnostics() []RewriteDiagnostic {
+	ctx.diagMu.Lock()
+	defer ctx.diagMu.Unlock()
+	out := make([]RewriteDiagnostic, len(ctx.diagnostics))
+	copy(out, ctx.diagnostics)
+	return out
+}
+
+// HasErrors returns true if any collected diagnostic has error severity.
+func (ctx *RewriteContext) HasErrors() bool {
+	ctx.diagMu.Lock()
+	defer ctx.diagMu.Unlock()
+	for _, d := range ctx.diagnostics {
+		if d.Severity == DiagnosticError {
+			return true
+		}
+	}
+	return false
 }
 
 // MakeWriteFile returns a WriteFile callback that applies all rewrites during emit.
@@ -89,7 +171,7 @@ func (ctx *RewriteContext) MakeWriteFile() shimcompiler.WriteFile {
 								os.Exit(1)
 							}
 						}()
-						text = rewriteController(text, fileName, matchingControllers, ctx.CompanionMap, ctx.ModuleFormat)
+						text = rewriteController(text, fileName, matchingControllers, ctx.CompanionMap, ctx.ModuleFormat, ctx.addDiagnostic)
 					}()
 				}
 			}


### PR DESCRIPTION
Closes #114.

## Summary

- Fix the issue #114 footprint: `extractClassFromVarStmt` now walks chained simple-assignment `BinaryExpression` initializers, so classes emitted as `let X = X_1 = class X {...}` (when the body references the class itself, e.g. `new Logger(X.name)`) are located. Previously every injection (`@Body` validation, `@Query`/`@Param` coercion, return serialization) was silently dropped on these classes — string query params hit handlers as strings.
- Add a diagnostic gate so the next unrecognized tsgo emit shape doesn't slip through unnoticed:
  - **Error** when an analyzed controller's class is missing from emitted JS — load-bearing miss, exit 1, fails the whole build.
  - **Warning** for each missed method-level rewrite — recoverable degradation (methods can emit as getters/setters, computed names, accessors, etc.). Build continues and operators see the warning in the existing summary.
  - Diagnostics collector is thread-safe; tsgo's `WriteFile` callback may run concurrently across goroutines.

## Test plan

- [x] `go test -race ./...` (all packages green)
- [x] New `TestLocateJS_SelfReferencingClass` covers the issue's repro
- [x] New diagnostic tests: class-not-located error, chained-class regression, per-method warning, no-method-warnings-when-class-missing, thread-safety
- [x] All 64 existing `rewriteController` test callers updated to pass `nil` for the new `report` callback
- [x] `pnpm test:e2e` (284 tests pass)