### PR TITLE
chore: add .gitattributes to keep LF endings on Windows clones (#148)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,48 @@
+# Default: normalize text files to LF on checkout
+* text=auto eol=lf
+
+# Patches MUST stay LF — git am verifies patch hashes against exact byte sequences
+patches/*.patch -text
+
+# Go source
+*.go    text eol=lf
+go.mod  text eol=lf
+go.sum  text eol=lf
+go.work text eol=lf
+
+# TypeScript / JavaScript
+*.ts   text eol=lf
+*.tsx  text eol=lf
+*.js   text eol=lf
+*.cjs  text eol=lf
+*.mjs  text eol=lf
+
+# Data / config formats
+*.json  text eol=lf
+*.jsonc text eol=lf
+*.toml  text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+
+# Documentation / markup
+*.md  text eol=lf
+*.mdx text eol=lf
+
+# Shell scripts
+*.sh text eol=lf
+
+# Binaries — never modify
+*.exe   binary
+*.dll   binary
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.ico   binary
+*.gif   binary
+*.webp  binary
+*.svg   text eol=lf
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.otf   binary
+*.eot   binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,23 @@ git -C typescript-go am ../patches/0001-your-change.patch
 
 Patches in `patches/` are applied automatically during `git submodule update`.
 
+## Windows contributors
+
+The repo ships a `.gitattributes` that forces LF line endings for all text
+files. This prevents `core.autocrlf=true` (the Windows Git default) from
+converting `patches/*.patch` to CRLF, which would corrupt them and break
+`just init`.
+
+If you cloned the repo before `.gitattributes` was added (or you already have
+CRLF in your working tree), run this once to renormalize every file:
+
+```bash
+git add --renormalize .
+git commit -m "chore: renormalize line endings" # if there are changes
+```
+
+No special Git configuration is required — just keep the default settings.
+
 ## Adding shim methods
 
 tsgonest accesses unexported tsgo functions via a shim layer. To expose a new


### PR DESCRIPTION
## Summary

Fixes #148.

On Windows with the default `core.autocrlf=true`, Git converts `\n` → `\r\n` on checkout for files it classifies as text. This silently corrupts `patches/*.patch`, causing `git am --3way` to fail with *"corrupt patch at line N"* and breaking `just init` for every Windows contributor.

### What changed

- **`.gitattributes`** (new file) — enforces LF endings repo-wide:
  - `* text=auto eol=lf` — default rule for all text files
  - `patches/*.patch -text` — tells Git to treat patches as binary so it **never** rewrites their bytes (`git am` is sensitive to byte-exact content including line endings)
  - Explicit `text eol=lf` for Go, TypeScript, JavaScript, JSON, YAML, TOML, Markdown, shell scripts, and SVG
  - `binary` marks for executables, fonts, and raster images
- **`CONTRIBUTING.md`** — adds a *"Windows contributors"* section explaining the `git add --renormalize .` one-time fix for contributors who already cloned before this change

### Renormalization result

The repo's working tree was already all-LF (primary maintainer on macOS), so `git add --renormalize .` produced **zero file changes** — no noisy diff, no commit needed beyond the two files above.

## Test plan

- [ ] Confirm `patches/` contains no CRLF: `! grep -lrP $'\r' patches/`
- [ ] On a Windows machine with `core.autocrlf=true`, clone the repo and verify `just init` completes without "corrupt patch" errors
- [ ] Verify `.gitattributes` is picked up: `git check-attr eol patches/0001-fix-early-return-from-invalid-tsconfig-for-better-er.patch` should report `eol: unspecified` (the `-text` rule means Git doesn't set eol — it leaves the file alone)