### PR TITLE
fix(runner): replace ProcessState read with atomic.Bool (#134)

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 )
 
 // Runner manages a child Node.js process.
@@ -24,6 +25,13 @@ type Runner struct {
 	done      chan struct{}
 	stopped   bool    // set by Stop(); prevents Start() after explicit shutdown
 	jobHandle uintptr // Windows Job Object handle; unused on other platforms
+
+	// alive is read by Running() without holding r.mu. The stdlib mutates
+	// cmd.ProcessState from inside cmd.Wait() without our lock, so reading
+	// ProcessState from Running() races with the Wait goroutine. Track liveness
+	// explicitly: set true after a successful cmd.Start(), cleared by the Wait
+	// goroutine on exit.
+	alive atomic.Bool
 }
 
 // New creates a new process runner.
@@ -86,10 +94,5 @@ func (r *Runner) Wait() {
 
 // Running returns true if the child process is running.
 func (r *Runner) Running() bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.cmd == nil || r.cmd.Process == nil {
-		return false
-	}
-	return r.cmd.ProcessState == nil || !r.cmd.ProcessState.Exited()
+	return r.alive.Load()
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -4,6 +4,8 @@ package runner
 
 import (
 	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -106,26 +108,58 @@ func TestRunner_DisableStdin_DefaultFalse(t *testing.T) {
 	}
 }
 
-// TestRunner_Running_DataRace_KnownIssue documents that Running() reads
-// r.cmd.ProcessState while the Wait goroutine spawned by Start() writes to it
-// (via cmd.Wait()). r.mu protects r.cmd the pointer, but not the internal
-// fields of *exec.Cmd — the stdlib mutates ProcessState from the goroutine
-// without acquiring r.mu. `go test -race` flags this.
-//
-// Reproduction:
-//
-//	go test -race -run TestRunner_Restart ./internal/runner/
-//
-// The existing TestRunner_Restart triggers it because it calls Restart() then
-// Running() back-to-back; the Wait goroutine on the previous cmd is still
-// finalizing ProcessState while the test reads it.
-//
-// Fix: Running() should not touch r.cmd.ProcessState. Either track an
-// atomic.Bool set/unset by Start/Wait, or check `select { case <-r.done:
-// return false; default: return true }` while holding r.mu only for r.done
-// access. Marked KNOWN ISSUE G in the audit.
-func TestRunner_Running_DataRace_KnownIssue(t *testing.T) {
-	t.Skip("KNOWN ISSUE G: Running() reads cmd.ProcessState concurrently with cmd.Wait(); see runner.go:94. Reproduce with `go test -race -run TestRunner_Restart`.")
+// TestRunner_Running_DataRace stress-tests Running() against Restart() to
+// guarantee the lock-free atomic-based liveness flag stays race-free under
+// `go test -race`. The previous implementation read r.cmd.ProcessState from
+// Running() while the Wait goroutine wrote it via cmd.Wait(); this test would
+// have flagged that race. Run with: go test -race ./internal/runner/.
+func TestRunner_Running_DataRace(t *testing.T) {
+	r := New("sleep", []string{"10"}, "")
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer r.Stop()
+
+	var (
+		stop    atomic.Bool
+		wg      sync.WaitGroup
+		reads   atomic.Int64
+		restart atomic.Int64
+	)
+
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for !stop.Load() {
+				_ = r.Running()
+				reads.Add(1)
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deadline := time.Now().Add(500 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			if err := r.Restart(); err != nil {
+				t.Errorf("Restart failed: %v", err)
+				return
+			}
+			restart.Add(1)
+		}
+		stop.Store(true)
+	}()
+
+	wg.Wait()
+
+	if restart.Load() < 2 {
+		t.Fatalf("expected at least 2 Restart() cycles to exercise the race window, got %d", restart.Load())
+	}
+	if reads.Load() < 1000 {
+		t.Fatalf("expected at least 1000 Running() reads to exercise the race window, got %d", reads.Load())
+	}
 }
 
 // TestRunner_GoroutineCountStableAcrossManyRestarts verifies that the cmd.Wait

--- a/internal/runner/runner_unix.go
+++ b/internal/runner/runner_unix.go
@@ -26,10 +26,15 @@ func (r *Runner) Start() error {
 		return fmt.Errorf("starting process: %w", err)
 	}
 
+	r.alive.Store(true)
+
 	// Wait for process in background
+	cmd := r.cmd
+	done := r.done
 	go func() {
-		r.cmd.Wait()
-		close(r.done)
+		cmd.Wait()
+		r.alive.Store(false)
+		close(done)
 	}()
 
 	return nil

--- a/internal/runner/runner_windows.go
+++ b/internal/runner/runner_windows.go
@@ -94,10 +94,15 @@ func (r *Runner) Start() error {
 		return fmt.Errorf("resuming process: %w", err)
 	}
 
+	r.alive.Store(true)
+
 	// Wait for process in background
+	cmd := r.cmd
+	done := r.done
 	go func() {
-		r.cmd.Wait()
-		close(r.done)
+		cmd.Wait()
+		r.alive.Store(false)
+		close(done)
 	}()
 
 	return nil

--- a/justfile
+++ b/justfile
@@ -61,11 +61,11 @@ build:
   Copy-Item tsgonest.exe packages\core\bin\tsgonest.exe
 
 test: build
-  go test ./internal/...
+  go test -race ./internal/...
   cd e2e && pnpm run test --run && cd ..
 
 test-unit:
-  go test ./internal/...
+  go test -race ./internal/...
 
 test-e2e: build
   cd e2e && pnpm run test --run && cd ..


### PR DESCRIPTION
Fixes #134

## Root cause

`internal/runner/runner.go`'s `Running()` read `r.cmd.ProcessState` while the goroutine spawned by `Start()` (in `runner_unix.go` / `runner_windows.go`) was calling `cmd.Wait()`. The stdlib mutates `cmd.ProcessState` from inside `Wait()` without taking our mutex, so although `r.mu` protects the `r.cmd` pointer, it does not protect the internal `*exec.Cmd` fields. `go test -race` consistently flagged this on `TestRunner_Restart`.

## Fix

- Add `alive atomic.Bool` to `Runner`.
- Set `r.alive.Store(true)` in `Start()` after a successful `cmd.Start()` (both unix and windows paths).
- Clear `r.alive.Store(false)` from the Wait goroutine after `cmd.Wait()` returns, before `close(done)`.
- `Running()` now returns `r.alive.Load()` with no mutex and no `ProcessState` access.
- Capture `cmd` and `done` into goroutine locals so the Wait goroutine never reads `r.cmd`/`r.done` (which `stop()` nils under the mutex) — keeps the goroutine independent of subsequent state mutations.

## Test plan

- [x] Renamed `TestRunner_Running_DataRace_KnownIssue` → `TestRunner_Running_DataRace`. It now spins 4 reader goroutines hammering `Running()` while a writer loops `Restart()` for 500ms. The reader+restart counts are asserted as a guardrail so the test fails if it stops actually exercising the race window.
- [x] `go test -race -count=10 ./internal/runner/...` — clean (~127s).
- [x] `go test -race ./internal/...` — full internal suite passes with race detector enabled.
- [x] `go test -race -count=5 -run "TestRunner_Restart|TestRunner_Running_DataRace" ./internal/runner/` — clean.

## CI

Enabled `-race` on the `justfile`'s `test` and `test-unit` recipes so future races on the runner (or anywhere in `./internal/...`) get caught at PR time.