### PR TITLE
chore: update typescript-go submodule to 092b34f534

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,4 @@
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/collections/cow.go
+++ b/internal/collections/cow.go
@@ -1,0 +1,76 @@
+package collections
+
+import "maps"
+
+// CopyOnWriteMap is a map that defers cloning of an inherited backing map
+// until the first mutation, and supports nested scopes that share the parent's
+// map for reads but get their own clone on write.
+//
+// The zero value is an empty map ready to use.
+type CopyOnWriteMap[K comparable, V any] struct {
+	m     map[K]V
+	owned bool
+}
+
+// Get returns the value for k and whether it was present.
+func (c *CopyOnWriteMap[K, V]) Get(k K) (V, bool) {
+	v, ok := c.m[k]
+	return v, ok
+}
+
+// Has reports whether k is in the map.
+func (c *CopyOnWriteMap[K, V]) Has(k K) bool {
+	_, ok := c.m[k]
+	return ok
+}
+
+// Set assigns v to k, cloning the inherited backing map first if necessary.
+func (c *CopyOnWriteMap[K, V]) Set(k K, v V) {
+	c.ensureOwned()
+	c.m[k] = v
+}
+
+func (c *CopyOnWriteMap[K, V]) ensureOwned() {
+	if c.owned {
+		return
+	}
+	if c.m == nil {
+		c.m = make(map[K]V)
+	} else {
+		c.m = maps.Clone(c.m)
+	}
+	c.owned = true
+}
+
+// EnterScope returns a function that restores this map to its current state.
+// While the scope is active, the map shares its current backing storage with
+// the parent scope: reads see the inherited entries, and the first mutation
+// transparently clones the storage so the parent's view is not modified.
+func (c *CopyOnWriteMap[K, V]) EnterScope() func() {
+	saved := *c
+	c.owned = false
+	return func() { *c = saved }
+}
+
+type CopyOnWriteSet[K comparable] struct {
+	m CopyOnWriteMap[K, struct{}]
+}
+
+// Has reports whether k is in the set.
+func (c *CopyOnWriteSet[K]) Has(k K) bool {
+	_, ok := c.m.Get(k)
+	return ok
+}
+
+// Set adds k to the set, cloning the inherited backing map first if necessary.
+func (c *CopyOnWriteSet[K]) Add(k K) {
+	c.m.Set(k, struct{}{})
+}
+
+// EnterScope returns a function that restores this set to its current state.
+// While the scope is active, the set shares its current backing storage with
+// the parent scope: reads see the inherited entries, and the first mutation
+// transparently clones the storage so the parent's view is not modified.
+func (c *CopyOnWriteSet[K]) EnterScope() func() {
+	return c.m.EnterScope()
+}

--- a/justfile
+++ b/justfile
@@ -16,6 +16,22 @@ init:
     pushd typescript-go && git am --3way --no-gpg-sign ../patches/*.patch && popd; \
   fi
   mkdir -p internal/collections && find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \;
+  just _patch-collections
+
+# Rewrites typescript-go's internal/json wrapper imports back to the upstream
+# go-json-experiment packages, since we can't import typescript-go internals.
+[unix]
+_patch-collections:
+  @if grep -q '"github.com/microsoft/typescript-go/internal/json"' internal/collections/ordered_map.go 2>/dev/null; then \
+    sed -i.bak \
+      -e 's|"github.com/microsoft/typescript-go/internal/json"|"github.com/go-json-experiment/json"\n\t"github.com/go-json-experiment/json/jsontext"|' \
+      -e 's|enc \*json\.Encoder|enc *jsontext.Encoder|g' \
+      -e 's|dec \*json\.Decoder|dec *jsontext.Decoder|g' \
+      -e 's|json\.BeginObject|jsontext.BeginObject|g' \
+      -e 's|json\.EndObject|jsontext.EndObject|g' \
+      internal/collections/ordered_map.go && \
+    rm -f internal/collections/ordered_map.go.bak; \
+  fi
 
 [windows]
 init:
@@ -25,6 +41,11 @@ init:
   pushd typescript-go; Get-ChildItem ../patches/*.patch -ErrorAction SilentlyContinue | ForEach-Object { git am --3way --no-gpg-sign $_.FullName }; popd
   New-Item -ItemType Directory -Force -Path internal\collections
   Get-ChildItem -Path .\typescript-go\internal\collections\* -File | Where-Object { $_.Name -notlike '*_test.go' } | ForEach-Object { Copy-Item $_.FullName -Destination .\internal\collections\ }
+  just _patch-collections
+
+[windows]
+_patch-collections:
+  $f = "internal\collections\ordered_map.go"; if (Test-Path $f) { $c = Get-Content -Raw $f; if ($c -match '"github.com/microsoft/typescript-go/internal/json"') { $c = $c -replace '"github.com/microsoft/typescript-go/internal/json"', "`"github.com/go-json-experiment/json`"`r`n`t`"github.com/go-json-experiment/json/jsontext`""; $c = $c -replace 'enc \*json\.Encoder', 'enc *jsontext.Encoder'; $c = $c -replace 'dec \*json\.Decoder', 'dec *jsontext.Decoder'; $c = $c -replace 'json\.BeginObject', 'jsontext.BeginObject'; $c = $c -replace 'json\.EndObject', 'jsontext.EndObject'; Set-Content -NoNewline $f $c } }
 
 [unix]
 build:

--- a/shim/ast/shim.go
+++ b/shim/ast/shim.go
@@ -421,6 +421,8 @@ func GetNameOfDeclaration(declaration *ast.Node) *ast.Node
 func GetNamespaceDeclarationNode(node *ast.Node) *ast.Node
 //go:linkname GetNewTargetContainer github.com/microsoft/typescript-go/internal/ast.GetNewTargetContainer
 func GetNewTargetContainer(node *ast.Node) *ast.Node
+//go:linkname GetNextJSDocCommentLocation github.com/microsoft/typescript-go/internal/ast.GetNextJSDocCommentLocation
+func GetNextJSDocCommentLocation(node *ast.Node) *ast.Node
 //go:linkname GetNodeAtPosition github.com/microsoft/typescript-go/internal/ast.GetNodeAtPosition
 func GetNodeAtPosition(file *ast.SourceFile, position int, includeJSDoc bool) *ast.Node
 //go:linkname GetNodeId github.com/microsoft/typescript-go/internal/ast.GetNodeId
@@ -578,6 +580,8 @@ func IsAdditiveOperatorOrHigher(kind ast.Kind) bool
 func IsAliasSymbolDeclaration(node *ast.Node) bool
 //go:linkname IsAmbientModule github.com/microsoft/typescript-go/internal/ast.IsAmbientModule
 func IsAmbientModule(node *ast.Node) bool
+//go:linkname IsAmbientModuleSymbolName github.com/microsoft/typescript-go/internal/ast.IsAmbientModuleSymbolName
+func IsAmbientModuleSymbolName(s string) bool
 //go:linkname IsAnyExportAssignment github.com/microsoft/typescript-go/internal/ast.IsAnyExportAssignment
 func IsAnyExportAssignment(node *ast.Node) bool
 //go:linkname IsAnyImportOrReExport github.com/microsoft/typescript-go/internal/ast.IsAnyImportOrReExport
@@ -789,7 +793,7 @@ func IsEqualityOperatorOrHigher(kind ast.Kind) bool
 //go:linkname IsExclusivelyTypeOnlyImportOrExport github.com/microsoft/typescript-go/internal/ast.IsExclusivelyTypeOnlyImportOrExport
 func IsExclusivelyTypeOnlyImportOrExport(node *ast.Node) bool
 //go:linkname IsExpandoInitializer github.com/microsoft/typescript-go/internal/ast.IsExpandoInitializer
-func IsExpandoInitializer(initializer *ast.Node) bool
+func IsExpandoInitializer(declaration *ast.Node, initializer *ast.Node) bool
 //go:linkname IsExpandoPropertyDeclaration github.com/microsoft/typescript-go/internal/ast.IsExpandoPropertyDeclaration
 func IsExpandoPropertyDeclaration(node *ast.Node) bool
 //go:linkname IsExponentiationOperator github.com/microsoft/typescript-go/internal/ast.IsExponentiationOperator

--- a/shim/checker/shim.go
+++ b/shim/checker/shim.go
@@ -348,6 +348,7 @@ const ObjectFlagsCouldContainTypeVariables = checker.ObjectFlagsCouldContainType
 const ObjectFlagsCouldContainTypeVariablesComputed = checker.ObjectFlagsCouldContainTypeVariablesComputed
 const ObjectFlagsEvolvingArray = checker.ObjectFlagsEvolvingArray
 const ObjectFlagsFreshLiteral = checker.ObjectFlagsFreshLiteral
+const ObjectFlagsFromTypeNode = checker.ObjectFlagsFromTypeNode
 const ObjectFlagsIdenticalBaseTypeCalculated = checker.ObjectFlagsIdenticalBaseTypeCalculated
 const ObjectFlagsIdenticalBaseTypeExists = checker.ObjectFlagsIdenticalBaseTypeExists
 const ObjectFlagsInstantiated = checker.ObjectFlagsInstantiated

--- a/shim/core/shim.go
+++ b/shim/core/shim.go
@@ -10,6 +10,8 @@ import _ "unsafe"
 
 //go:linkname ApplyBulkEdits github.com/microsoft/typescript-go/internal/core.ApplyBulkEdits
 func ApplyBulkEdits(text string, edits []core.TextChange) string
+//go:linkname ApplyDebugStackLimit github.com/microsoft/typescript-go/internal/core.ApplyDebugStackLimit
+func ApplyDebugStackLimit()
 type Arena[T any] = core.Arena[T]
 //go:linkname BoolToTristate github.com/microsoft/typescript-go/internal/core.BoolToTristate
 func BoolToTristate(b bool) core.Tristate


### PR DESCRIPTION
## Summary

- Bumps the typescript-go submodule from `515d036f9` → `092b34f534` (67 upstream commits).
- Regenerates the shim layer to track upstream API changes (`ast`, `checker`, `core`).
- Adds the new upstream `cow.go` (CopyOnWriteMap) to `internal/collections/`.
- Adds a `_patch-collections` recipe to the `justfile` that rewrites
  `internal/collections/ordered_map.go` after copy: upstream now imports
  the typescript-go-internal `json` wrapper, which we cannot import, so we
  rewrite it back to the underlying `github.com/go-json-experiment/json`
  + `jsontext` packages that we already depend on.

## Notable upstream commits

- `092b34f` Align and simplify `getFunctionLikeHost` / `GetNextJSDocCommentLocation`
- `e070bc6` Fix `isInitialized` not restored after `tryRestart`
- `88f5792` Only include _visible_ expando functions in declaration emit output
- `b6de67f` Defer global ambient module merging in `initializeChecker`
- `ed6cf5d` Avoid over-expanding recursive constraints in `getBaseSignature`
- `04b3256` Fix crash for destructuring under `noUncheckedIndexedAccess` + `noLib`
- `ea005f3` Fix assertion violation in auto-imports for JSX tag when React is type-imported
- `51a1064` Exit LSP process if parent process stops existing
- `3c6134d` Fix JSDoc codeblock parsing: preserve fenced state across newlines
- `16ff7f0` Fix tsconfig/jsconfig priority for JS files when both coexist
- `1e58c41` Optimize type variable scope map cloning with CoW
- `ee4225a` Fix inference from `never` into union targets
- `1b81e8f` Exposing more endpoints
- `2c25188` Add `TS_GO_DEBUG_STACK_LIMIT` to cap goroutine stack size at entry points

## Shim changes (regenerated)

- `ast`: adds `GetNextJSDocCommentLocation`, `IsAmbientModuleSymbolName`;
  `IsExpandoInitializer` signature now takes `(declaration, initializer)`.
- `checker`: adds `ObjectFlagsFromTypeNode` constant.
- `core`: adds `ApplyDebugStackLimit`.

No shims could be removed — every method/field listed in `shim/*/extra-shim.json`
is still unexported in upstream (`isArrayType`, `isReadonlySymbol`, `Type.alias`).

## Test plan

- [x] `go build ./cmd/tsgonest/` succeeds
- [x] `just test` (Go unit tests across 13 packages) passes
- [x] `just test` e2e suite (284/284 vitest tests) passes
- [ ] CI green