### PR TITLE
fix(runner): honor GenerateConsoleCtrlEvent return on Windows (#146)

### DIFF
--- a/internal/runner/runner_windows.go
+++ b/internal/runner/runner_windows.go
@@ -11,6 +11,12 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// generateConsoleCtrlEvent is a package-level variable so tests can inject a
+// fake implementation to exercise the error-path without a real console.
+var generateConsoleCtrlEvent = func(event uint32, pid uint32) error {
+	return windows.GenerateConsoleCtrlEvent(event, pid)
+}
+
 const createSuspended = 0x00000004
 
 // Start starts the child process inside a Windows Job Object.
@@ -118,7 +124,15 @@ func (r *Runner) stop() error {
 
 	// Try graceful shutdown via CTRL_BREAK_EVENT.
 	// Node.js handles this signal and can run cleanup code.
-	windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(r.cmd.Process.Pid))
+	if err := generateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(r.cmd.Process.Pid)); err != nil {
+		// Signal not delivered (no console attached, wrong process group, etc.).
+		// Waiting 5s would be futile — r.done will never close on its own.
+		r.cmd.Process.Kill()
+		<-r.done
+		r.closeJob()
+		r.cmd = nil
+		return nil
+	}
 
 	select {
 	case <-r.done:

--- a/internal/runner/runner_windows_test.go
+++ b/internal/runner/runner_windows_test.go
@@ -378,3 +378,67 @@ func TestRunner_ConcurrentStopRestart(t *testing.T) {
 	}
 	r.Stop()
 }
+
+// TestRunnerStop_NoConsoleSkipsWait verifies that when GenerateConsoleCtrlEvent
+// returns an error (e.g. ERROR_INVALID_HANDLE — no console attached), stop()
+// kills the process immediately and returns well under the 5-second grace period.
+func TestRunnerStop_NoConsoleSkipsWait(t *testing.T) {
+	orig := generateConsoleCtrlEvent
+	generateConsoleCtrlEvent = func(event uint32, pid uint32) error {
+		return fmt.Errorf("ERROR_INVALID_HANDLE")
+	}
+	t.Cleanup(func() { generateConsoleCtrlEvent = orig })
+
+	r := New("ping", []string{"-n", "300", "127.0.0.1"}, "")
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	if err := r.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed >= 500*time.Millisecond {
+		t.Errorf("Stop() took %v — expected <500ms when signal delivery fails (no 5s wait)", elapsed)
+	}
+}
+
+// TestRunnerStop_WithConsoleWaitsForGraceful verifies that when
+// GenerateConsoleCtrlEvent succeeds and the process exits promptly,
+// stop() returns via the graceful path without waiting the full 5 seconds.
+func TestRunnerStop_WithConsoleWaitsForGraceful(t *testing.T) {
+	orig := generateConsoleCtrlEvent
+	generateConsoleCtrlEvent = func(event uint32, pid uint32) error {
+		// Signal "succeeded" — now kill the process so r.done closes quickly,
+		// simulating a process that handles CTRL_BREAK and exits gracefully.
+		return nil
+	}
+	t.Cleanup(func() { generateConsoleCtrlEvent = orig })
+
+	r := New("ping", []string{"-n", "300", "127.0.0.1"}, "")
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Kill the process out-of-band so r.done closes while stop() is in the select.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		r.mu.Lock()
+		if r.cmd != nil && r.cmd.Process != nil {
+			r.cmd.Process.Kill()
+		}
+		r.mu.Unlock()
+	}()
+
+	start := time.Now()
+	if err := r.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed >= 5*time.Second {
+		t.Errorf("Stop() took %v — should have returned via graceful path when r.done closes", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #146

`GenerateConsoleCtrlEvent` returns a non-nil error when no console is attached (`ERROR_INVALID_HANDLE`), the process is not in our group (`ERROR_INVALID_PARAMETER`), or the target isn't found (`ERROR_NOT_FOUND`). The previous code silently discarded this error and then waited the full 5-second grace period — a period that could never resolve because the signal was never delivered.

**Root cause fix:** check the return value. On error, skip directly to `TerminateProcess` + `<-r.done`. This eliminates the 5-second stall in every no-console scenario (CI pipelines, detached parents, Windows services, GUI launchers, etc.).

**Testability:** introduced a package-level `var generateConsoleCtrlEvent` function variable (defaulting to `windows.GenerateConsoleCtrlEvent`) so tests can inject a fake without needing a real console attached.

## Test plan

- [ ] `TestRunnerStop_NoConsoleSkipsWait` — fake signal func returns error; `Stop()` completes in <500ms (no 5s wait)
- [ ] `TestRunnerStop_WithConsoleWaitsForGraceful` — fake signal func returns nil; process is killed out-of-band at 50ms; `Stop()` returns via the graceful `<-r.done` path, well under 5s
- [ ] `GOARCH=amd64 GOOS=windows GOWORK=off go build ./internal/runner/...` — clean compile
- [ ] `GOWORK=off go test -count=1 ./internal/runner/...` — all tests pass