### PR TITLE
fix(dev): prevent orphan child spawn during shutdown race (#129)

### DIFF
--- a/cmd/tsgonest/dev.go
+++ b/cmd/tsgonest/dev.go
@@ -266,7 +266,13 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal) devLoopResult {
 		}
 	}
 
-	// Ensure child cleanup on return (covers both exit and restart paths)
+	// Ensure child cleanup on return (covers both exit and restart paths).
+	// Defer registration order matters here — defers run LIFO, so the order is:
+	//   1. close(done) — signals helper goroutines to begin shutdown
+	//   2. wg.Wait()   — joins the rebuild goroutine before we touch proc
+	//   3. proc.Stop() — only after the rebuild goroutine has exited, so it
+	//      cannot race with us by calling proc.Restart() after Stop.
+	// Registering proc.Stop first means it runs last.
 	defer func() {
 		if proc != nil {
 			proc.Stop()
@@ -295,7 +301,12 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal) devLoopResult {
 	}
 
 	// done is closed when runDevLoop returns, so helper goroutines can exit cleanly.
+	// wg tracks the rebuild goroutine so we can join it before proc.Stop runs;
+	// otherwise an in-flight rebuild can complete and call proc.Restart() after
+	// Stop, spawning an orphan child.
 	done := make(chan struct{})
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	defer close(done)
 
 	// Channel-based rebuild loop: the watcher pushes debounced event batches
@@ -318,77 +329,25 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal) devLoopResult {
 		},
 	)
 
-	// Rebuild loop goroutine.
-	// Strategy: build after each debounced batch, then check whether more
-	// changes arrived during the build.  If so, DON'T restart — loop back
-	// and wait for the next debounced batch so the full "calm period" passes
-	// before the final build + restart.  This prevents the race where rapid
-	// multi-file saves cause a premature restart with a half-written dist/.
+	// Rebuild loop goroutine. See rebuildLoop for the build/restart strategy.
+	var procIface rebuildRestarter
+	if proc != nil {
+		procIface = proc
+	}
+	wg.Add(1)
 	go func() {
-		for {
-			select {
-			case events := <-changeCh:
-				if !flags.preserveWatchOutput {
-					fmt.Fprint(os.Stderr, "\033[2J\033[H")
-				}
-
-				printStatus(os.Stderr, pretty, "◆", "detected %d change(s), rebuilding...", len(events))
-
-				if flags.verbose {
-					for _, ev := range events {
-						fmt.Fprintf(os.Stderr, "  [%s] %s\n", ev.Op, ev.Path)
-					}
-				}
-
-				// Fast path: single file changed with no deletes/creates — use UpdateProgram
-				// which skips re-reading/re-parsing all other source files.
-				var result int
-				if len(events) == 1 && events[0].Op == "write" {
-					result = builder.BuildSingleFile(events[0].Path)
-				} else {
-					result = builder.Build()
-				}
-
-				// Check whether more changes are in-flight: either already
-				// flushed to the channel, or still in the watcher's debounce
-				// buffer.  If so, skip the restart and loop back — the next
-				// debounced batch will trigger another build once things settle.
-				changedDuringBuild := false
-			drainLoop:
-				for {
-					select {
-					case <-changeCh:
-						changedDuringBuild = true
-					default:
-						break drainLoop
-					}
-				}
-				if w.Pending() {
-					changedDuringBuild = true
-				}
-
-				if changedDuringBuild {
-					printStatus(os.Stderr, pretty, "↻", "changes detected during build, debouncing...")
-					continue
-				}
-
-				if result != 0 {
-					printStatus(os.Stderr, pretty, "✗", "build failed, watching for changes...")
-				} else if proc != nil {
-					printStatus(os.Stderr, pretty, "▶", "restarting...")
-					if err := proc.Restart(); err != nil {
-						fmt.Fprintf(os.Stderr, "error restarting: %v\n", err)
-					}
-				}
-
-				if manualRestart {
-					fmt.Fprintln(os.Stderr, "To restart at any time, enter \"rs\".")
-				}
-
-			case <-done:
-				return
-			}
-		}
+		defer wg.Done()
+		rebuildLoop(rebuildLoopDeps{
+			changeCh:            changeCh,
+			done:                done,
+			builder:             builder,
+			proc:                procIface,
+			pending:             w.Pending,
+			pretty:              pretty,
+			verbose:             flags.verbose,
+			preserveWatchOutput: flags.preserveWatchOutput,
+			manualRestart:       manualRestart,
+		})
 	}()
 
 	// Watch config files for changes. When tsconfig.json or tsgonest.config
@@ -493,6 +452,109 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal) devLoopResult {
 		fmt.Fprintf(os.Stderr, "watcher error: %v\n", watchErr)
 	}
 	return devLoopExit
+}
+
+// rebuildBuilder is the subset of devBuilder used by rebuildLoop. Defined as
+// an interface so tests can substitute a fake builder without touching tsgo.
+type rebuildBuilder interface {
+	Build() int
+	BuildSingleFile(path string) int
+}
+
+// rebuildRestarter is the subset of *runner.Runner used by rebuildLoop.
+// Restart() must NOT be called after the dev loop has signalled shutdown
+// (see rebuildLoop), because runner.Runner.Restart clears its internal
+// "stopped" flag and would spawn a fresh child after the dev loop's
+// deferred Stop has run, leaking an orphan process.
+type rebuildRestarter interface {
+	Restart() error
+}
+
+// rebuildLoopDeps bundles the inputs to rebuildLoop. It exists to keep the
+// long parameter list manageable and to give tests a single struct to fill in.
+type rebuildLoopDeps struct {
+	changeCh            <-chan []watcher.Event
+	done                <-chan struct{}
+	builder             rebuildBuilder
+	proc                rebuildRestarter
+	pending             func() bool
+	pretty              bool
+	verbose             bool
+	preserveWatchOutput bool
+	manualRestart       bool
+}
+
+// rebuildLoop is the body of the dev rebuild goroutine. After each debounced
+// batch it builds, then drains any changes that arrived during the build. If
+// nothing else is pending it restarts the child process. Crucially it checks
+// d.done immediately before calling proc.Restart() — without that check, an
+// in-flight build could complete after the dev loop began shutting down and
+// spawn a fresh child after proc.Stop, leaking an orphan.
+func rebuildLoop(d rebuildLoopDeps) {
+	for {
+		select {
+		case events := <-d.changeCh:
+			if !d.preserveWatchOutput {
+				fmt.Fprint(os.Stderr, "\033[2J\033[H")
+			}
+
+			printStatus(os.Stderr, d.pretty, "◆", "detected %d change(s), rebuilding...", len(events))
+
+			if d.verbose {
+				for _, ev := range events {
+					fmt.Fprintf(os.Stderr, "  [%s] %s\n", ev.Op, ev.Path)
+				}
+			}
+
+			var result int
+			if len(events) == 1 && events[0].Op == "write" {
+				result = d.builder.BuildSingleFile(events[0].Path)
+			} else {
+				result = d.builder.Build()
+			}
+
+			changedDuringBuild := false
+		drainLoop:
+			for {
+				select {
+				case <-d.changeCh:
+					changedDuringBuild = true
+				default:
+					break drainLoop
+				}
+			}
+			if d.pending != nil && d.pending() {
+				changedDuringBuild = true
+			}
+
+			if changedDuringBuild {
+				printStatus(os.Stderr, d.pretty, "↻", "changes detected during build, debouncing...")
+				continue
+			}
+
+			select {
+			case <-d.done:
+				return
+			default:
+			}
+
+			if result != 0 {
+				printStatus(os.Stderr, d.pretty, "✗", "build failed, watching for changes...")
+			} else if d.proc != nil {
+				printStatus(os.Stderr, d.pretty, "▶", "restarting...")
+				if err := d.proc.Restart(); err != nil {
+					fmt.Fprintf(os.Stderr, "error restarting: %v\n", err)
+				}
+			}
+
+			if d.manualRestart {
+				fmt.Fprintln(os.Stderr, "To restart at any time, enter \"rs\".")
+			}
+
+		case <-d.done:
+			return
+		}
+	}
 }
 
 // resolveRuntime determines the runtime to use.

--- a/cmd/tsgonest/dev_known_issues_test.go
+++ b/cmd/tsgonest/dev_known_issues_test.go
@@ -12,29 +12,190 @@ package main
 import (
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/tsgonest/tsgonest/internal/watcher"
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
-// A. Defer-order can spawn an orphan child after Stop()
+// A. Defer-order can spawn an orphan child after Stop()  — FIXED (#129)
 // ─────────────────────────────────────────────────────────────────────────────
 
-// In runDevLoop, the deferred close(done) runs before the deferred proc.Stop()
-// (LIFO order — proc.Stop's defer is registered first at line ~266, close(done)
-// later at line ~295). The rebuild goroutine is not joined. If it's mid-build
-// when runDevLoop returns:
+// fakeBuilder lets us simulate a slow rebuild without invoking tsgo. The
+// build pauses on buildStarted/releaseBuild so the test can interleave a
+// shutdown with an in-flight build.
+type fakeBuilder struct {
+	buildStarted chan struct{}
+	releaseBuild chan struct{}
+	calls        atomic.Int32
+}
+
+func (f *fakeBuilder) Build() int {
+	f.calls.Add(1)
+	if f.buildStarted != nil {
+		select {
+		case f.buildStarted <- struct{}{}:
+		default:
+		}
+	}
+	if f.releaseBuild != nil {
+		<-f.releaseBuild
+	}
+	return 0
+}
+
+func (f *fakeBuilder) BuildSingleFile(_ string) int { return f.Build() }
+
+// fakeRestarter records every Restart() call so the test can assert that
+// no restart happens after shutdown was signalled.
+type fakeRestarter struct {
+	mu       sync.Mutex
+	restarts int
+}
+
+func (f *fakeRestarter) Restart() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.restarts++
+	return nil
+}
+
+func (f *fakeRestarter) Count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.restarts
+}
+
+// TestDevLoop_RebuildGoroutineDoesNotRestartAfterShutdown reproduces the
+// orphan-child race from issue #129 and asserts the fix:
 //
-//  1. close(done) fires — does NOT unblock the goroutine; it's running a build.
-//  2. proc.Stop() fires — kills the current child.
-//  3. Rebuild goroutine completes — sees no `<-done` arm yet (it hasn't reached
-//     the next select). Calls proc.Restart() → proc.Start() → orphan child.
-//  4. runDevLoop returns. The orphan child outlives the dev loop.
-//
-// Fix: track the rebuild goroutine with sync.WaitGroup and Wait() before the
-// proc.Stop() defer runs. Or set an atomic "shutting down" flag that the
-// rebuild goroutine checks before calling proc.Restart().
-func TestDevLoop_RebuildGoroutineCanRestartAfterShutdown_KnownIssue(t *testing.T) {
-	t.Skip("KNOWN ISSUE A: rebuild goroutine isn't joined; can call proc.Restart() after proc.Stop() — orphan node process. Fix in dev.go runDevLoop.")
+//  1. Trigger a rebuild.
+//  2. Wait until the build is mid-flight.
+//  3. Close `done` (simulating runDevLoop's deferred close).
+//  4. Release the build so it completes.
+//  5. The goroutine must NOT call proc.Restart() — its post-build done check
+//     must short-circuit, otherwise a fresh child would be spawned after
+//     proc.Stop has run, leaking an orphan.
+//  6. The goroutine must exit (verified via wg.Wait inside a timeout).
+func TestDevLoop_RebuildGoroutineDoesNotRestartAfterShutdown(t *testing.T) {
+	builder := &fakeBuilder{
+		buildStarted: make(chan struct{}, 1),
+		releaseBuild: make(chan struct{}),
+	}
+	restarter := &fakeRestarter{}
+	changeCh := make(chan []watcher.Event, 1)
+	done := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rebuildLoop(rebuildLoopDeps{
+			changeCh: changeCh,
+			done:     done,
+			builder:  builder,
+			proc:     restarter,
+			pending:  func() bool { return false },
+		})
+	}()
+
+	changeCh <- []watcher.Event{{Path: "src/a.ts", Op: "write"}}
+
+	select {
+	case <-builder.buildStarted:
+	case <-time.After(2 * time.Second):
+		close(done)
+		close(builder.releaseBuild)
+		wg.Wait()
+		t.Fatal("build never started")
+	}
+
+	close(done)
+	close(builder.releaseBuild)
+
+	exited := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(exited)
+	}()
+	select {
+	case <-exited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rebuild goroutine did not exit after done was closed")
+	}
+
+	if got := restarter.Count(); got != 0 {
+		t.Fatalf("proc.Restart() called %d time(s) after shutdown — orphan child would have been spawned", got)
+	}
+}
+
+// TestDevLoop_RebuildGoroutineNoRestartUnderRaceStress hammers the same
+// shutdown race many times. If the done check were removed (or the WaitGroup
+// join missing), some iterations would race between build completion and
+// shutdown and call Restart().
+func TestDevLoop_RebuildGoroutineNoRestartUnderRaceStress(t *testing.T) {
+	const iterations = 50
+
+	for i := 0; i < iterations; i++ {
+		builder := &fakeBuilder{
+			buildStarted: make(chan struct{}, 1),
+			releaseBuild: make(chan struct{}),
+		}
+		restarter := &fakeRestarter{}
+		changeCh := make(chan []watcher.Event, 1)
+		done := make(chan struct{})
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rebuildLoop(rebuildLoopDeps{
+				changeCh: changeCh,
+				done:     done,
+				builder:  builder,
+				proc:     restarter,
+				pending:  func() bool { return false },
+			})
+		}()
+
+		changeCh <- []watcher.Event{{Path: "src/a.ts", Op: "write"}}
+
+		select {
+		case <-builder.buildStarted:
+		case <-time.After(2 * time.Second):
+			close(done)
+			close(builder.releaseBuild)
+			wg.Wait()
+			t.Fatalf("iter %d: build never started", i)
+		}
+
+		// Close done while the build is mid-flight, then release the build
+		// so it finishes and reaches the post-build branch. The goroutine
+		// must observe done and skip proc.Restart(), even though releaseBuild
+		// is closed on the very next instruction. Without a defensive done
+		// check before Restart, the goroutine's prior post-drainLoop state
+		// would race ahead and spawn a fresh child.
+		close(done)
+		close(builder.releaseBuild)
+
+		exited := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(exited)
+		}()
+		select {
+		case <-exited:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("iter %d: rebuild goroutine did not exit", i)
+		}
+
+		if got := restarter.Count(); got != 0 {
+			t.Fatalf("iter %d: proc.Restart() called %d time(s) after shutdown — orphan-child race regressed", i, got)
+		}
+	}
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #129

## Root cause

`runDevLoop` registered `defer proc.Stop()` BEFORE `defer close(done)`. Defers run LIFO, so on shutdown `close(done)` fired first, then `proc.Stop()`. The rebuild goroutine that listens on `changeCh` was never joined. If it was mid-build when shutdown began:

1. `close(done)` fires — the goroutine is in `builder.Build()`, doesn't see it.
2. `proc.Stop()` fires — kills the current child, sets `stopped=true`.
3. The build completes, the goroutine falls through to the post-drain branch and calls `proc.Restart()`. `Restart()` clears the `stopped` flag and calls `Start()`, spawning a fresh child after Stop has already run.
4. `runDevLoop` returns; the orphan outlives the dev loop.

## Fix

Both pieces of the recommended approach are applied:

- `sync.WaitGroup` joins the rebuild goroutine before `runDevLoop` returns. Defers are reordered so they run as: `close(done)` -> `wg.Wait()` -> `proc.Stop()` (i.e. `proc.Stop` is registered first so it runs last).
- A defensive `select { case <-done: return; default: }` guard sits immediately before `proc.Restart()` so an in-flight build that finishes during teardown short-circuits instead of restarting.

The rebuild goroutine body was extracted into a small `rebuildLoop` helper (with a `rebuildBuilder` and `rebuildRestarter` interface) so it can be exercised directly from tests without standing up tsgo or a real child process.

## Test plan

- [x] `gofmt -w cmd internal` — clean.
- [x] `go test -count=1 ./cmd/tsgonest/... ./internal/runner/...` — pass.
- [x] `go test -race -count=1 ./cmd/tsgonest/...` — pass.
- [x] `go test -race -count=10 -run TestDevLoop_Rebuild ./cmd/tsgonest/...` — pass (stress under race).
- [x] `TestDevLoop_RebuildGoroutineDoesNotRestartAfterShutdown` (renamed from the `_KnownIssue` doc-test, assertion flipped to a hard check that `proc.Restart` is NEVER called after `done` is closed).
- [x] `TestDevLoop_RebuildGoroutineNoRestartUnderRaceStress` — 50 iterations of: trigger rebuild, close `done` mid-build, release the build, assert no restart and goroutine exits.

### Pre-existing, out of scope

`go test -race ./internal/runner/...` flags a data race in `Runner.Running()` reading `cmd.ProcessState` while the `cmd.Wait()` goroutine writes to it. This is the documented `TestRunner_Running_DataRace_KnownIssue` ("KNOWN ISSUE G") on `main` and is unrelated to #129. My change neither introduces nor depends on that race; without `-race` the runner tests are green.