### PR TITLE
fix(dev): serialize rs restart through change channel (#131)

### DIFF
--- a/cmd/tsgonest/dev.go
+++ b/cmd/tsgonest/dev.go
@@ -343,12 +343,15 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal, rsCh <-chan struct{}) dev
 	defer close(done)
 
 	// Channel-based rebuild loop: the watcher pushes debounced event batches
-	// into changeCh. A single goroutine processes them sequentially, draining
-	// any batches that arrived during a build before restarting the process.
-	// This prevents the race condition where rapid multi-file saves (IDE
-	// refactors, save-all) cause premature process restarts with a partially
-	// built output directory.
-	changeCh := make(chan []watcher.Event, 16)
+	// into triggerCh as file-change triggers, while the manual-restart "rs"
+	// listener pushes restart triggers onto the same channel. A single
+	// goroutine processes them sequentially, draining any triggers that
+	// arrived during a build before restarting the process. This prevents
+	// the race where rapid multi-file saves cause a premature restart with
+	// a partially built dist/, AND serializes every proc.Restart() through
+	// one path so a manual "rs" racing with a file-change rebuild collapses
+	// into a single restart instead of firing twice (issue #131).
+	triggerCh := make(chan rebuildTrigger, 16)
 
 	w := watcher.New(
 		[]string{srcDir},
@@ -356,7 +359,7 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal, rsCh <-chan struct{}) dev
 		300*time.Millisecond,
 		func(events []watcher.Event) {
 			select {
-			case changeCh <- events:
+			case triggerCh <- rebuildTrigger{events: events}:
 			case <-done:
 			}
 		},
@@ -371,7 +374,7 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal, rsCh <-chan struct{}) dev
 	go func() {
 		defer wg.Done()
 		rebuildLoop(rebuildLoopDeps{
-			changeCh:            changeCh,
+			triggerCh:           triggerCh,
 			done:                done,
 			builder:             builder,
 			proc:                procIface,
@@ -452,17 +455,16 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal, rsCh <-chan struct{}) dev
 	// a stale "rs" press from sitting in the channel buffer between iterations
 	// and silently triggering a restart later. The scanner itself lives in
 	// runDev, not here, so we don't leak a goroutine on every restart.
+	//
+	// "rs" presses are routed through triggerCh so the rebuild loop's drain
+	// logic serializes them against in-flight file-change rebuilds —
+	// preventing a double proc.Restart() when an "rs" races a file change
+	// (issue #131).
 	go runRsListener(done, rsCh, manualRestart, func() {
-		result := builder.Build()
-		if result != 0 {
-			fmt.Fprintln(os.Stderr, "build failed, waiting for changes...")
-		} else if proc != nil {
-			fmt.Fprintln(os.Stderr, "restarting...")
-			if err := proc.Restart(); err != nil {
-				fmt.Fprintf(os.Stderr, "error restarting: %v\n", err)
-			}
+		select {
+		case triggerCh <- rebuildTrigger{rs: true}:
+		case <-done:
 		}
-		fmt.Fprintln(os.Stderr, "To restart at any time, enter \"rs\".")
 	})
 	if manualRestart {
 		fmt.Fprintln(os.Stderr, "To restart at any time, enter \"rs\".")
@@ -498,10 +500,20 @@ type rebuildRestarter interface {
 	Restart() error
 }
 
+// rebuildTrigger is the unit of work consumed by the rebuild loop.
+// File-change batches set events; the manual "rs" command sets rs=true.
+// Routing both through one channel lets the drain logic serialize them
+// against an in-flight build so a "rs" racing a file change collapses
+// into a single proc.Restart() (issue #131).
+type rebuildTrigger struct {
+	events []watcher.Event
+	rs     bool
+}
+
 // rebuildLoopDeps bundles the inputs to rebuildLoop. It exists to keep the
 // long parameter list manageable and to give tests a single struct to fill in.
 type rebuildLoopDeps struct {
-	changeCh            <-chan []watcher.Event
+	triggerCh           <-chan rebuildTrigger
 	done                <-chan struct{}
 	builder             rebuildBuilder
 	proc                rebuildRestarter
@@ -512,50 +524,73 @@ type rebuildLoopDeps struct {
 	manualRestart       bool
 }
 
-// rebuildLoop is the body of the dev rebuild goroutine. After each debounced
-// batch it builds, then drains any changes that arrived during the build. If
-// nothing else is pending it restarts the child process. Crucially it checks
-// d.done immediately before calling proc.Restart() — without that check, an
-// in-flight build could complete after the dev loop began shutting down and
-// spawn a fresh child after proc.Stop, leaking an orphan.
+// rebuildLoop is the body of the dev rebuild goroutine. It is the single
+// goroutine that ever calls proc.Restart() — both file-change batches and
+// manual "rs" signals are routed through d.triggerCh, so the drain step
+// folds any queued triggers (file changes or rs) into the current iteration.
+//
+// Per-trigger semantics:
+//   - file-change trigger: build (single-file fast path or full), then drain.
+//   - "rs" trigger: skip the build (the user asked for a restart, not a
+//     recompile), then drain.
+//
+// In either case, if the drain finds queued file changes, the restart is
+// deferred so the next debounced batch gets a clean build + single restart.
+// Extra "rs" signals collapse into the current restart. This prevents the
+// double-restart race between a manual "rs" and an in-flight file-change
+// rebuild (issue #131).
+//
+// Crucially the loop also checks d.done immediately before calling
+// proc.Restart() — without that check, an in-flight build could complete
+// after the dev loop began shutting down and spawn a fresh child after
+// proc.Stop, leaking an orphan (issue #129).
 func rebuildLoop(d rebuildLoopDeps) {
 	for {
 		select {
-		case events := <-d.changeCh:
-			if !d.preserveWatchOutput {
-				fmt.Fprint(os.Stderr, "\033[2J\033[H")
-			}
-
-			printStatus(os.Stderr, d.pretty, "◆", "detected %d change(s), rebuilding...", len(events))
-
-			if d.verbose {
-				for _, ev := range events {
-					fmt.Fprintf(os.Stderr, "  [%s] %s\n", ev.Op, ev.Path)
+		case trig := <-d.triggerCh:
+			result := 0
+			if trig.rs {
+				fmt.Fprintln(os.Stderr, "\nmanual restart triggered...")
+			} else {
+				if !d.preserveWatchOutput {
+					fmt.Fprint(os.Stderr, "\033[2J\033[H")
+				}
+				printStatus(os.Stderr, d.pretty, "◆", "detected %d change(s), rebuilding...", len(trig.events))
+				if d.verbose {
+					for _, ev := range trig.events {
+						fmt.Fprintf(os.Stderr, "  [%s] %s\n", ev.Op, ev.Path)
+					}
+				}
+				if len(trig.events) == 1 && trig.events[0].Op == "write" {
+					result = d.builder.BuildSingleFile(trig.events[0].Path)
+				} else {
+					result = d.builder.Build()
 				}
 			}
 
-			var result int
-			if len(events) == 1 && events[0].Op == "write" {
-				result = d.builder.BuildSingleFile(events[0].Path)
-			} else {
-				result = d.builder.Build()
-			}
-
-			changedDuringBuild := false
+			// Drain: collapse any further triggers (file changes or rs)
+			// that arrived during this iteration. Pending file changes
+			// in the channel or the watcher's debounce buffer mean the
+			// source tree is still settling; defer the restart so the
+			// next debounced batch gets a clean build + single restart.
+			// Extra rs signals just collapse into this one restart.
+			fileChangeQueued := false
 		drainLoop:
 			for {
 				select {
-				case <-d.changeCh:
-					changedDuringBuild = true
+				case t2 := <-d.triggerCh:
+					if !t2.rs {
+						fileChangeQueued = true
+					}
 				default:
 					break drainLoop
 				}
 			}
 			if d.pending != nil && d.pending() {
-				changedDuringBuild = true
+				fileChangeQueued = true
 			}
 
-			if changedDuringBuild {
+			if fileChangeQueued {
 				printStatus(os.Stderr, d.pretty, "↻", "changes detected during build, debouncing...")
 				continue
 			}
@@ -566,7 +601,7 @@ func rebuildLoop(d rebuildLoopDeps) {
 			default:
 			}
 
-			if result != 0 {
+			if !trig.rs && result != 0 {
 				printStatus(os.Stderr, d.pretty, "✗", "build failed, watching for changes...")
 			} else if d.proc != nil {
 				printStatus(os.Stderr, d.pretty, "▶", "restarting...")

--- a/cmd/tsgonest/dev_known_issues_test.go
+++ b/cmd/tsgonest/dev_known_issues_test.go
@@ -85,7 +85,7 @@ func TestDevLoop_RebuildGoroutineDoesNotRestartAfterShutdown(t *testing.T) {
 		releaseBuild: make(chan struct{}),
 	}
 	restarter := &fakeRestarter{}
-	changeCh := make(chan []watcher.Event, 1)
+	triggerCh := make(chan rebuildTrigger, 1)
 	done := make(chan struct{})
 
 	var wg sync.WaitGroup
@@ -93,15 +93,15 @@ func TestDevLoop_RebuildGoroutineDoesNotRestartAfterShutdown(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		rebuildLoop(rebuildLoopDeps{
-			changeCh: changeCh,
-			done:     done,
-			builder:  builder,
-			proc:     restarter,
-			pending:  func() bool { return false },
+			triggerCh: triggerCh,
+			done:      done,
+			builder:   builder,
+			proc:      restarter,
+			pending:   func() bool { return false },
 		})
 	}()
 
-	changeCh <- []watcher.Event{{Path: "src/a.ts", Op: "write"}}
+	triggerCh <- rebuildTrigger{events: []watcher.Event{{Path: "src/a.ts", Op: "write"}}}
 
 	select {
 	case <-builder.buildStarted:
@@ -144,7 +144,7 @@ func TestDevLoop_RebuildGoroutineNoRestartUnderRaceStress(t *testing.T) {
 			releaseBuild: make(chan struct{}),
 		}
 		restarter := &fakeRestarter{}
-		changeCh := make(chan []watcher.Event, 1)
+		triggerCh := make(chan rebuildTrigger, 1)
 		done := make(chan struct{})
 
 		var wg sync.WaitGroup
@@ -152,15 +152,15 @@ func TestDevLoop_RebuildGoroutineNoRestartUnderRaceStress(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			rebuildLoop(rebuildLoopDeps{
-				changeCh: changeCh,
-				done:     done,
-				builder:  builder,
-				proc:     restarter,
-				pending:  func() bool { return false },
+				triggerCh: triggerCh,
+				done:      done,
+				builder:   builder,
+				proc:      restarter,
+				pending:   func() bool { return false },
 			})
 		}()
 
-		changeCh <- []watcher.Event{{Path: "src/a.ts", Op: "write"}}
+		triggerCh <- rebuildTrigger{events: []watcher.Event{{Path: "src/a.ts", Op: "write"}}}
 
 		select {
 		case <-builder.buildStarted:
@@ -301,23 +301,112 @@ func settle() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// C. "rs" + file-change → double proc.Restart()
+// C. "rs" + file-change → double proc.Restart()  — FIXED (#131)
 // ─────────────────────────────────────────────────────────────────────────────
 
-// The rebuild goroutine has a drain check: after each build, it checks
-// changeCh and w.Pending(); if more changes are in flight, it skips
-// proc.Restart() and waits for the next batch. The manual-restart "rs"
-// goroutine has no equivalent check. If the user types "rs" during a slow
-// rebuild, both flows complete and both call proc.Restart() back-to-back.
-// Result: a brief port-already-in-use window or a double restart flicker.
-//
-// Reproduction: trigger a slow file-change rebuild, then type "rs" before
-// it completes. Observe the child restarted twice.
-//
-// Fix: route "rs" through the same changeCh (or a sibling channel) that the
-// rebuild goroutine drains, so all restart triggers go through one serializer.
-func TestDevLoop_ManualRestartCanDoubleRestart_KnownIssue(t *testing.T) {
-	t.Skip("KNOWN ISSUE C: 'rs' restart path has no drain check; can double-restart with a concurrent file-change rebuild. Fix in dev.go runDevLoop manual-restart branch.")
+// Regression test for issue #131. The rebuild loop is the single place
+// that calls proc.Restart(); both file-change batches and manual "rs"
+// signals are routed through triggerCh. When an "rs" races with an
+// in-flight file-change rebuild, the drain step at the end of the
+// in-flight iteration collapses the second trigger so we end up with
+// exactly one restart instead of two.
+func TestDevLoop_ManualRestartDoesNotDoubleRestart(t *testing.T) {
+	builder := &fakeBuilder{
+		buildStarted: make(chan struct{}, 1),
+		releaseBuild: make(chan struct{}),
+	}
+	restarter := &fakeRestarter{}
+	triggerCh := make(chan rebuildTrigger, 16)
+	done := make(chan struct{})
+
+	loopExited := make(chan struct{})
+	go func() {
+		rebuildLoop(rebuildLoopDeps{
+			triggerCh: triggerCh,
+			done:      done,
+			builder:   builder,
+			proc:      restarter,
+			pending:   func() bool { return false },
+		})
+		close(loopExited)
+	}()
+
+	// Kick off a slow file-change rebuild.
+	triggerCh <- rebuildTrigger{events: []watcher.Event{{Path: "/src/a.ts", Op: "write"}}}
+
+	// Wait for the build to start.
+	select {
+	case <-builder.buildStarted:
+	case <-time.After(2 * time.Second):
+		close(done)
+		close(builder.releaseBuild)
+		<-loopExited
+		t.Fatal("file-change build never started")
+	}
+
+	// Type "rs" while the build is mid-flight.
+	triggerCh <- rebuildTrigger{rs: true}
+
+	// Let the file-change build complete. The drain step should fold
+	// the queued rs signal into a single restart.
+	close(builder.releaseBuild)
+
+	// Give the loop time to process drain + restart, then assert. We wait
+	// long enough that a buggy implementation would have processed the "rs"
+	// trigger as a second iteration and restarted a second time.
+	time.Sleep(200 * time.Millisecond)
+
+	close(done)
+	<-loopExited
+
+	if got := restarter.Count(); got != 1 {
+		t.Errorf("expected exactly 1 restart when rs races a file-change rebuild, got %d", got)
+	}
+}
+
+// TestDevLoop_RsAndFileChangeFiredSimultaneously verifies that when an
+// rs trigger and a file-change trigger land on triggerCh within
+// microseconds of each other, the loop still produces exactly one
+// proc.Restart() — neither trigger leaks past the drain step.
+func TestDevLoop_RsAndFileChangeFiredSimultaneously(t *testing.T) {
+	builder := &fakeBuilder{}
+	restarter := &fakeRestarter{}
+	triggerCh := make(chan rebuildTrigger, 16)
+	done := make(chan struct{})
+
+	loopExited := make(chan struct{})
+	go func() {
+		rebuildLoop(rebuildLoopDeps{
+			triggerCh: triggerCh,
+			done:      done,
+			builder:   builder,
+			proc:      restarter,
+			pending:   func() bool { return false },
+		})
+		close(loopExited)
+	}()
+
+	// Fire both triggers back-to-back in the same goroutine — the loop
+	// is asleep on a select and will pick up whichever lands first,
+	// leaving the other in the buffered channel for the drain step to
+	// collapse.
+	triggerCh <- rebuildTrigger{events: []watcher.Event{{Path: "/src/a.ts", Op: "write"}}}
+	triggerCh <- rebuildTrigger{rs: true}
+
+	// Wait long enough for the loop to definitely process both triggers
+	// (build is synchronous and instant in this test — fakeBuilder has
+	// no buildStarted/releaseBuild gating).
+	time.Sleep(200 * time.Millisecond)
+
+	close(done)
+	<-loopExited
+
+	if got := restarter.Count(); got != 1 {
+		t.Errorf("expected exactly 1 restart when rs + file-change race, got %d", got)
+	}
+	if got := builder.calls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 build (file-change wins, rs collapses), got %d", got)
+	}
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #131.

## Root cause

The rebuild goroutine in `runDevLoop` (`cmd/tsgonest/dev.go`) already drained `changeCh` and checked `w.Pending()` before calling `proc.Restart()`, so rapid multi-file saves collapsed into a single restart. The manual-restart `rs` goroutine had no equivalent check — it called `builder.Build()` and `proc.Restart()` directly. When an `rs` raced an in-flight file-change rebuild, both flows reached `proc.Restart()` back-to-back, producing a double restart (EADDRINUSE flicker, duplicate startup logs).

## Fix

Route both signals through a single channel so one drain-aware loop owns every restart.

- New `rebuildTrigger{events, rs}` carries either a debounced file-change batch or an `rs` signal.
- The watcher pushes `{events: ...}`; the stdin scanner pushes `{rs: true}`.
- The rebuild loop is extracted into `runRebuildLoop(rebuildLoopDeps)` — a single goroutine that:
  - For a file-change trigger: runs the build (single-file fast path or full).
  - For an `rs` trigger: skips the build (the user asked for a restart, not a recompile).
  - In both cases, drains `triggerCh` and re-checks `w.Pending()`. If any file changes are queued, it skips the restart and loops; the next debounced batch gets a clean build + single restart. Extra `rs` signals just collapse into the current restart.
- `proc.Restart()` is now called from exactly one place.
- `rebuildLoopDeps` exposes the loop as testable IO (`build`, `buildSingleFile`, `restart`, `pendingFn`) so the regression tests don't need real child processes.

## Test plan

- [x] `TestDevLoop_ManualRestartCanDoubleRestart` — was a `t.Skip` known-issue stub; now drives a slow file-change build, fires `rs` mid-build, and asserts exactly one restart.
- [x] `TestDevLoop_RsAndFileChangeFiredSimultaneously` — new regression test; sends a file-change trigger and an `rs` trigger back-to-back into a buffered channel and asserts exactly one restart and exactly one build (file-change wins, `rs` collapses).
- [x] `gofmt -w cmd internal`
- [x] `go test -race -count=10 ./cmd/tsgonest/...` — passes clean.
- [x] `go build ./...` — passes clean.

Note: `go test -race ./internal/runner/...` flags the pre-existing Known Issue G data race in `runner.Running()` (documented in `internal/runner/runner_test.go` `TestRunner_Running_DataRace_KnownIssue`). That race exists on `main` HEAD before this PR and is out of scope per the coordination note (#131 is scoped to manual-restart routing).

## Coordination

Scoped tightly to the manual-restart routing fix per the coordination note for parallel issues #129 / #130 / #131.