### PR TITLE
fix(sdkgen): make formatter invocation cross-platform (#143)

### DIFF
--- a/cmd/tsgonest/dev_known_issues_test.go
+++ b/cmd/tsgonest/dev_known_issues_test.go
@@ -24,11 +24,11 @@ import (
 // later at line ~295). The rebuild goroutine is not joined. If it's mid-build
 // when runDevLoop returns:
 //
-//   1. close(done) fires — does NOT unblock the goroutine; it's running a build.
-//   2. proc.Stop() fires — kills the current child.
-//   3. Rebuild goroutine completes — sees no `<-done` arm yet (it hasn't reached
-//      the next select). Calls proc.Restart() → proc.Start() → orphan child.
-//   4. runDevLoop returns. The orphan child outlives the dev loop.
+//  1. close(done) fires — does NOT unblock the goroutine; it's running a build.
+//  2. proc.Stop() fires — kills the current child.
+//  3. Rebuild goroutine completes — sees no `<-done` arm yet (it hasn't reached
+//     the next select). Calls proc.Restart() → proc.Start() → orphan child.
+//  4. runDevLoop returns. The orphan child outlives the dev loop.
 //
 // Fix: track the rebuild goroutine with sync.WaitGroup and Wait() before the
 // proc.Stop() defer runs. Or set an atomic "shutting down" flag that the
@@ -85,7 +85,7 @@ func TestDevLoop_ManualRestartCanDoubleRestart_KnownIssue(t *testing.T) {
 
 // dev.go:~243 has:
 //
-//   proc = runner.New("sh", []string{"-c", flags.execCmd}, cwd)
+//	proc = runner.New("sh", []string{"-c", flags.execCmd}, cwd)
 //
 // `sh` is not on PATH on default Windows installs (only with Git Bash / WSL).
 // Windows users running `tsgonest dev --exec "node ./scripts/run.js"` get

--- a/internal/sdkgen/generate.go
+++ b/internal/sdkgen/generate.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"unicode"
 )
@@ -149,6 +151,22 @@ type formatterInfo struct {
 	rootDir string // directory where the config file lives (for running npx)
 }
 
+// runNpx builds an *exec.Cmd that invokes npx with the given arguments.
+// On Windows, npx is npx.cmd and must be executed through cmd.exe /C so the
+// shell resolves .cmd shims correctly. Forward slashes are required for glob
+// arguments because prettier's glob engine treats backslashes as escape chars.
+func runNpx(args ...string) *exec.Cmd {
+	return runNpxForGOOS(runtime.GOOS, args...)
+}
+
+// runNpxForGOOS is the testable core of runNpx; goos mirrors runtime.GOOS.
+func runNpxForGOOS(goos string, args ...string) *exec.Cmd {
+	if goos == "windows" {
+		return exec.Command("cmd.exe", append([]string{"/C", "npx"}, args...)...)
+	}
+	return exec.Command("npx", args...)
+}
+
 // formatOutput detects a project formatter and runs it on the output directory.
 // Supported: prettier, biome, oxfmt. Errors are non-fatal (warnings only).
 // The formatter is invoked from the directory where its config was found,
@@ -159,18 +177,23 @@ func formatOutput(outputDir string) {
 		return
 	}
 	var cmd *exec.Cmd
+	// Use path.Join (not filepath.Join) so the glob always uses forward slashes —
+	// prettier's glob engine treats backslashes as escape characters on Windows.
+	globPattern := path.Join(filepath.ToSlash(outputDir), "**/*.ts")
 	switch f.name {
 	case "prettier":
-		cmd = exec.Command("npx", "prettier", "--write", filepath.Join(outputDir, "**/*.ts"))
+		cmd = runNpx("prettier", "--write", globPattern)
 	case "biome":
-		cmd = exec.Command("npx", "@biomejs/biome", "format", "--write", outputDir)
+		cmd = runNpx("@biomejs/biome", "format", "--write", outputDir)
 	case "oxfmt":
-		cmd = exec.Command("npx", "oxfmt", "--write", outputDir)
+		cmd = runNpx("oxfmt", "--write", outputDir)
 	default:
 		return
 	}
 	cmd.Dir = f.rootDir
-	cmd.Run()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: formatter failed: %v\n%s", err, out)
+	}
 }
 
 // detectFormatter walks up from outputDir looking for formatter config files.

--- a/internal/sdkgen/generate_test.go
+++ b/internal/sdkgen/generate_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"path"
 )
 
 func TestGenerate_BasicFixture(t *testing.T) {
@@ -661,4 +663,50 @@ func TestBuildFormData_InterfaceCompatibleConstraint(t *testing.T) {
 		"FormDataValue should still be exported")
 	assertContains(t, formDataContent, "export type FormDataCompatible",
 		"FormDataCompatible should still be exported for backwards compatibility")
+}
+
+func TestRunNpxForGOOS_NonWindows(t *testing.T) {
+	for _, goos := range []string{"linux", "darwin"} {
+		cmd := runNpxForGOOS(goos, "prettier", "--write", "out/**/*.ts")
+		if cmd.Path == "" {
+			t.Fatalf("goos=%s: cmd.Path is empty", goos)
+		}
+		// Args[0] is the executable path resolved by exec.LookPath; check raw args via Args.
+		if len(cmd.Args) < 1 || !strings.HasSuffix(cmd.Args[0], "npx") {
+			t.Errorf("goos=%s: expected executable to be npx, got %v", goos, cmd.Args)
+		}
+		if cmd.Args[1] != "prettier" {
+			t.Errorf("goos=%s: expected first arg to be 'prettier', got %q", goos, cmd.Args[1])
+		}
+	}
+}
+
+func TestRunNpxForGOOS_Windows(t *testing.T) {
+	cmd := runNpxForGOOS("windows", "prettier", "--write", "out/**/*.ts")
+	if cmd.Path == "" {
+		t.Fatal("windows: cmd.Path is empty")
+	}
+	// On a non-Windows host, cmd.exe won't be found — check Args directly.
+	if !strings.Contains(cmd.Args[0], "cmd") {
+		t.Errorf("windows: expected cmd.exe as executable, got %q", cmd.Args[0])
+	}
+	if len(cmd.Args) < 4 || cmd.Args[1] != "/C" || cmd.Args[2] != "npx" {
+		t.Errorf("windows: expected [cmd.exe /C npx ...], got %v", cmd.Args)
+	}
+	if cmd.Args[3] != "prettier" {
+		t.Errorf("windows: expected 'prettier' as first npx arg, got %q", cmd.Args[3])
+	}
+}
+
+func TestRunNpxGlobArgUsesForwardSlashes(t *testing.T) {
+	// No matter what the OS path separator is, the glob passed to prettier must
+	// use forward slashes so prettier's glob engine interprets it correctly.
+	outputDir := filepath.Join("C:", "Users", "ci", "project", "sdk")
+	globPattern := path.Join(filepath.ToSlash(outputDir), "**/*.ts")
+	if strings.Contains(globPattern, `\`) {
+		t.Errorf("glob pattern contains backslashes: %q", globPattern)
+	}
+	if !strings.HasSuffix(globPattern, "**/*.ts") {
+		t.Errorf("glob pattern does not end with **/*.ts: %q", globPattern)
+	}
 }


### PR DESCRIPTION
Fixes #143

## Root cause

`formatOutput` in `internal/sdkgen/generate.go` had two Windows-specific bugs:

1. **npx.cmd not found**: `exec.Command("npx", ...)` silently fails on Windows because `npx` is `npx.cmd` — a shell script that only resolves when a shell is the launcher. Discarding the `cmd.Run()` error hid this completely.
2. **Backslash glob**: `filepath.Join(outputDir, "**/*.ts")` produces backslash paths on Windows; prettier's glob engine treats `\` as an escape character and matches nothing.

## Fix

- Extracted `runNpx` / `runNpxForGOOS(goos, args...)` helper. On Windows it wraps the invocation in `cmd.exe /C npx ...`; on other platforms it calls `npx` directly.
- Glob argument now uses `path.Join(filepath.ToSlash(outputDir), "**/*.ts")` — always forward slashes.
- Applied to all three formatter branches (prettier, biome, oxfmt).
- `cmd.CombinedOutput()` replaces the discarded `cmd.Run()` — failures print `warning: formatter failed: <err>` to stderr. Formatting remains best-effort (non-fatal).

## Test plan

- `TestRunNpxForGOOS_NonWindows` — verifies non-Windows invokes `npx` directly.
- `TestRunNpxForGOOS_Windows` — verifies Windows produces `[cmd.exe /C npx ...]`.
- `TestRunNpxGlobArgUsesForwardSlashes` — verifies glob never contains backslashes regardless of OS path separator.
- `go test -race -count=1 ./internal/sdkgen/...` passes (1.7 s).