### PR TITLE
fix(codegen): normalize backslashes in cross-companion import paths

### DIFF
--- a/internal/codegen/relative_import_test.go
+++ b/internal/codegen/relative_import_test.go
@@ -1,0 +1,109 @@
+package codegen
+
+import "testing"
+
+// TestRelativeCompanionImport_ForwardSlash verifies the happy path: both
+// inputs are forward-slash relative paths (the canonical form on Unix).
+func TestRelativeCompanionImport_ForwardSlash(t *testing.T) {
+	cases := []struct {
+		from string
+		to   string
+		want string
+	}{
+		{
+			// Same directory.
+			from: "dist/channel/dto/channel.dto.A.tsgonest.js",
+			to:   "dist/channel/dto/channel.dto.B.tsgonest.js",
+			want: "./channel.dto.B.tsgonest.js",
+		},
+		{
+			// Sibling directory.
+			from: "dist/channel/channel.controller.A.tsgonest.js",
+			to:   "dist/channel/dto/channel.dto.B.tsgonest.js",
+			want: "./dto/channel.dto.B.tsgonest.js",
+		},
+		{
+			// Parent directory.
+			from: "dist/channel/dto/channel.dto.A.tsgonest.js",
+			to:   "dist/shared.B.tsgonest.js",
+			want: "../../shared.B.tsgonest.js",
+		},
+	}
+
+	for _, c := range cases {
+		got := relativeCompanionImport(c.from, c.to)
+		if got != c.want {
+			t.Errorf("relativeCompanionImport(%q, %q) = %q; want %q", c.from, c.to, got, c.want)
+		}
+	}
+}
+
+// TestRelativeCompanionImport_WindowsBackslash_Issue140 exercises the Windows
+// bug from issue #140. The codegen layer previously used Go's `path` package
+// (forward-slash semantics) on inputs that came from `filepath.Join` on
+// Windows (backslash output). The result was an `import` path that started
+// with `./` glued onto an absolute Windows path:
+//
+//	"./D:\Web_Development\...\channel.dto.B.tsgonest.js"
+//
+// causing `Cannot find module` at runtime.
+//
+// Regression test: feed in backslashed paths exactly as they appear on
+// Windows and assert the import path is a valid forward-slash relative path
+// with no absolute-path leak.
+func TestRelativeCompanionImport_WindowsBackslash_Issue140(t *testing.T) {
+	cases := []struct {
+		name string
+		from string
+		to   string
+		want string
+	}{
+		{
+			name: "absolute Windows path, same dir",
+			from: `D:\Web_Development\proj\dist\channel\dto\channel.dto.A.tsgonest.js`,
+			to:   `D:\Web_Development\proj\dist\channel\dto\channel.dto.B.tsgonest.js`,
+			want: "./channel.dto.B.tsgonest.js",
+		},
+		{
+			name: "absolute Windows path, sibling dir",
+			from: `D:\Web_Development\proj\dist\channel\channel.controller.A.tsgonest.js`,
+			to:   `D:\Web_Development\proj\dist\channel\dto\channel.dto.B.tsgonest.js`,
+			want: "./dto/channel.dto.B.tsgonest.js",
+		},
+		{
+			name: "absolute Windows path, parent dir",
+			from: `D:\Web_Development\proj\dist\channel\dto\channel.dto.A.tsgonest.js`,
+			to:   `D:\Web_Development\proj\dist\shared.B.tsgonest.js`,
+			want: "../../shared.B.tsgonest.js",
+		},
+		{
+			name: "mixed separators (Git Bash on Windows)",
+			from: `C:/proj/dist\channel\channel.dto.A.tsgonest.js`,
+			to:   `C:/proj\dist/channel\dto/channel.dto.B.tsgonest.js`,
+			want: "./dto/channel.dto.B.tsgonest.js",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := relativeCompanionImport(c.from, c.to)
+			if got != c.want {
+				t.Errorf("relativeCompanionImport(%q, %q)\n  got:  %q\n  want: %q", c.from, c.to, got, c.want)
+			}
+			// Defensive: never produce an output with backslashes or an
+			// absolute-path leak (drive letter, leading `/`, etc.).
+			if containsBackslash(got) {
+				t.Errorf("output contains backslash: %q", got)
+			}
+		})
+	}
+}
+
+func containsBackslash(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/codegen/validate.go
+++ b/internal/codegen/validate.go
@@ -438,7 +438,21 @@ func companionImportPath(typeName string, registry *metadata.TypeRegistry) strin
 
 // relativeCompanionImport computes a relative import path from the current companion
 // file to the target companion file. Both paths should be relative to the same root.
+//
+// Inputs are normalized to forward slashes first because they may arrive with
+// backslashes on Windows (the upstream `outputBase` is built via
+// `filepath.Join`, which uses native separators). The `path` package below
+// only understands `/`, so without this normalization a Windows path like
+// `D:\proj\dist\foo.tsgonest.js` would be treated as a single component,
+// fall through to the "no common prefix" branch, and emit
+// `./D:\proj\dist\foo.tsgonest.js` — a broken `require()` target. See #140.
+//
+// We use strings.ReplaceAll instead of filepath.ToSlash because ToSlash only
+// converts the OS-native separator — on Unix builds processing Windows-shaped
+// paths (e.g. tests, cross-compiled tools), backslashes pass through unchanged.
 func relativeCompanionImport(fromCompanionPath, toCompanionPath string) string {
+	fromCompanionPath = strings.ReplaceAll(fromCompanionPath, "\\", "/")
+	toCompanionPath = strings.ReplaceAll(toCompanionPath, "\\", "/")
 	fromDir := path.Dir(fromCompanionPath)
 	rel, err := relPath(fromDir, toCompanionPath)
 	if err != "" {


### PR DESCRIPTION
Fixes #140.

## Summary

On Windows, generated companion files were emitting broken `import` paths for cross-file recursive type references — looking like:

\`\`\`
Error: Cannot find module './D:\Web_Development\proj\dist\channel\dto\channel.dto.B.tsgonest.js'
\`\`\`

…with the absolute Windows path glued to a `./` prefix.

## Root cause

\`internal/codegen/validate.go::relativeCompanionImport\` used Go's \`path\` package (forward-slash semantics only) on inputs that come from \`filepath.Join\` upstream — backslashed on Windows. \`path.Dir("D:\\proj\\…")\` returns \`.\` because it sees no \`/\`, then \`relPath(".", "D:\\proj\\…")\` returns the absolute path verbatim, then the function prefixes \`./\`.

The controller-rewrite import path (\`internal/rewrite/imports.go::companionRelativePath\`) already handled this correctly. Only the cross-companion recursive-ref import path was broken.

## Fix

Two-line change in \`relativeCompanionImport\`: \`strings.ReplaceAll(p, "\\\\", "/")\` on both inputs before passing to \`path.Dir\`. \`filepath.ToSlash\` is *not* used because it's a no-op on Unix — on a Unix build processing Windows-shaped paths (tests, cross-compiled tools), backslashes would pass through unchanged.

## Tests

- \`internal/codegen/relative_import_test.go\` — happy-path forward-slash + absolute-Windows + mixed-separator (Git Bash) cases. Test fails on the broken code, passes on the fix.
- Full suite (Go + 284 e2e) green.

## Test plan

- [x] \`go test ./internal/codegen/\` passes
- [x] \`just test\` (full suite + e2e) passes
- [ ] CI green
- [ ] Verify on Windows with the user's reproduction