### PR TITLE
fix(build): support ** in --assets patterns (#138)

### DIFF
--- a/cmd/tsgonest/assets.go
+++ b/cmd/tsgonest/assets.go
@@ -3,34 +3,41 @@ package main
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/bmatcuk/doublestar/v4"
 )
 
 // copyAssets copies files matching a glob pattern from srcDir to destDir,
 // preserving the relative directory structure.
+//
+// Unlike filepath.Glob, this supports ** (double-star) patterns so that
+// patterns like **/*.json match files at any depth. Input patterns are
+// normalised to forward slashes before matching (required by doublestar),
+// and returned paths are converted back to the OS-native separator.
 func copyAssets(srcDir, destDir, pattern string) (int, error) {
-	matches, err := filepath.Glob(filepath.Join(srcDir, pattern))
+	fsys := os.DirFS(srcDir)
+	matches, err := doublestar.Glob(fsys, filepath.ToSlash(pattern))
 	if err != nil {
 		return 0, err
 	}
 
 	count := 0
 	for _, match := range matches {
-		rel, err := filepath.Rel(srcDir, match)
-		if err != nil {
-			continue
-		}
-		dest := filepath.Join(destDir, rel)
+		nativeMatch := filepath.FromSlash(match)
+		abs := filepath.Join(srcDir, nativeMatch)
 
-		info, err := os.Stat(match)
+		info, err := os.Stat(abs)
 		if err != nil || info.IsDir() {
 			continue
 		}
+
+		dest := filepath.Join(destDir, nativeMatch)
 
 		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 			return count, err
 		}
 
-		data, err := os.ReadFile(match)
+		data, err := os.ReadFile(abs)
 		if err != nil {
 			return count, err
 		}

--- a/cmd/tsgonest/assets_test.go
+++ b/cmd/tsgonest/assets_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeFixture creates a directory tree under base. Each entry in files is a
+// slash-separated relative path; directories are created as needed.
+func makeFixture(t *testing.T, base string, files []string) {
+	t.Helper()
+	for _, f := range files {
+		full := filepath.Join(base, filepath.FromSlash(f))
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte("content of "+f), 0644); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+}
+
+// assertCopied checks that every path in want exists under destDir.
+func assertCopied(t *testing.T, destDir string, want []string) {
+	t.Helper()
+	for _, rel := range want {
+		p := filepath.Join(destDir, filepath.FromSlash(rel))
+		if _, err := os.Stat(p); os.IsNotExist(err) {
+			t.Errorf("expected %s to be copied, but it is missing", rel)
+		}
+	}
+}
+
+// assertNotCopied checks that none of the paths in unwanted exist under destDir.
+func assertNotCopied(t *testing.T, destDir string, unwanted []string) {
+	t.Helper()
+	for _, rel := range unwanted {
+		p := filepath.Join(destDir, filepath.FromSlash(rel))
+		if _, err := os.Stat(p); err == nil {
+			t.Errorf("expected %s NOT to be copied, but it exists", rel)
+		}
+	}
+}
+
+func TestCopyAssets_DoubleStarJSON(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	makeFixture(t, src, []string{
+		"a.json",
+		"sub/b.json",
+		"sub/deep/c.json",
+		"sub/deep/deeper/d.json",
+		"sub/other.ts",
+		"ignore.ts",
+	})
+
+	count, err := copyAssets(src, dst, "**/*.json")
+	if err != nil {
+		t.Fatalf("copyAssets error: %v", err)
+	}
+	if count != 4 {
+		t.Errorf("count = %d, want 4", count)
+	}
+
+	assertCopied(t, dst, []string{
+		"a.json",
+		"sub/b.json",
+		"sub/deep/c.json",
+		"sub/deep/deeper/d.json",
+	})
+	assertNotCopied(t, dst, []string{"sub/other.ts", "ignore.ts"})
+}
+
+func TestCopyAssets_SingleStarFlatOnly(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	makeFixture(t, src, []string{
+		"top.json",
+		"also.json",
+		"nested/deep.json",
+	})
+
+	count, err := copyAssets(src, dst, "*.json")
+	if err != nil {
+		t.Fatalf("copyAssets error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("count = %d, want 2 (only top-level)", count)
+	}
+
+	assertCopied(t, dst, []string{"top.json", "also.json"})
+	assertNotCopied(t, dst, []string{"nested/deep.json"})
+}
+
+func TestCopyAssets_PrefixedDoubleStarPattern(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	makeFixture(t, src, []string{
+		"src/index.ts",
+		"src/sub/util.ts",
+		"src/sub/deep/helper.ts",
+		"root.ts",
+		"other/thing.ts",
+	})
+
+	count, err := copyAssets(src, dst, "src/**/*.ts")
+	if err != nil {
+		t.Fatalf("copyAssets error: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+
+	assertCopied(t, dst, []string{
+		"src/index.ts",
+		"src/sub/util.ts",
+		"src/sub/deep/helper.ts",
+	})
+	assertNotCopied(t, dst, []string{"root.ts", "other/thing.ts"})
+}
+
+func TestCopyAssets_NoMatches(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	makeFixture(t, src, []string{"a.ts", "b.ts"})
+
+	count, err := copyAssets(src, dst, "**/*.json")
+	if err != nil {
+		t.Fatalf("copyAssets error (no matches should not error): %v", err)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+}
+
+func TestCopyAssets_DeeplyNested(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	makeFixture(t, src, []string{
+		"a/b/c/d/e.json",
+		"a/b/c/d/e/f/g.json",
+		"a/b/c/d/e/f/g/h/i.json",
+		"skip.ts",
+	})
+
+	count, err := copyAssets(src, dst, "**/*.json")
+	if err != nil {
+		t.Fatalf("copyAssets error: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+
+	assertCopied(t, dst, []string{
+		"a/b/c/d/e.json",
+		"a/b/c/d/e/f/g.json",
+		"a/b/c/d/e/f/g/h/i.json",
+	})
+}
+
+func TestCopyAssets_WindowsBackslashPattern(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	makeFixture(t, src, []string{
+		"assets/icon.png",
+		"assets/sub/logo.png",
+	})
+
+	// Simulate a Windows-style pattern with backslashes; filepath.ToSlash inside
+	// copyAssets must normalise it before doublestar sees it.
+	pattern := filepath.FromSlash("assets/**/*.png")
+
+	count, err := copyAssets(src, dst, pattern)
+	if err != nil {
+		t.Fatalf("copyAssets error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("count = %d, want 2", count)
+	}
+
+	assertCopied(t, dst, []string{
+		"assets/icon.png",
+		"assets/sub/logo.png",
+	})
+}
+
+func TestCopyAssets_PreservesRelativeStructure(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	makeFixture(t, src, []string{
+		"locales/en/messages.json",
+		"locales/fr/messages.json",
+	})
+
+	_, err := copyAssets(src, dst, "**/*.json")
+	if err != nil {
+		t.Fatalf("copyAssets error: %v", err)
+	}
+
+	assertCopied(t, dst, []string{
+		"locales/en/messages.json",
+		"locales/fr/messages.json",
+	})
+}
+
+func TestCopyAssets_ExactFile(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	makeFixture(t, src, []string{
+		"assets/icon.png",
+		"assets/other.svg",
+	})
+
+	count, err := copyAssets(src, dst, "assets/icon.png")
+	if err != nil {
+		t.Fatalf("copyAssets error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+
+	assertCopied(t, dst, []string{"assets/icon.png"})
+	assertNotCopied(t, dst, []string{"assets/other.svg"})
+}

--- a/go.mod
+++ b/go.mod
@@ -22,15 +22,16 @@ require golang.org/x/tools v0.44.0
 
 require (
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
+	github.com/microsoft/typescript-go v0.0.0-20260424234512-515d036f927a // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 )
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433
-	github.com/microsoft/typescript-go v0.0.0-20260424234512-515d036f927a
 	github.com/microsoft/typescript-go/shim/ast v0.0.0-00010101000000-000000000000
 	github.com/microsoft/typescript-go/shim/bundled v0.0.0-00010101000000-000000000000
 	github.com/microsoft/typescript-go/shim/checker v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 h1:vymEbVwYFP/L05h5TKQxvkXoKxNvTpjxYKdF1Nlwuao=


### PR DESCRIPTION
## Summary

- Fixes #138: `tsgonest build --assets '**/*.json'` silently matched zero files because `filepath.Glob` does not support `**` (double-star) patterns
- Replaces `filepath.Glob` in `copyAssets` with `github.com/bmatcuk/doublestar/v4` (`doublestar.Glob` against `os.DirFS(srcDir)`)
- Input patterns are normalised to forward slashes via `filepath.ToSlash` before matching (required by doublestar), and returned relative paths are converted back to OS-native separators via `filepath.FromSlash` before joining

## Root cause

`filepath.Glob` / `filepath.Match` in the Go stdlib explicitly documents that `**` is **not** a special sequence — it matches only as a literal two-character segment. Every glob with `**` silently returned zero matches.

## New dependency

`github.com/bmatcuk/doublestar/v4 v4.10.0` — a well-maintained, zero-transitive-dependency library that follows the same path-matching semantics as most CLI tools.

## Test plan

- [x] `**/*.json` matches JSON files at all depths (root, 1-level nested, 3-level nested, 8-level nested)
- [x] `*.json` (no `**`) still matches only top-level files — no behavioural regression
- [x] `src/**/*.ts` only matches `.ts` files under `src/`
- [x] Pattern with zero matches returns `count=0`, no error
- [x] Windows-style backslash pattern (`assets\**\*.png`) is normalised correctly
- [x] Relative directory structure is preserved in destination
- [x] Exact file pattern (`assets/icon.png`) copies a single file
- [x] `go test -race -count=1 ./cmd/tsgonest/...` passes clean