### PR TITLE
fix(dev): suppress deleteOutDir on watch rebuilds to fix node-startup race

### DIFF
--- a/cmd/tsgonest/build.go
+++ b/cmd/tsgonest/build.go
@@ -34,6 +34,7 @@ type buildFlags struct {
 	TsconfigPath string
 	DumpMetadata bool
 	Clean        bool
+	NoClean      bool // overrides cfg.DeleteOutDir; used by watch rebuilds
 	Assets       string
 	NoCheck      bool
 	TsgoArgs     []string // flags to forward to tsgo's ParseCommandLine
@@ -65,6 +66,8 @@ func parseBuildArgs(args []string) buildFlags {
 			f.DumpMetadata = true
 		case "--clean":
 			f.Clean = true
+		case "--no-clean":
+			f.NoClean = true
 		case "--assets":
 			if i+1 < len(args) {
 				i++
@@ -197,7 +200,10 @@ func runBuildWithIncrAndProgram(args []string, oldIncrProgram *shimincremental.P
 
 	// Honor deleteOutDir from config (same as nest-cli.json convention).
 	// The --clean CLI flag always wins, but deleteOutDir in config enables it too.
-	if !clean && cfg != nil && cfg.DeleteOutDir {
+	// --no-clean (used by `tsgonest dev` watch rebuilds) suppresses both — wiping
+	// dist/ and .tsbuildinfo on every incremental rebuild causes a race where
+	// the previous node restart's lazy require() lands in an empty dist/.
+	if !clean && !flags.NoClean && cfg != nil && cfg.DeleteOutDir {
 		clean = true
 	}
 

--- a/cmd/tsgonest/build_test.go
+++ b/cmd/tsgonest/build_test.go
@@ -67,6 +67,24 @@ func TestParseBuildArgs_TsgonestFlags(t *testing.T) {
 	}
 }
 
+func TestParseBuildArgs_NoCleanFlag(t *testing.T) {
+	f := parseBuildArgs([]string{"--no-clean"})
+	if !f.NoClean {
+		t.Error("NoClean should be true when --no-clean is passed")
+	}
+	if f.Clean {
+		t.Error("Clean should remain false when only --no-clean is passed")
+	}
+
+	// Both flags coexist (dev mode initial build with deleteOutDir):
+	// --no-clean from watchBuildArgs + --clean appended for the initial build.
+	// Both bools are set; runBuildWithIncrAndProgram resolves precedence.
+	both := parseBuildArgs([]string{"--no-clean", "--clean"})
+	if !both.NoClean || !both.Clean {
+		t.Errorf("both flags should parse: NoClean=%v Clean=%v", both.NoClean, both.Clean)
+	}
+}
+
 func TestParseBuildArgs_ProjectShortFlag(t *testing.T) {
 	f := parseBuildArgs([]string{"-p", "tsconfig.app.json"})
 	if f.TsconfigPath != "tsconfig.app.json" {

--- a/cmd/tsgonest/dev.go
+++ b/cmd/tsgonest/dev.go
@@ -189,8 +189,12 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal) devLoopResult {
 		resolvedConfigPath = cfgResult.Path
 	}
 
-	// Build args for watch rebuilds (no --clean)
-	watchBuildArgs := []string{}
+	// Build args for watch rebuilds (no --clean).
+	// --no-clean suppresses cfg.DeleteOutDir — incremental rebuilds must NOT
+	// wipe dist/ or .tsbuildinfo, otherwise (a) the incremental fast path is
+	// defeated and (b) a freshly restarted node racing on lazy require() can
+	// land in an empty dist/ during the next rebuild's clean window.
+	watchBuildArgs := []string{"--no-clean"}
 	if resolvedConfigPath != "" {
 		watchBuildArgs = append(watchBuildArgs, "--config", resolvedConfigPath)
 	}

--- a/e2e/flags.test.ts
+++ b/e2e/flags.test.ts
@@ -178,4 +178,37 @@ describe("deleteOutDir config option", () => {
 
     clean();
   });
+
+  it("--no-clean should suppress deleteOutDir (used by `tsgonest dev` watch rebuilds)", () => {
+    clean();
+
+    // Initial build with deleteOutDir — establishes a clean dist + .tsbuildinfo.
+    const first = runTsgonest([
+      "--project",
+      "testdata/delete-outdir/tsconfig.json",
+      "--config",
+      "testdata/delete-outdir/tsgonest.config.json",
+    ]);
+    expect(first.exitCode).toBe(0);
+    expect(existsSync(resolve(distDir, "index.js"))).toBe(true);
+
+    // Plant a marker that deleteOutDir would normally wipe.
+    writeFileSync(resolve(distDir, "watch-marker.js"), "marker");
+
+    // Watch-style rebuild: --no-clean must suppress cfg.DeleteOutDir,
+    // so the dist/ contents (including the marker) survive the rebuild.
+    const second = runTsgonest([
+      "--project",
+      "testdata/delete-outdir/tsconfig.json",
+      "--config",
+      "testdata/delete-outdir/tsgonest.config.json",
+      "--no-clean",
+    ]);
+    expect(second.exitCode).toBe(0);
+    expect(second.stderr).not.toContain("cleaning output directory");
+    expect(existsSync(resolve(distDir, "index.js"))).toBe(true);
+    expect(existsSync(resolve(distDir, "watch-marker.js"))).toBe(true);
+
+    clean();
+  });
 });


### PR DESCRIPTION
## Summary

When `deleteOutDir` is set in `tsgonest.config`, every watch rebuild was wiping `dist/` and `.tsbuildinfo`. The intent in `dev.go` was already that watch rebuilds should be incremental (the `watchBuildArgs` literally has the comment `// Build args for watch rebuilds (no --clean)`), but `build.go` was unconditionally upgrading `clean = true` whenever `cfg.DeleteOutDir` was set.

## The race

1. Rebuild N completes → `proc.Restart()` → node starts loading modules.
2. A file save lands during node's startup window.
3. Debounce fires → rebuild N+1 starts with `cleanDir(dist/)`.
4. Node's in-flight `require()` lands in an empty `dist/` → **cannot find module**.

`deleteOutDir` makes this critically bad because `dist/` is briefly empty during the clean window. Without it, the new emit just overwrites in place — node usually keeps reading.

There was also a perf bug — every watch rebuild was a full rebuild because `.tsbuildinfo` and the post-processing cache were also being deleted by the clean path.

## Fix

- Add `--no-clean` flag to `buildFlags` that explicitly suppresses the `cfg.DeleteOutDir` upgrade.
- Pass `--no-clean` in `dev.go`'s `watchBuildArgs`. The initial build still honors `deleteOutDir` (the existing code appends `--clean` after `--no-clean`, and explicit `--clean` wins).

## Test plan

- [x] `go test ./...` — all unit tests pass (incl. new `TestParseBuildArgs_NoCleanFlag`)
- [x] `pnpm --filter e2e test` — 285/285 e2e tests pass (incl. new `--no-clean` test in `flags.test.ts`)
- [ ] CI green