### PR TITLE
fix(watcher): handle forward-slash paths in shouldSkipPath (#136)

### DIFF
--- a/internal/watcher/edge_cases_test.go
+++ b/internal/watcher/edge_cases_test.go
@@ -402,6 +402,62 @@ func TestWatch_PollingMissesIdenticalSizeIdenticalMtimeRewrite(t *testing.T) {
 // shouldSkipPath edge cases
 // ─────────────────────────────────────────────────────────────────────────────
 
+// TestShouldSkipPath_SeparatorNormalization verifies that shouldSkipPath
+// correctly handles forward-slash paths (Git Bash on Windows and Linux/macOS),
+// OS-native paths built with filepath.Join, and edge cases that must not match.
+func TestShouldSkipPath_SeparatorNormalization(t *testing.T) {
+	cases := []struct {
+		path       string
+		want       bool
+		descriptor string
+	}{
+		// Forward-slash paths: the primary regression target.
+		// On Windows, Git Bash (and some fsnotify builds) deliver "C:/..." paths.
+		// On Linux/macOS, all paths are already forward-slash.
+		{`C:/proj/src/node_modules/foo.ts`, true, "forward-slash: mid-path node_modules"},
+		{`C:/proj/node_modules`, true, "forward-slash: node_modules at end (no trailing slash)"},
+		{`C:/proj/.git/objects`, true, "forward-slash: .git mid-path"},
+		{`C:/proj/dist/main.js`, true, "forward-slash: dist mid-path"},
+		{`/home/user/proj/node_modules/foo.ts`, true, "unix: mid-path node_modules"},
+		{`/home/user/proj/node_modules`, true, "unix: node_modules at end"},
+		{`/home/user/proj/.git/HEAD`, true, "unix: .git mid-path"},
+		{`/home/user/proj/build/app.js`, true, "unix: build mid-path"},
+		{`/home/user/proj/coverage/lcov.info`, true, "unix: coverage mid-path"},
+		{`/home/user/proj/.next/cache/foo`, true, "unix: .next mid-path"},
+		{`/home/user/proj/.turbo/cache`, true, "unix: .turbo mid-path"},
+
+		// OS-native paths (filepath.Join uses the platform separator).
+		// These exercise the ToSlash conversion on Windows and are no-ops on Linux/macOS.
+		{filepath.Join("proj", "src", "node_modules", "foo.ts"), true, "native: mid-path node_modules"},
+		{filepath.Join("proj", "node_modules"), true, "native: node_modules at end"},
+		{filepath.Join("proj", ".git", "objects"), true, "native: .git mid-path"},
+		{filepath.Join("proj", "dist", "main.js"), true, "native: dist mid-path"},
+		{filepath.Join("proj", "build", "out.js"), true, "native: build mid-path"},
+		{filepath.Join("proj", "coverage", "lcov.info"), true, "native: coverage mid-path"},
+		{filepath.Join("proj", ".next", "cache", "foo"), true, "native: .next mid-path"},
+		{filepath.Join("proj", ".turbo", "cache"), true, "native: .turbo mid-path"},
+		{filepath.Join("proj", "__pycache__", "mod.pyc"), true, "native: __pycache__ mid-path"},
+
+		// Relative paths
+		{"node_modules/foo.ts", true, "relative forward-slash: node_modules/foo.ts"},
+		{"node_modules", true, "relative: bare node_modules directory name"},
+
+		// Negative cases: must NOT match — substring/suffix traps
+		{"/path/notnode_modules/foo.ts", false, "notnode_modules is not a skip dir"},
+		{"/path/node_modules_old/foo.ts", false, "node_modules_old suffix trap"},
+		{"/path/to/src/app.ts", false, "normal source file"},
+		{"/path/to/mynode_modules/foo.ts", false, "prefix+node_modules substring trap"},
+		{filepath.Join("proj", "src", "node_modulesFake", "foo.ts"), false, "native: lookalike dir must not match"},
+	}
+
+	for _, c := range cases {
+		got := shouldSkipPath(c.path)
+		if got != c.want {
+			t.Errorf("shouldSkipPath(%q) = %v, want %v — %s", c.path, got, c.want, c.descriptor)
+		}
+	}
+}
+
 // TestShouldSkipPath_CaseSensitive_KnownIssue documents that shouldSkipPath
 // uses case-sensitive Contains. On Windows (case-insensitive filesystem), a
 // path containing "Node_Modules" is not skipped. Fix: strings.EqualFold or

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -264,14 +264,16 @@ func fsnotifyOpToString(op fsnotify.Op) string {
 
 // shouldSkipPath returns true if the path contains a directory segment
 // that should be ignored (e.g., node_modules, .git).
+// Normalizes separators to "/" before matching so that Windows native paths
+// (backslash) and Git Bash / forward-slash paths both match correctly.
 func shouldSkipPath(path string) bool {
+	normalized := filepath.ToSlash(path)
 	for dir := range skipDirs {
-		// Check for /dir/ segment or /dir at the end
-		seg := string(filepath.Separator) + dir + string(filepath.Separator)
-		if strings.Contains(path, seg) {
-			return true
-		}
-		if strings.HasSuffix(path, string(filepath.Separator)+dir) {
+		seg := "/" + dir + "/"
+		if strings.Contains(normalized, seg) ||
+			strings.HasSuffix(normalized, "/"+dir) ||
+			normalized == dir ||
+			strings.HasPrefix(normalized, dir+"/") {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #136

- **Root cause**: `shouldSkipPath` built skip-dir segments using `string(filepath.Separator)`, which is `\` on Windows. Paths from Git Bash (and some fsnotify configurations) arrive as forward-slash (`C:/proj/node_modules/foo.ts`), so the backslash segment never matched and writes inside `node_modules` triggered phantom rebuilds.
- **Fix**: Normalize the incoming path once with `filepath.ToSlash` before matching, then check against `/`-separated segments. Added `HasPrefix(normalized, dir+"/")` to also catch relative paths like `node_modules/foo.ts`. `filepath.ToSlash` is a no-op on Linux/macOS, so existing behavior is preserved there.
- **Scope**: Only `shouldSkipPath` — no other watcher behavior is touched.

## Test plan

- [ ] `TestShouldSkipPath_SeparatorNormalization` covers: forward-slash Windows paths (`C:/proj/.../node_modules/...`), OS-native paths via `filepath.Join`, relative paths, bare dir name, and negative cases (substring traps like `node_modules_old`, `mynode_modules`)
- [ ] All configured skip dirs (`.git`, `.next`, `.turbo`, `dist`, `build`, `coverage`, `__pycache__`) are exercised
- [ ] `go test -race -count=1 -run TestShouldSkipPath ./internal/watcher/...` passes clean