### PR TITLE
fix(build): cross-platform cleanDir safety guard (#139)

### DIFF
--- a/cmd/tsgonest/build.go
+++ b/cmd/tsgonest/build.go
@@ -842,10 +842,57 @@ func tsbuildInfoPathFromTsconfig(resolvedTsconfigPath string) string {
 	return strings.TrimSuffix(resolvedTsconfigPath, ".json") + ".tsbuildinfo"
 }
 
+// validateOutDir checks that outDir is safe to remove. This is the LAST line of
+// defense before os.RemoveAll — do NOT weaken these checks.
+func validateOutDir(outDir string) error {
+	if outDir == "" {
+		return fmt.Errorf("refusing to clean empty outDir")
+	}
+
+	clean := filepath.Clean(outDir)
+
+	// Reject bare navigation tokens before making the path absolute —
+	// "." and ".." are almost certainly user mistakes, and their resolved
+	// value changes with the working directory at runtime.
+	if clean == "." || clean == ".." {
+		return fmt.Errorf("refusing to clean dangerous path %q", outDir)
+	}
+
+	abs, err := filepath.Abs(clean)
+	if err != nil {
+		return fmt.Errorf("resolving outDir: %w", err)
+	}
+
+	// Strip volume prefix (e.g. "C:" on Windows, "" on Unix), then verify
+	// that something meaningful remains below the root or volume root.
+	vol := filepath.VolumeName(abs)
+	rest := strings.TrimPrefix(abs, vol)
+	rest = strings.Trim(rest, string(filepath.Separator))
+	if rest == "" || rest == "." || rest == ".." {
+		return fmt.Errorf("refusing to clean dangerous path %q", outDir)
+	}
+
+	// Refuse to wipe the user's home directory.
+	if home, err := os.UserHomeDir(); err == nil {
+		if absHome, err := filepath.Abs(home); err == nil && abs == absHome {
+			return fmt.Errorf("refusing to clean home directory %q", outDir)
+		}
+	}
+
+	// Refuse to wipe the current working directory.
+	if cwd, err := os.Getwd(); err == nil {
+		if absCwd, err := filepath.Abs(cwd); err == nil && abs == absCwd {
+			return fmt.Errorf("refusing to clean current working directory %q", outDir)
+		}
+	}
+
+	return nil
+}
+
 // cleanDir removes a directory after safety checks.
 func cleanDir(outDir string) error {
-	if outDir == "/" || outDir == "." || outDir == ".." {
-		return fmt.Errorf("refusing to clean dangerous path: %s", outDir)
+	if err := validateOutDir(outDir); err != nil {
+		return err
 	}
 
 	if _, err := os.Stat(outDir); os.IsNotExist(err) {
@@ -859,8 +906,8 @@ func cleanDir(outDir string) error {
 // smartCleanDir removes all files in outDir but preserves .tsbuildinfo,
 // so incremental compilation can still reuse cached data from the previous build.
 func smartCleanDir(outDir string, tsbuildInfoPath string) error {
-	if outDir == "/" || outDir == "." || outDir == ".." {
-		return fmt.Errorf("refusing to clean dangerous path: %s", outDir)
+	if err := validateOutDir(outDir); err != nil {
+		return err
 	}
 
 	if _, err := os.Stat(outDir); os.IsNotExist(err) {

--- a/cmd/tsgonest/build_test.go
+++ b/cmd/tsgonest/build_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/core"
@@ -784,6 +785,90 @@ func TestPipeline_FullIntegrationWithTSConfig(t *testing.T) {
 	// CLI --target es2022 should override tsconfig target: es2015
 	if finalOpts.Target != core.ScriptTargetES2022 {
 		t.Errorf("Target = %v, want ScriptTargetES2022 (CLI override)", finalOpts.Target)
+	}
+}
+
+// --- validateOutDir tests ---
+
+func TestValidateOutDir_DangerousUnixPaths(t *testing.T) {
+	for _, p := range []string{"/", ".", ".."} {
+		if err := validateOutDir(p); err == nil {
+			t.Errorf("validateOutDir(%q) should refuse dangerous path, got nil", p)
+		}
+	}
+}
+
+func TestValidateOutDir_EmptyString(t *testing.T) {
+	if err := validateOutDir(""); err == nil {
+		t.Error("validateOutDir(\"\") should refuse empty string")
+	}
+}
+
+func TestValidateOutDir_ParentTraversalToRoot(t *testing.T) {
+	// On a Unix system, if CWD is exactly one level below root (e.g. /tmp),
+	// "../.." resolves to "/" which the root-path guard must catch.
+	// We test this by checking that validateOutDir("/") is always refused,
+	// which is covered by TestValidateOutDir_DangerousUnixPaths above.
+	// Additional coverage: raw ".." (one level up from CWD) must be refused
+	// by the token check regardless of where CWD is.
+	if err := validateOutDir(".."); err == nil {
+		t.Error("validateOutDir(\"..\") should always refuse bare parent-traversal")
+	}
+}
+
+func TestValidateOutDir_LegitAbsolutePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dist")
+	if err := validateOutDir(path); err != nil {
+		t.Errorf("validateOutDir(%q) should allow legit absolute path, got: %v", path, err)
+	}
+}
+
+func TestValidateOutDir_LegitRelativePath(t *testing.T) {
+	for _, p := range []string{"dist", "./dist", "build/output"} {
+		if err := validateOutDir(p); err != nil {
+			t.Errorf("validateOutDir(%q) should allow legit relative path, got: %v", p, err)
+		}
+	}
+}
+
+func TestValidateOutDir_HomeDirectory(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+	if err := validateOutDir(home); err == nil {
+		t.Errorf("validateOutDir(%q) should refuse home directory", home)
+	}
+}
+
+func TestValidateOutDir_CurrentWorkingDirectory(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Skip("cannot determine cwd")
+	}
+	if err := validateOutDir(cwd); err == nil {
+		t.Errorf("validateOutDir(%q) should refuse cwd", cwd)
+	}
+}
+
+func TestValidateOutDir_WindowsDriveRoots(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific path tests")
+	}
+	for _, p := range []string{`C:\`, `C:`, `D:\`, `c:\`, `\`} {
+		if err := validateOutDir(p); err == nil {
+			t.Errorf("validateOutDir(%q) should refuse Windows drive root", p)
+		}
+	}
+}
+
+func TestValidateOutDir_WindowsLegitPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific path tests")
+	}
+	p := `C:\Users\project\dist`
+	if err := validateOutDir(p); err != nil {
+		t.Errorf("validateOutDir(%q) should allow legit Windows path, got: %v", p, err)
 	}
 }
 


### PR DESCRIPTION
Fixes #139

## Root cause

`cleanDir` and `smartCleanDir` had a unix-only safety check (`outDir == "/" || outDir == "." || outDir == ".."`) before calling `os.RemoveAll`. On Windows, `filepath.Clean("C:\\")` produces `C:\` and `filepath.Clean("/")` produces `\` — neither matches the guard — so a misconfigured `"outDir": "/"` in `tsconfig.json` would silently wipe the drive root.

## Threat model

`os.RemoveAll` with an unchecked path has infinite blast radius. A user with a typo in their `tsconfig.json` `outDir` (e.g. `/` or `C:\`) and `--clean` / `deleteOutDir: true` would lose everything on that volume. Low likelihood, catastrophic severity.

## Fix

Extracted a shared `validateOutDir(outDir string) error` function that both `cleanDir` and `smartCleanDir` call first. The guard:

1. Rejects empty strings
2. Rejects bare `.` and `..` tokens (before any path resolution, so the check is CWD-invariant)
3. Uses `filepath.Abs` + `filepath.VolumeName` to strip the volume prefix (`C:` on Windows, `""` on Unix) and verify a non-empty path component remains below the root — catches `C:\`, `D:\`, `\`, and `/`
4. Refuses to wipe `os.UserHomeDir()`
5. Refuses to wipe `os.Getwd()`

The original unix checks are subsumed by the new logic (defence in depth still applies for `.` / `..` via the token check).

## Test plan

- `TestValidateOutDir_DangerousUnixPaths` — `/`, `.`, `..` all refused
- `TestValidateOutDir_EmptyString` — empty string refused
- `TestValidateOutDir_ParentTraversalToRoot` — `..` always refused by token check
- `TestValidateOutDir_LegitAbsolutePath` — tempdir/dist allowed
- `TestValidateOutDir_LegitRelativePath` — `dist`, `./dist`, `build/output` allowed
- `TestValidateOutDir_HomeDirectory` — home dir refused
- `TestValidateOutDir_CurrentWorkingDirectory` — CWD refused
- `TestValidateOutDir_WindowsDriveRoots` — `C:\`, `C:`, `D:\`, `c:\`, `\` refused (gated on `runtime.GOOS == "windows"`)
- `TestValidateOutDir_WindowsLegitPath` — `C:\Users\project\dist` allowed (gated on Windows)

Tests call `validateOutDir` directly — no `os.RemoveAll` executes against any of these paths.

```
go test -race -count=1 ./cmd/tsgonest/...
ok  github.com/tsgonest/tsgonest/cmd/tsgonest  1.6s
```