### PR TITLE
fix(watcher): recover from fsnotify buffer overflow (#137)

### DIFF
--- a/internal/watcher/edge_cases_test.go
+++ b/internal/watcher/edge_cases_test.go
@@ -565,6 +565,193 @@ func TestShouldSkipPath_CaseInsensitive(t *testing.T) {
 // Stress: many concurrent file events
 // ─────────────────────────────────────────────────────────────────────────────
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Overflow recovery (Issue #137)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestIsOverflowError_RecognizesKernelSignals locks in the detection contract
+// across all backends so a backend swap or fsnotify upgrade can't silently
+// make the watcher stop recovering from bursts.
+func TestIsOverflowError_RecognizesKernelSignals(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", fmt.Errorf("permission denied"), false},
+		{"fsnotify sentinel", fmtErrf("%w", fsnotifyOverflowSentinel()), true},
+		{"enospc wrapped", fmtErrf("inotify: %w", syscallENOSPC()), true},
+		{"windows-style string", fmt.Errorf("ReadDirectoryChangesW: notify_enum_dir overflow"), true},
+		{"raw 1022 string", fmt.Errorf("system call returned error 1022"), true},
+		{"buffer overflow string", fmt.Errorf("queue or buffer overflow"), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isOverflowError(c.err); got != c.want {
+				t.Errorf("isOverflowError(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// TestWatch_OverflowRecovery_SynthesizesMissedEvents primes the snapshot,
+// mutates files OUT-OF-BAND so fsnotify never sees them (no time.Sleep race —
+// we touch files after priming and call the recovery path directly), then
+// asserts the recovery synthesizes write/create/remove events for every change.
+func TestWatch_OverflowRecovery_SynthesizesMissedEvents(t *testing.T) {
+	dir := t.TempDir()
+	// buildSnapshot resolves the watch root through EvalSymlinks (e.g. /var ->
+	// /private/var on macOS), so events arrive keyed on the resolved path.
+	// Resolve here too so the assertions match.
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	keep := filepath.Join(dir, "keep.ts")
+	mutate := filepath.Join(dir, "mutate.ts")
+	gone := filepath.Join(dir, "gone.ts")
+
+	if err := os.WriteFile(keep, []byte("export const k=1;"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mutate, []byte("export const m=1;"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(gone, []byte("export const g=1;"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(chan []Event, 16)
+	w := New([]string{dir}, []string{".ts"}, 30*time.Millisecond, func(events []Event) {
+		got <- events
+	})
+	w.primeSnapshotForTest()
+
+	// Mutate out-of-band: rewrite mutate.ts (size + mtime change), create new.ts,
+	// remove gone.ts. None of these go through fsnotify because Watch() isn't running.
+	time.Sleep(20 * time.Millisecond)
+	if err := os.WriteFile(mutate, []byte("export const m=42;"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	created := filepath.Join(dir, "new.ts")
+	if err := os.WriteFile(created, []byte("export const n=1;"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(gone); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger the same recovery path the overflow error branch would.
+	if w.triggerOverflowForTest() {
+		t.Fatalf("single overflow recovery shouldn't trigger fallback")
+	}
+	if w.overflowFailuresForTest() != 0 {
+		t.Errorf("expected failures=0 after clean recovery, got %d", w.overflowFailuresForTest())
+	}
+
+	events := drainEvents(got, 500*time.Millisecond)
+
+	byPath := map[string]string{}
+	for _, ev := range events {
+		byPath[ev.Path] = ev.Op
+	}
+	if op := byPath[mutate]; op != "write" {
+		t.Errorf("expected write event for mutated file, got %q (all=%v)", op, events)
+	}
+	if op := byPath[created]; op != "create" {
+		t.Errorf("expected create event for new file, got %q (all=%v)", op, events)
+	}
+	if op := byPath[gone]; op != "remove" {
+		t.Errorf("expected remove event for deleted file, got %q (all=%v)", op, events)
+	}
+	if _, present := byPath[keep]; present {
+		t.Errorf("did not expect any event for unchanged file, got %q", byPath[keep])
+	}
+}
+
+// TestWatch_OverflowFallback_SwitchesToPolling forces two consecutive failed
+// recoveries and asserts (a) the failure counter increments, (b) the watcher
+// flips into polling mode, and (c) Watch() is now serviced by the polling
+// backend (it picks up a fresh write).
+func TestWatch_OverflowFallback_SwitchesToPolling(t *testing.T) {
+	dir := t.TempDir()
+	// Match buildSnapshot's EvalSymlinks resolution so polling event paths
+	// compare equal to our expected target path.
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	if err := os.WriteFile(filepath.Join(dir, "seed.ts"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(chan []Event, 16)
+	w := New([]string{dir}, []string{".ts"}, 30*time.Millisecond, func(events []Event) {
+		got <- events
+	})
+	w.SetPollInterval(50 * time.Millisecond)
+	w.primeSnapshotForTest()
+
+	// Force every recovery attempt to look like it failed even though the
+	// re-walk itself succeeded.
+	recoverHook = func() bool { return true }
+	t.Cleanup(func() { recoverHook = nil })
+
+	if w.triggerOverflowForTest() {
+		t.Fatalf("first failure should not trigger fallback (need %d)", maxOverflowFailures)
+	}
+	if got := w.overflowFailuresForTest(); got != 1 {
+		t.Fatalf("after 1 failed recovery, expected failures=1, got %d", got)
+	}
+	if w.fallbackTriggeredForTest() {
+		t.Fatalf("fallback flag set too early")
+	}
+
+	if !w.triggerOverflowForTest() {
+		t.Fatalf("second failure should trigger fallback")
+	}
+	if !w.fallbackTriggeredForTest() {
+		t.Fatalf("fallbackToPolling should be true after %d failures", maxOverflowFailures)
+	}
+
+	// Now run the polling backend (the real Watch() would have done this
+	// automatically after watchFsnotify returned). Confirm new writes are
+	// still delivered through the polling path.
+	stopped := make(chan struct{})
+	go func() {
+		_ = w.watchPolling()
+		close(stopped)
+	}()
+	defer func() {
+		w.Stop()
+		<-stopped
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	target := filepath.Join(dir, "after-fallback.ts")
+	if err := os.WriteFile(target, []byte("y"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case events := <-got:
+			for _, ev := range events {
+				if ev.Path == target {
+					return
+				}
+			}
+		case <-deadline:
+			t.Fatal("polling backend did not deliver an event for the post-fallback write")
+		}
+	}
+}
+
+// helpers used only by TestIsOverflowError_RecognizesKernelSignals.
+func fmtErrf(format string, a ...any) error { return fmt.Errorf(format, a...) }
+func fsnotifyOverflowSentinel() error       { return errOverflow }
+func syscallENOSPC() error                  { return errENOSPC }
+
 // TestWatch_BurstWritesNoDataRace runs the watcher under concurrent writes to
 // `go test -race` for a few hundred file events. Catches data races in the
 // shared `pending` slice.

--- a/internal/watcher/overflow_seam_test.go
+++ b/internal/watcher/overflow_seam_test.go
@@ -1,0 +1,61 @@
+package watcher
+
+import (
+	"syscall"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// This file exposes package-internal seams that exist solely for tests in
+// internal/watcher/*_test.go. Nothing here is exported and it must not be
+// called from production code.
+
+var (
+	errOverflow = fsnotify.ErrEventOverflow
+	errENOSPC   = syscall.ENOSPC
+)
+
+// recoverHook lets tests force recoverFromOverflow to report failure even
+// when the underlying re-walk succeeds. When non-nil, its return value
+// replaces the natural recovery outcome.
+var recoverHook func() (forceFailure bool)
+
+func (w *Watcher) triggerOverflowForTest() bool {
+	recovered := w.recoverFromOverflow(nil)
+	if recoverHook != nil && recoverHook() {
+		recovered = false
+	}
+
+	w.snapMu.Lock()
+	if recovered {
+		w.overflowFailures = 0
+	} else {
+		w.overflowFailures++
+	}
+	failures := w.overflowFailures
+	w.snapMu.Unlock()
+
+	if failures >= maxOverflowFailures {
+		w.snapMu.Lock()
+		w.fallbackToPolling = true
+		w.snapMu.Unlock()
+		return true
+	}
+	return false
+}
+
+func (w *Watcher) overflowFailuresForTest() int {
+	w.snapMu.Lock()
+	defer w.snapMu.Unlock()
+	return w.overflowFailures
+}
+
+func (w *Watcher) fallbackTriggeredForTest() bool {
+	return w.shouldFallback()
+}
+
+func (w *Watcher) primeSnapshotForTest() {
+	w.snapMu.Lock()
+	w.prevSnapshot = w.buildSnapshot()
+	w.snapMu.Unlock()
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,11 +1,13 @@
 package watcher
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -19,6 +21,10 @@ type Event struct {
 
 // DefaultPollInterval is the default polling interval for the polling fallback.
 const DefaultPollInterval = 500 * time.Millisecond
+
+// maxOverflowFailures is the number of consecutive overflow recovery attempts
+// allowed before the watcher gives up on fsnotify and falls back to polling.
+const maxOverflowFailures = 2
 
 // skipDirs are directory base names that should never be watched or walked.
 // These are either non-source content or hidden directories that produce
@@ -49,6 +55,11 @@ type Watcher struct {
 	pending []Event
 	timer   *time.Timer
 	stopCh  chan struct{}
+
+	snapMu            sync.Mutex
+	prevSnapshot      map[string]fileInfo
+	overflowFailures  int
+	fallbackToPolling bool
 }
 
 // New creates a new file watcher.
@@ -70,10 +81,11 @@ func (w *Watcher) SetPollInterval(d time.Duration) {
 
 // Watch starts watching for file changes. This is a blocking call that runs
 // until Stop() is called. Tries fsnotify first, falls back to polling if
-// the OS watch limit is exhausted.
+// the OS watch limit is exhausted or if fsnotify reports too many buffer
+// overflows in a row (Windows ReadDirectoryChangesW or inotify queue).
 func (w *Watcher) Watch() error {
 	err := w.watchFsnotify()
-	if err == nil {
+	if err == nil && !w.shouldFallback() {
 		return nil
 	}
 	// Don't fall back to polling when a watch root vanished — polling the
@@ -81,8 +93,15 @@ func (w *Watcher) Watch() error {
 	if _, gone := err.(*ErrWatchRootGone); gone {
 		return err
 	}
-	// fsnotify failed — fall back to polling
+	// fsnotify failed (or asked us to fall back after repeated overflows) —
+	// run the polling backend.
 	return w.watchPolling()
+}
+
+func (w *Watcher) shouldFallback() bool {
+	w.snapMu.Lock()
+	defer w.snapMu.Unlock()
+	return w.fallbackToPolling
 }
 
 // Stop stops the watcher.
@@ -112,6 +131,13 @@ func (e *ErrWatchRootGone) Error() string {
 // watchFsnotify uses OS-level file system notifications for near-instant
 // change detection. Returns a non-nil error if setup fails (e.g., watch
 // limit exhausted), in which case the caller should fall back to polling.
+//
+// On a buffer-overflow error from the kernel (Windows ERROR_NOTIFY_ENUM_DIR
+// surfaced as fsnotify.ErrEventOverflow, or inotify IN_Q_OVERFLOW), the
+// watcher re-walks the watched roots and synthesizes events for any files
+// whose modTime/size differs from the in-memory snapshot. After
+// maxOverflowFailures consecutive failed recoveries it gives up and lets
+// Watch() fall back to polling.
 func (w *Watcher) watchFsnotify() error {
 	fsw, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -135,6 +161,10 @@ func (w *Watcher) watchFsnotify() error {
 		}
 	}
 
+	w.snapMu.Lock()
+	w.prevSnapshot = w.buildSnapshot()
+	w.snapMu.Unlock()
+
 	for {
 		select {
 		case <-w.stopCh:
@@ -144,10 +174,6 @@ func (w *Watcher) watchFsnotify() error {
 			if !ok {
 				return nil
 			}
-			// Ignore Chmod-only events — these fire on all platforms for
-			// non-content changes: macOS Spotlight/xattr, Windows Defender
-			// scans, Linux permission/ownership changes. Only suppress when
-			// Chmod is the sole operation; combined Write|Chmod passes through.
 			if ev.Op == fsnotify.Chmod {
 				continue
 			}
@@ -164,9 +190,7 @@ func (w *Watcher) watchFsnotify() error {
 				continue
 			}
 
-			// Filter by extension
 			if !w.matchesExtension(ev.Name) {
-				// New directories need to be watched for new files
 				if ev.Has(fsnotify.Create) {
 					if info, err := os.Stat(ev.Name); err == nil && info.IsDir() {
 						if addErr := w.addRecursive(fsw, ev.Name); addErr == nil {
@@ -177,6 +201,7 @@ func (w *Watcher) watchFsnotify() error {
 				continue
 			}
 
+			w.recordSnapshotEntry(ev.Name)
 			event := Event{Path: ev.Name, Op: fsnotifyOpToString(ev.Op)}
 			w.addPending(event)
 
@@ -184,10 +209,118 @@ func (w *Watcher) watchFsnotify() error {
 			if !ok {
 				return nil
 			}
-			// Log but don't crash — transient errors are common
+			if isOverflowError(err) {
+				if w.handleOverflow(fsw) {
+					return nil
+				}
+				continue
+			}
 			fmt.Fprintf(os.Stderr, "watcher: %v\n", err)
 		}
 	}
+}
+
+// handleOverflow runs the snapshot-diff recovery and tracks consecutive
+// failures. Returns true if the caller should exit watchFsnotify so the
+// outer Watch() can fall back to polling.
+func (w *Watcher) handleOverflow(fsw *fsnotify.Watcher) bool {
+	recovered := w.recoverFromOverflow(fsw)
+
+	w.snapMu.Lock()
+	if recovered {
+		w.overflowFailures = 0
+	} else {
+		w.overflowFailures++
+	}
+	failures := w.overflowFailures
+	w.snapMu.Unlock()
+
+	if failures >= maxOverflowFailures {
+		fmt.Fprintf(os.Stderr,
+			"watcher: fsnotify overflow recovery failed %d times; falling back to polling\n",
+			failures)
+		w.snapMu.Lock()
+		w.fallbackToPolling = true
+		w.snapMu.Unlock()
+		return true
+	}
+	return false
+}
+
+// recoverFromOverflow re-walks every watched root, diffs against the
+// in-memory snapshot, and pushes synthesized Create/Write/Remove events
+// downstream. It also re-attaches fsw to any directories that appeared
+// since the last walk so subsequent events do not get dropped.
+//
+// Returns true on a clean re-walk (no errors, snapshot replaced). Returns
+// false if any root failed to walk — the caller treats this as a recovery
+// failure and may fall back to polling on repeated misses.
+func (w *Watcher) recoverFromOverflow(fsw *fsnotify.Watcher) bool {
+	ok := true
+	if fsw != nil {
+		for _, dir := range w.dirs {
+			if err := w.addRecursive(fsw, dir); err != nil {
+				ok = false
+			}
+		}
+	}
+
+	newSnapshot := w.buildSnapshot()
+
+	w.snapMu.Lock()
+	prev := w.prevSnapshot
+	w.prevSnapshot = newSnapshot
+	w.snapMu.Unlock()
+
+	for _, ev := range w.diff(prev, newSnapshot) {
+		w.addPending(ev)
+	}
+	return ok
+}
+
+func (w *Watcher) recordSnapshotEntry(path string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		w.snapMu.Lock()
+		if w.prevSnapshot != nil {
+			delete(w.prevSnapshot, path)
+		}
+		w.snapMu.Unlock()
+		return
+	}
+	if info.IsDir() {
+		return
+	}
+	w.snapMu.Lock()
+	if w.prevSnapshot == nil {
+		w.prevSnapshot = make(map[string]fileInfo)
+	}
+	w.prevSnapshot[path] = fileInfo{modTime: info.ModTime(), size: info.Size()}
+	w.snapMu.Unlock()
+}
+
+// isOverflowError reports whether err is a kernel-level overflow signal
+// from any fsnotify backend. Windows ReadDirectoryChangesW reports
+// ERROR_NOTIFY_ENUM_DIR (1022) when its 64KB buffer overflows during a
+// burst (large git checkout, pnpm install). Linux inotify reports
+// IN_Q_OVERFLOW when the per-instance event queue fills. Both surface as
+// fsnotify.ErrEventOverflow; we also accept ENOSPC on Linux (inotify
+// watch-descriptor exhaustion) and a string fallback for any future
+// backend that wraps differently.
+func isOverflowError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, fsnotify.ErrEventOverflow) {
+		return true
+	}
+	if errors.Is(err, syscall.ENOSPC) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "overflow") ||
+		strings.Contains(msg, "notify_enum_dir") ||
+		strings.Contains(msg, "error 1022")
 }
 
 // addRecursive walks a directory tree and adds each directory to the
@@ -273,9 +406,17 @@ var printWatchLimitWarning = sync.OnceFunc(func() {
 	fmt.Fprintln(os.Stderr, "")
 })
 
-// watchPolling uses the original polling approach as a fallback.
+// watchPolling uses the original polling approach as a fallback. When
+// transitioning from fsnotify after an overflow fallback, it seeds from the
+// last-known fsnotify snapshot so the initial poll doesn't synthesize
+// spurious "create" events for every file already on disk.
 func (w *Watcher) watchPolling() error {
-	snapshot := w.buildSnapshot()
+	w.snapMu.Lock()
+	snapshot := w.prevSnapshot
+	w.snapMu.Unlock()
+	if snapshot == nil {
+		snapshot = w.buildSnapshot()
+	}
 
 	ticker := time.NewTicker(w.pollInterval)
 	defer ticker.Stop()
@@ -293,6 +434,9 @@ func (w *Watcher) watchPolling() error {
 				}
 			}
 			snapshot = newSnapshot
+			w.snapMu.Lock()
+			w.prevSnapshot = newSnapshot
+			w.snapMu.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
Fixes #137

## Root cause

On Windows, fsnotify uses `ReadDirectoryChangesW` with a 64KB kernel buffer per watched directory. A burst that exceeds the buffer (large `git checkout`, `pnpm install`) returns `ERROR_NOTIFY_ENUM_DIR`, surfaced by fsnotify as `fsnotify.ErrEventOverflow`. Linux inotify behaves the same when its per-instance event queue fills (`IN_Q_OVERFLOW`). The previous error branch in `watchFsnotify` just logged the error and moved on, so saved files silently missed rebuilds — users blamed their editor.

## Fix — two-strikes design

1. **Snapshot in memory.** A `prevSnapshot` (`path -> {modTime, size}`) is seeded during the initial walk in `watchFsnotify` and updated on every event delivered by fsnotify.
2. **Detect overflow.** A new `isOverflowError` helper recognises the signal across backends: `fsnotify.ErrEventOverflow`, `syscall.ENOSPC`, plus a string fallback for `"overflow"` / `"notify_enum_dir"` / `"error 1022"` so a future backend wrap doesn't silently break recovery.
3. **First and second strike: re-walk + synthesize.** `recoverFromOverflow` re-attaches fsnotify to every watched root (so brand-new directories don't get dropped), walks them, builds a fresh snapshot, diffs against the previous one, and pushes synthesized Create/Write/Remove events into the same `addPending` pipeline downstream consumers already use.
4. **After 2 consecutive failed recoveries: fall back to polling.** A clear warning is logged and the rest of the session runs through `watchPolling`, seeded from the last fsnotify snapshot so the first poll doesn't re-emit every existing file as a fake "create".

The polling backend already existed; the change just wires the fsnotify path into it on hard failure.

## Test plan

Tests live in `internal/watcher/edge_cases_test.go` and use a package-internal seam (`overflow_seam_test.go`, `_test.go` so it never reaches production binaries) to drive the recovery path without depending on the OS actually overflowing the kernel buffer.

- [x] `TestIsOverflowError_RecognizesKernelSignals` — table test pinning the detection contract for the fsnotify sentinel, wrapped `ENOSPC`, and the three string fallbacks.
- [x] `TestWatch_OverflowRecovery_SynthesizesMissedEvents` — primes the snapshot, mutates files out-of-band (write, create, delete), triggers recovery, asserts the right `Op` is synthesized for each path and that the unchanged file produces nothing.
- [x] `TestWatch_OverflowFallback_SwitchesToPolling` — forces two consecutive recovery failures via a hook, asserts the failure counter increments, the fallback flag flips, and a subsequent write is delivered through the polling backend.
- [x] `go test -race -count=1 ./internal/watcher/...` — clean (incl. existing 20+ KnownIssue / leak / burst tests).

## Notes

- Scope is intentionally limited to overflow recovery. Sister fixes for #132/#133/#136 land in their own PRs.
- The seam (`triggerOverflowForTest`, `recoverHook`, `primeSnapshotForTest`) is lowercase and only available to in-package tests.