### PR TITLE
fix(dev): use cmd /C on Windows for --exec (#135)

### DIFF
--- a/cmd/tsgonest/dev.go
+++ b/cmd/tsgonest/dev.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -244,7 +245,8 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal) devLoopResult {
 	// Build runtime args
 	var proc *runner.Runner
 	if flags.execCmd != "" {
-		proc = runner.New("sh", []string{"-c", flags.execCmd}, cwd)
+		shell, shellArgs := pickExecShell(flags.execCmd)
+		proc = runner.New(shell, shellArgs, cwd)
 	} else if entryPoint != "" {
 		runtimeArgs := buildRuntimeArgs(runtimeName, entryPoint, flags.debugFlag, flags.envFile, flags.noSourceMaps, flags.passthroughArgs)
 		proc = runner.New(runtimeName, runtimeArgs, cwd)
@@ -632,4 +634,15 @@ func detectEntryPoint(cwd string) string {
 	}
 
 	return ""
+}
+
+func pickExecShellFor(goos, execCmd string) (string, []string) {
+	if goos == "windows" {
+		return "cmd", []string{"/C", execCmd}
+	}
+	return "sh", []string{"-c", execCmd}
+}
+
+func pickExecShell(execCmd string) (string, []string) {
+	return pickExecShellFor(runtime.GOOS, execCmd)
 }

--- a/cmd/tsgonest/dev_known_issues_test.go
+++ b/cmd/tsgonest/dev_known_issues_test.go
@@ -241,51 +241,33 @@ func TestDevLoop_ManualRestartCanDoubleRestart_KnownIssue(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// F. --exec flag uses `sh -c` unconditionally
+// F. --exec flag shell selection by GOOS
 // ─────────────────────────────────────────────────────────────────────────────
 
-// dev.go:~243 has:
-//
-//	proc = runner.New("sh", []string{"-c", flags.execCmd}, cwd)
-//
-// `sh` is not on PATH on default Windows installs (only with Git Bash / WSL).
-// Windows users running `tsgonest dev --exec "node ./scripts/run.js"` get
-// "exec: sh: file not found" and the dev loop never starts the child.
-//
-// Fix: select shell by GOOS — "cmd" + ["/C", execCmd] on Windows, "sh" +
-// ["-c", execCmd] elsewhere. Or use os/exec's automatic resolution via a
-// small platform helper.
 func TestDevLoop_ExecFlagShellSelection(t *testing.T) {
-	// This test runs cross-platform but only meaningfully asserts on the
-	// platform where the bug bites.
-	if runtime.GOOS == "windows" {
-		// On Windows the current code unconditionally tries "sh" — the test
-		// can't actually exec it without breaking, so we just assert the
-		// intent: any shell-selection helper added later must NOT pick sh
-		// on Windows.
-		got, _ := pickExecShellForTest("echo hello")
-		if strings.HasPrefix(got, "sh") {
-			t.Errorf("Windows --exec must not use 'sh'; got %q. See KNOWN ISSUE F in dev_known_issues_test.go", got)
-		}
-		return
-	}
-	// On Unix, sh is fine.
-	got, _ := pickExecShellForTest("echo hello")
-	if got != "sh" {
-		t.Errorf("Unix --exec should use 'sh'; got %q", got)
-	}
-}
+	cmd := "echo hello"
 
-// pickExecShellForTest mirrors what a future buildExecCommand helper should
-// return. Today, dev.go inlines the choice ("sh") regardless of platform.
-// This stub lets the test express the intended contract; the implementation
-// will be added when the fix lands.
-func pickExecShellForTest(cmd string) (string, []string) {
-	if runtime.GOOS == "windows" {
-		// PLACEHOLDER: the fix should return ("cmd", []string{"/C", cmd})
-		// or similar. Returning "sh" here mirrors the current bug so the
-		// test currently flags Windows correctly.
-		return "sh", []string{"-c", cmd}
+	prog, args := pickExecShellFor("linux", cmd)
+	if prog != "sh" {
+		t.Errorf("linux: expected prog %q, got %q", "sh", prog)
 	}
-	return "sh", []string{"-c", cmd}
+	if len(args) != 2 || args[0] != "-c" || args[1] != cmd {
+		t.Errorf("linux: expected args %v, got %v", []string{"-c", cmd}, args)
+	}
+
+	prog, args = pickExecShellFor("darwin", cmd)
+	if prog != "sh" {
+		t.Errorf("darwin: expected prog %q, got %q", "sh", prog)
+	}
+	if len(args) != 2 || args[0] != "-c" || args[1] != cmd {
+		t.Errorf("darwin: expected args %v, got %v", []string{"-c", cmd}, args)
+	}
+
+	prog, args = pickExecShellFor("windows", cmd)
+	if prog != "cmd" {
+		t.Errorf("windows: expected prog %q, got %q", "cmd", prog)
+	}
+	if len(args) != 2 || args[0] != "/C" || args[1] != cmd {
+		t.Errorf("windows: expected args %v, got %v", []string{"/C", cmd}, args)
+	}
 }


### PR DESCRIPTION
Fixes #135

## Root cause

`cmd/tsgonest/dev.go` unconditionally spawned `sh -c <execCmd>` for the `--exec` flag. `sh` is not on PATH on default Windows installs, so users got `exec: "sh": file not found` and the dev loop never started the child process.

## Fix

Added `pickExecShellFor(goos, execCmd string) (string, []string)` (parameterized for testability) and `pickExecShell(execCmd string)` (wraps with `runtime.GOOS`) in `dev.go`. The call site now uses `pickExecShell` instead of the hardcoded `sh -c` string.

- Windows: `cmd /C <execCmd>`
- All other platforms: `sh -c <execCmd>`

## Test plan

- `TestDevLoop_ExecFlagShellSelection` is rewritten as a pure unit test of `pickExecShellFor` — no process spawning, runs identically on any host OS, and asserts correct behavior for `linux`, `darwin`, and `windows` goos values.
- `GOWORK=off go test -race -count=1 ./cmd/tsgonest/...` passes clean.