### PR TITLE
fix(dev): hoist stdin scanner above runDevLoop (#130)

### DIFF
--- a/cmd/tsgonest/dev.go
+++ b/cmd/tsgonest/dev.go
@@ -150,9 +150,41 @@ func runDev(args []string) int {
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
+	// Single long-lived stdin scanner shared across config-change restarts.
+	// bufio.Scanner.Scan() blocks in a kernel read(2) syscall and cannot be
+	// interrupted by closing a `done` channel. If we spawned a fresh scanner
+	// per runDevLoop iteration, every config-change restart would leak a
+	// goroutine still blocked on os.Stdin, and stale scanners would race the
+	// active iteration for keystrokes (issue #130). Instead, spawn the scanner
+	// exactly once here. It naturally dies with the process at exit, when
+	// stdin is closed by the OS — that's the only acceptable termination
+	// condition for an uninterruptible read.
+	//
+	// Forwarding is non-blocking via a buffered channel: if the active
+	// runDevLoop iteration isn't currently selecting on rsCh (e.g. between
+	// iterations during a config restart), at most one pending "rs" event is
+	// dropped — which matches the user's intuition that only the most-recent
+	// keystroke matters.
+	rsCh := make(chan struct{}, 1)
+	go func() {
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line != "rs" {
+				continue
+			}
+			select {
+			case rsCh <- struct{}{}:
+			default:
+				// Active iteration hasn't drained the previous "rs" yet.
+				// Drop this one — coalescing repeated presses is fine.
+			}
+		}
+	}()
+
 	// Run the dev loop. It restarts from scratch when config files change.
 	for {
-		result := runDevLoop(&flags, sigCh)
+		result := runDevLoop(&flags, sigCh, rsCh)
 		if result != devLoopRestart {
 			return 0
 		}
@@ -164,7 +196,14 @@ func runDev(args []string) int {
 // runDevLoop runs one iteration of the dev loop: load config, build, start
 // child, watch source files, and poll config files. Returns devLoopRestart
 // if a config file changed, or devLoopExit if a signal was received.
-func runDevLoop(flags *devFlags, sigCh chan os.Signal) devLoopResult {
+//
+// rsCh receives manual-restart events from the long-lived stdin scanner in
+// runDev. It is shared across iterations so we don't leak a scanner goroutine
+// per config-change restart (issue #130). This iteration drains the channel
+// regardless of whether manualRestart is currently enabled — it just no-ops
+// when the current config disables manualRestart, so a stale "rs" press from
+// a previous iteration's config doesn't pile up on the channel.
+func runDevLoop(flags *devFlags, sigCh chan os.Signal, rsCh <-chan struct{}) devLoopResult {
 	cwd := flags.cwd
 	pretty := compiler.IsPrettyOutput()
 
@@ -405,32 +444,27 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal) devLoopResult {
 		}
 	}()
 
-	// Manual restart listener
-	if manualRestart {
-		go func() {
-			scanner := bufio.NewScanner(os.Stdin)
-			for scanner.Scan() {
-				select {
-				case <-done:
-					return
-				default:
-				}
-				line := strings.TrimSpace(scanner.Text())
-				if line == "rs" {
-					fmt.Fprintln(os.Stderr, "\nmanual restart triggered...")
-					result := builder.Build()
-					if result != 0 {
-						fmt.Fprintln(os.Stderr, "build failed, waiting for changes...")
-					} else if proc != nil {
-						fmt.Fprintln(os.Stderr, "restarting...")
-						if err := proc.Restart(); err != nil {
-							fmt.Fprintf(os.Stderr, "error restarting: %v\n", err)
-						}
-					}
-					fmt.Fprintln(os.Stderr, "To restart at any time, enter \"rs\".")
-				}
+	// Manual restart listener.
+	//
+	// We always run this goroutine (even when manualRestart is currently
+	// disabled) so that rsCh — which is shared across config-change restarts
+	// — is always being drained while this iteration is active. This prevents
+	// a stale "rs" press from sitting in the channel buffer between iterations
+	// and silently triggering a restart later. The scanner itself lives in
+	// runDev, not here, so we don't leak a goroutine on every restart.
+	go runRsListener(done, rsCh, manualRestart, func() {
+		result := builder.Build()
+		if result != 0 {
+			fmt.Fprintln(os.Stderr, "build failed, waiting for changes...")
+		} else if proc != nil {
+			fmt.Fprintln(os.Stderr, "restarting...")
+			if err := proc.Restart(); err != nil {
+				fmt.Fprintf(os.Stderr, "error restarting: %v\n", err)
 			}
-		}()
+		}
+		fmt.Fprintln(os.Stderr, "To restart at any time, enter \"rs\".")
+	})
+	if manualRestart {
 		fmt.Fprintln(os.Stderr, "To restart at any time, enter \"rs\".")
 	}
 
@@ -547,6 +581,29 @@ func rebuildLoop(d rebuildLoopDeps) {
 
 		case <-d.done:
 			return
+		}
+	}
+}
+
+// runRsListener consumes manual-restart events from rsCh until done closes.
+// When manualRestart is false, events are drained but ignored — this ensures
+// stale presses left over from a prior config don't pile up in the buffered
+// channel between iterations of runDevLoop. When manualRestart is true and an
+// event arrives, the provided onRestart callback runs.
+//
+// Extracted from runDevLoop so the goroutine-leak fix for issue #130 is
+// directly testable without spinning up a real builder/runner.
+func runRsListener(done <-chan struct{}, rsCh <-chan struct{}, manualRestart bool, onRestart func()) {
+	for {
+		select {
+		case <-done:
+			return
+		case <-rsCh:
+			if !manualRestart {
+				continue
+			}
+			fmt.Fprintln(os.Stderr, "\nmanual restart triggered...")
+			onRestart()
 		}
 	}
 }

--- a/cmd/tsgonest/dev_known_issues_test.go
+++ b/cmd/tsgonest/dev_known_issues_test.go
@@ -11,7 +11,6 @@ package main
 
 import (
 	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -199,25 +198,106 @@ func TestDevLoop_RebuildGoroutineNoRestartUnderRaceStress(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// B. Stdin scanner goroutine multiplies on config restart
+// B. Stdin scanner goroutine multiplies on config restart  — FIXED (#130)
 // ─────────────────────────────────────────────────────────────────────────────
 
-// When manualRestart is true, runDevLoop spawns a goroutine that calls
-// bufio.NewScanner(os.Stdin) and loops on scanner.Scan(). scanner.Scan()
-// blocks in a kernel syscall; closing `done` cannot interrupt it. On a
-// config-change restart, runDevLoop returns and a new iteration spawns
-// another scanner. The previous scanner is still blocked on Stdin. Each
-// config change adds one more scanner. They all race for stdin reads.
+// Issue #130 fix: a single long-lived stdin scanner lives in runDev and
+// forwards "rs" presses to the active runDevLoop iteration via a shared
+// rsCh channel. Each iteration's manual-restart listener (runRsListener)
+// terminates cleanly when its `done` channel closes. As a result, repeated
+// config-change restarts must NOT accumulate goroutines.
 //
-// Reproduction: configure manualRestart: true, save tsconfig.json N times
-// (N config restarts). Type "rs". One of the N+1 scanners wins; the others
-// silently consume keystrokes that the user expected the active loop to see.
-//
-// Fix: hoist the stdin scanner above runDevLoop so a single goroutine
-// survives across config restarts, and have it send "rs" events on a channel
-// that the active runDevLoop iteration selects on.
-func TestDevLoop_StdinScannerLeaksAcrossConfigRestarts_KnownIssue(t *testing.T) {
-	t.Skip("KNOWN ISSUE B: bufio.Scanner on os.Stdin is uninterruptible; each config-change restart leaks a scanner goroutine. Fix in dev.go runDev (lift scanner above the loop).")
+// We can't directly count "scanner goroutines blocked on os.Stdin" in a unit
+// test (that's the whole point — they're uninterruptible), so we exercise
+// the contract that replaced the leaky scanner: runRsListener is the only
+// per-iteration goroutine spawned by the manual-restart path, and it must
+// exit when done closes. After N simulated restarts, total goroutine count
+// must be flat.
+func TestDevLoop_StdinScannerSurvivesAcrossConfigRestarts(t *testing.T) {
+	const restarts = 8
+
+	// Snapshot baseline goroutine count after the runtime stabilises.
+	settle()
+	before := runtime.NumGoroutine()
+
+	rsCh := make(chan struct{}, 1) // shared — same shape as runDev's rsCh
+
+	for i := 0; i < restarts; i++ {
+		done := make(chan struct{})
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			runRsListener(done, rsCh, true, func() {})
+		}()
+		<-started
+		// Simulate a runDevLoop iteration ending (config change → return).
+		close(done)
+		// Give the listener a moment to observe the close and exit.
+		settle()
+	}
+
+	after := runtime.NumGoroutine()
+	if after > before+1 {
+		t.Errorf("goroutine leak across %d simulated config-change restarts: before=%d after=%d (delta=%d)\nA single long-lived stdin scanner must survive restarts without spawning new goroutines per iteration. See issue #130.",
+			restarts, before, after, after-before)
+	}
+}
+
+// Regression test: across N simulated config-change restarts, an "rs" press
+// pushed onto the shared rsCh must reach the currently-active iteration's
+// listener (not a stale leaked scanner from a previous iteration).
+func TestDevLoop_StdinScannerForwardsRsAcrossRestarts(t *testing.T) {
+	const restarts = 5
+
+	rsCh := make(chan struct{}, 1) // shared across iterations, like runDev's rsCh
+
+	for i := 0; i < restarts; i++ {
+		done := make(chan struct{})
+		var triggered atomic.Int32
+		fired := make(chan struct{}, 1)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runRsListener(done, rsCh, true, func() {
+				triggered.Add(1)
+				select {
+				case fired <- struct{}{}:
+				default:
+				}
+			})
+		}()
+
+		// Push "rs" — like the long-lived scanner does on a real keystroke.
+		select {
+		case rsCh <- struct{}{}:
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d: rsCh send blocked — listener not draining", i)
+		}
+
+		// The active iteration's listener must consume it.
+		select {
+		case <-fired:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("iteration %d: 'rs' press never reached the active listener (would happen if a stale scanner from a prior iteration intercepted it)", i)
+		}
+		if got := triggered.Load(); got != 1 {
+			t.Fatalf("iteration %d: onRestart fired %d times, want 1", i, got)
+		}
+
+		close(done)
+		wg.Wait()
+	}
+}
+
+// settle yields enough that goroutines closing in response to a `done` close
+// have a chance to actually exit before NumGoroutine is sampled.
+func settle() {
+	for i := 0; i < 20; i++ {
+		runtime.Gosched()
+		time.Sleep(5 * time.Millisecond)
+	}
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #130.

`runDevLoop` previously spawned a `bufio.NewScanner(os.Stdin)` goroutine on every iteration when `manualRestart: true`. `Scanner.Scan()` blocks in a kernel `read(2)` syscall and cannot be interrupted by closing a `done` channel — so each config-change restart left the previous scanner blocked on stdin while spawning a fresh one. After N config restarts, N+1 scanners were racing for keystrokes; the user's "rs" press could be silently consumed by a stale iteration.

## Root cause

Per-iteration ownership of an uninterruptible blocking read. There is no way to cancel `Scan()` without closing `os.Stdin` itself.

## Fix

- Spawn the stdin scanner **exactly once** at the top of `runDev` (it lives for the lifetime of the dev process and dies naturally when the process exits — that's the only acceptable termination for an uninterruptible read).
- The scanner forwards `rs` presses onto a buffered `rsCh chan struct{}` shared across all `runDevLoop` iterations. Send is non-blocking (`select`/`default`); coalescing repeated presses is fine.
- `runDevLoop` accepts `rsCh` as a parameter. The per-iteration manual-restart goroutine is now `runRsListener`, which `select`s on `{done, rsCh}` and exits cleanly when `done` closes — so goroutine count stays flat across restarts.
- The listener is always spawned (even when the current config disables `manualRestart`) so a stale press doesn't sit in the channel buffer between iterations and silently fire later. When the current config disables manual restart, events are drained but ignored.

The listener body is extracted into `runRsListener` so the contract can be unit-tested without spinning up a real builder/runner.

## Test plan

- [x] `TestDevLoop_StdinScannerSurvivesAcrossConfigRestarts` — runs `runRsListener` 8 times against the same shared `rsCh`, closes `done` between iterations, asserts `runtime.NumGoroutine()` does not grow.
- [x] `TestDevLoop_StdinScannerForwardsRsAcrossRestarts` — across 5 simulated restarts, pushes one "rs" event onto `rsCh` per iteration and asserts the active listener's `onRestart` callback fires exactly once each time (a stale leaked listener would steal the event).
- [x] Removed the corresponding `_KnownIssue` doc-test in `cmd/tsgonest/dev_known_issues_test.go` (B).
- [x] `gofmt -w cmd internal` clean.
- [x] `go test -race -count=1 ./cmd/tsgonest/...` passes.
- [x] `go test -count=1 ./internal/runner/...` passes.

## Notes / nuances

- `go test -race ./internal/runner/...` flags a **pre-existing** race in `TestRunner_Restart` (also reproduces on `main` without this PR's changes). It is unrelated to issue #130 and out of scope here per the minimal-change rule. Filed as a separate concern for the runner package.
- The stdin-scanner goroutine in `runDev` cannot be cleanly stopped — that's intrinsic to `bufio.Scanner` on stdin. Acceptable because it dies with the process when stdin closes.
- `rsCh` capacity is 1 with a non-blocking send; this matches user intuition that repeated presses while a restart is mid-flight should coalesce, not queue.