### PR TITLE
fix(watcher): surface error when watch root is renamed (#132)

### DIFF
--- a/cmd/tsgonest/dev.go
+++ b/cmd/tsgonest/dev.go
@@ -482,10 +482,15 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal) devLoopResult {
 	}
 
 	printStatus(os.Stderr, pretty, "◇", "watching for changes...")
-	w.Watch()
+	watchErr := w.Watch()
 
 	if restartRequested.Load() {
 		return devLoopRestart
+	}
+	if gone, ok := watchErr.(*watcher.ErrWatchRootGone); ok {
+		printStatus(os.Stderr, pretty, "✗", "watched directory %q was renamed or removed; please restart `tsgonest dev`", gone.Path)
+	} else if watchErr != nil {
+		fmt.Fprintf(os.Stderr, "watcher error: %v\n", watchErr)
 	}
 	return devLoopExit
 }

--- a/internal/watcher/edge_cases_test.go
+++ b/internal/watcher/edge_cases_test.go
@@ -12,6 +12,7 @@ package watcher
 // behavior. When a fix lands, these tests should be flipped to assert correctness.
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -52,17 +53,13 @@ func drainEvents(ch <-chan []Event, timeout time.Duration) []Event {
 // D. Watched-root rename
 // ─────────────────────────────────────────────────────────────────────────────
 
-// TestWatch_RootRename_SilentlyStopsEvents_KnownIssue documents that renaming
-// the watched root makes fsnotify silently drop events. There is no logic in
-// addPending or watchFsnotify to re-add the root or surface an error to the
-// caller. A `tsgonest dev` user who runs `mv src src.bak && mv staging src`
-// gets no rebuilds until restart.
-//
-// Expected fix: detect Remove/Rename on a watched root (or any directory we
-// added recursively), then either (a) print a clear error and bail out of the
-// fsnotify loop so the caller can retry, or (b) re-walk and re-add the root
-// when the new path appears.
-func TestWatch_RootRename_SilentlyStopsEvents_KnownIssue(t *testing.T) {
+// TestWatch_RootRename_SurfacesError verifies that when the watched root is
+// renamed out from under the watcher, Watch returns an *ErrWatchRootGone
+// instead of silently going deaf. Before the fix, fsnotify dropped events
+// without any signal: macOS (kqueue) stopped delivering events, Linux
+// (inotify) auto-removed the watch — either way `tsgonest dev` appeared to
+// keep running but never rebuilt again.
+func TestWatch_RootRename_SurfacesError(t *testing.T) {
 	parent := t.TempDir()
 	src := filepath.Join(parent, "src")
 	if err := os.Mkdir(src, 0755); err != nil {
@@ -74,7 +71,9 @@ func TestWatch_RootRename_SilentlyStopsEvents_KnownIssue(t *testing.T) {
 	w := New([]string{src}, []string{".ts"}, 50*time.Millisecond, func(events []Event) {
 		got <- events
 	})
-	go w.Watch()
+
+	watchErr := make(chan error, 1)
+	go func() { watchErr <- w.Watch() }()
 	defer w.Stop()
 	time.Sleep(200 * time.Millisecond)
 
@@ -93,26 +92,55 @@ func TestWatch_RootRename_SilentlyStopsEvents_KnownIssue(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Now create the original path again and write a file inside.
+	select {
+	case err := <-watchErr:
+		var gone *ErrWatchRootGone
+		if !errors.As(err, &gone) {
+			t.Fatalf("expected *ErrWatchRootGone, got %T: %v", err, err)
+		}
+		if gone.Path == "" {
+			t.Errorf("ErrWatchRootGone.Path is empty")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Watch did not return ErrWatchRootGone within 3s after the watched root was renamed")
+	}
+}
+
+// TestWatch_RootRemove_SurfacesError verifies that removing (rmdir) the
+// watched root is also detected and surfaces the same ErrWatchRootGone
+// instead of silently dropping events. Same root-cause as the rename case
+// — both Remove and Rename fsnotify ops on a watch root must terminate
+// the watch loop with a clear error.
+func TestWatch_RootRemove_SurfacesError(t *testing.T) {
+	parent := t.TempDir()
+	src := filepath.Join(parent, "src")
 	if err := os.Mkdir(src, 0755); err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(filepath.Join(src, "app.ts"), []byte("const a = 3;"), 0644)
 
-	// Drain anything that arrives in the next second.
-	events := drainEvents(got, 1*time.Second)
+	got := make(chan []Event, 16)
+	w := New([]string{src}, []string{".ts"}, 50*time.Millisecond, func(events []Event) {
+		got <- events
+	})
 
-	// Today, the watcher does not re-attach to the new src/. We expect zero
-	// post-rename events. When the bug is fixed, this assertion should be
-	// flipped to expect at least one event for the new app.ts.
-	for _, ev := range events {
-		if ev.Path == filepath.Join(src, "app.ts") {
-			t.Logf("FIXED: post-rename write was detected (%v) — flip this assertion", ev)
-			return
-		}
+	watchErr := make(chan error, 1)
+	go func() { watchErr <- w.Watch() }()
+	defer w.Stop()
+	time.Sleep(200 * time.Millisecond)
+
+	if err := os.Remove(src); err != nil {
+		t.Fatal(err)
 	}
-	// Still broken — log so the test is observable but not failing CI.
-	t.Logf("KNOWN ISSUE: %d events received post-rename, none for the recreated app.ts", len(events))
+
+	select {
+	case err := <-watchErr:
+		var gone *ErrWatchRootGone
+		if !errors.As(err, &gone) {
+			t.Fatalf("expected *ErrWatchRootGone, got %T: %v", err, err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Watch did not return ErrWatchRootGone within 3s after the watched root was removed")
+	}
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -76,6 +76,11 @@ func (w *Watcher) Watch() error {
 	if err == nil {
 		return nil
 	}
+	// Don't fall back to polling when a watch root vanished — polling the
+	// missing path would also produce nothing, and the user needs to know.
+	if _, gone := err.(*ErrWatchRootGone); gone {
+		return err
+	}
 	// fsnotify failed — fall back to polling
 	return w.watchPolling()
 }
@@ -90,6 +95,20 @@ func (w *Watcher) Stop() {
 	}
 }
 
+// ErrWatchRootGone is returned by Watch when one of the configured watch
+// roots is renamed or removed while the watcher is running. fsnotify's
+// behavior in this case is platform-dependent and silent: macOS (kqueue)
+// stops delivering events, Linux (inotify) auto-removes the watch. Either
+// way, file changes go undetected from that point on, so we surface a
+// clear error rather than appear to keep working.
+type ErrWatchRootGone struct {
+	Path string
+}
+
+func (e *ErrWatchRootGone) Error() string {
+	return fmt.Sprintf("watch root %q was renamed or removed; restart tsgonest dev", e.Path)
+}
+
 // watchFsnotify uses OS-level file system notifications for near-instant
 // change detection. Returns a non-nil error if setup fails (e.g., watch
 // limit exhausted), in which case the caller should fall back to polling.
@@ -99,6 +118,15 @@ func (w *Watcher) watchFsnotify() error {
 		return err
 	}
 	defer fsw.Close()
+
+	// Capture the watch roots, normalized, so we can detect when one of
+	// them is renamed or removed mid-flight. Symlink-resolved paths are
+	// preferred because fsnotify reports events using the resolved path
+	// on platforms where the watch was added via a symlinked input.
+	roots := make(map[string]string, len(w.dirs))
+	for _, dir := range w.dirs {
+		roots[normalizeWatchPath(dir)] = dir
+	}
 
 	// Recursively add all directories under each watched root.
 	for _, dir := range w.dirs {
@@ -122,6 +150,12 @@ func (w *Watcher) watchFsnotify() error {
 			// Chmod is the sole operation; combined Write|Chmod passes through.
 			if ev.Op == fsnotify.Chmod {
 				continue
+			}
+
+			if ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename) {
+				if rootPath, gone := matchedRoot(roots, ev.Name); gone {
+					return &ErrWatchRootGone{Path: rootPath}
+				}
 			}
 
 			// Skip events from directories that shouldn't be watched
@@ -272,6 +306,29 @@ func fsnotifyOpToString(op fsnotify.Op) string {
 	default:
 		return "write"
 	}
+}
+
+// normalizeWatchPath returns a canonical absolute form of a watch root
+// for comparison against fsnotify event paths. fsnotify reports event
+// paths as they were passed to Add (no symlink resolution), so we only
+// Abs+Clean here — resolving symlinks would make /var/foo (the path the
+// user added on macOS) miss events reported under that same /var/foo.
+func normalizeWatchPath(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(p)
+}
+
+// matchedRoot reports whether eventPath equals one of the registered
+// watch roots, returning the original (unnormalized) root path so error
+// messages reflect what the user passed in.
+func matchedRoot(roots map[string]string, eventPath string) (string, bool) {
+	norm := normalizeWatchPath(eventPath)
+	if orig, ok := roots[norm]; ok {
+		return orig, true
+	}
+	return "", false
 }
 
 // shouldSkipPath returns true if the path contains a directory segment


### PR DESCRIPTION
Fixes #132

## Root cause

`watchFsnotify` adds source-root directories to fsnotify and waits for events, but never reacts to the watched root itself disappearing. When the user renames or removes a watched directory:

- macOS (kqueue) silently stops delivering events.
- Linux (inotify) auto-removes the watch.

Either way, no error surfaces and `tsgonest dev` appears to keep running while never rebuilding again.

## Fix

- Capture watch roots normalized once (Abs+Clean — *not* EvalSymlinks; fsnotify reports paths as they were passed to `Add`, so resolving symlinks makes `/var/foo` mismatch the event-reported `/var/foo` on macOS).
- On every fsnotify `Remove`/`Rename` event, compare the event path against the captured roots; on a match, return a typed `*ErrWatchRootGone` from `watchFsnotify`.
- `Watch()` no longer falls back to polling on this error (polling a missing path would also be silent).
- `runDevLoop` surfaces this case with a clear "watched directory was renamed or removed; please restart `tsgonest dev`" message instead of letting `Watch` silently return.

Scoped: only the root-rename detection path is touched; rebuild/debounce/polling logic is untouched.

## Test plan

- [x] `TestWatch_RootRename_SilentlyStopsEvents_KnownIssue` flipped to `TestWatch_RootRename_SurfacesError` — asserts `*ErrWatchRootGone` is returned within 3s after the root is renamed.
- [x] New `TestWatch_RootRemove_SurfacesError` covers `rmdir` of the root.
- [x] `gofmt -w internal cmd`
- [x] `go test -race -count=1 ./internal/watcher/... ./cmd/tsgonest/...` passes.