### PR TITLE
fix(watcher): handle symlinked/junction watch roots (#152)

### DIFF
--- a/internal/watcher/edge_cases_test.go
+++ b/internal/watcher/edge_cases_test.go
@@ -514,3 +514,77 @@ func TestWatch_BurstWritesNoDataRace(t *testing.T) {
 	wg.Wait()
 	time.Sleep(200 * time.Millisecond)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Symlinked watch root (#152)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestWatch_SymlinkedRoot_DetectsChanges verifies that fsnotify-mode watching
+// works when the watch root is itself a symlink (or Windows junction). The
+// underlying filepath.Walk uses os.Lstat, which would otherwise see the
+// symlink as a non-directory and skip it entirely — meaning fsw.Add never
+// runs and the dev loop is silent forever. addRecursive must resolve the
+// root via filepath.EvalSymlinks before walking.
+func TestWatch_SymlinkedRoot_DetectsChanges(t *testing.T) {
+	parent := t.TempDir()
+	real := filepath.Join(parent, "real")
+	if err := os.Mkdir(real, 0755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(parent, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlink creation not permitted: %v", err)
+	}
+
+	got := make(chan []Event, 16)
+	w := New([]string{link}, []string{".ts"}, 50*time.Millisecond, func(events []Event) {
+		got <- events
+	})
+	go w.Watch()
+	defer w.Stop()
+	time.Sleep(200 * time.Millisecond)
+
+	// Write a file in the REAL directory and expect an event.
+	if err := os.WriteFile(filepath.Join(real, "app.ts"), []byte("export const x = 1;"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-got:
+		// good — fsnotify saw the write through the resolved root
+	case <-time.After(2 * time.Second):
+		t.Fatal("write to symlinked watch root was not detected; addRecursive likely no-op'd")
+	}
+}
+
+// TestPolling_SymlinkedRoot_Snapshots verifies the same root-symlink resolution
+// works for the polling fallback (buildSnapshot). Without EvalSymlinks at the
+// root, the .ts file inside the resolved target would be invisible to the
+// snapshot diff and polling would never report a change.
+func TestPolling_SymlinkedRoot_Snapshots(t *testing.T) {
+	parent := t.TempDir()
+	real := filepath.Join(parent, "real")
+	if err := os.Mkdir(real, 0755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(parent, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlink creation not permitted: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(real, "app.ts"), []byte("export const x = 1;"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := &Watcher{
+		dirs:         []string{link},
+		extensions:   []string{".ts"},
+		debounce:     20 * time.Millisecond,
+		pollInterval: 30 * time.Millisecond,
+	}
+
+	snap := w.buildSnapshot()
+	if len(snap) != 1 {
+		t.Fatalf("expected 1 file in snapshot through symlinked root, got %d (snap=%v)", len(snap), snap)
+	}
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -158,7 +158,19 @@ func (w *Watcher) watchFsnotify() error {
 // fsnotify watcher. Skips directories in the skipDirs set and hidden
 // directories (prefixed with "."). Returns an error if adding any
 // directory fails (typically ENOSPC on Linux when the inotify limit is hit).
+//
+// The root is resolved through filepath.EvalSymlinks so that watch roots
+// which are themselves symlinks or Windows junctions (mklink /J, OneDrive
+// Documents/Desktop redirection, monorepo layout symlinks) are walked as
+// their real targets. filepath.Walk uses os.Lstat, which reports symlinks
+// as non-directories regardless of target — without this resolution the
+// walk would no-op silently and no fsnotify.Add would ever run.
+// Symlinks discovered nested inside the tree are NOT followed, to avoid
+// cycles and double-watches.
 func (w *Watcher) addRecursive(fsw *fsnotify.Watcher, root string) error {
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil // skip inaccessible paths
@@ -290,6 +302,12 @@ type fileInfo struct {
 func (w *Watcher) buildSnapshot() map[string]fileInfo {
 	snap := make(map[string]fileInfo)
 	for _, dir := range w.dirs {
+		// Mirror addRecursive: resolve symlinks/junctions at the root so the
+		// polling fallback walks the real target instead of no-op'ing on a
+		// symlinked watch root. Nested symlinks are still left alone.
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			dir = resolved
+		}
 		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return nil

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -21,10 +21,16 @@ func TestWatcher_BuildSnapshot(t *testing.T) {
 		t.Fatalf("expected 1 file in snapshot, got %d", len(snap))
 	}
 
-	// Verify the .ts file is in the snapshot
-	tsPath := filepath.Join(dir, "foo.ts")
+	// Verify the .ts file is in the snapshot. buildSnapshot resolves symlinks
+	// at the root (e.g. on macOS /var/folders -> /private/var/folders) so
+	// compare against the resolved path.
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		resolved = dir
+	}
+	tsPath := filepath.Join(resolved, "foo.ts")
 	if _, ok := snap[tsPath]; !ok {
-		t.Fatalf("expected %s in snapshot", tsPath)
+		t.Fatalf("expected %s in snapshot, got %v", tsPath, snap)
 	}
 }
 


### PR DESCRIPTION
Fixes #152

## Root cause

`internal/watcher/watcher.go::addRecursive` uses `filepath.Walk`, which calls `os.Lstat`. `os.Lstat` reports symlinks (and Windows junctions — `mklink /J`, OneDrive `Documents`/`Desktop` redirection) as non-directories regardless of what they point at. So when the watch root itself is a symlink/junction, `info.IsDir()` returns false, the walk does nothing, no `fsnotify.Add` ever runs, and the dev loop is silent forever. The polling fallback (`buildSnapshot`) had the same bug.

This is hit on Windows whenever the user's project lives under a OneDrive-redirected folder (very common), and on macOS/Linux any time a monorepo uses symlinks to lay out apps.

## Fix

Resolve the watch root via `filepath.EvalSymlinks` before calling `filepath.Walk` in both `addRecursive` and `buildSnapshot`. Nested symlinks discovered inside the tree are deliberately left alone — following them risks cycles (`a -> b -> a`) and double-watches, and the issue notes the root-only case is the common scenario.

Also updated `TestWatcher_BuildSnapshot` to compare against the resolved path: snapshot keys are now consistently the real-path form (e.g. on macOS `/var/folders/...` becomes `/private/var/folders/...`), which is more correct anyway.

## Scope

Only `addRecursive` and `buildSnapshot`. Nothing else in `watcher.go` was touched, so this should not conflict with the parallel work on the same file (case-insensitive `shouldSkipPath`, configpoller).

## Coordination with #132 (PR #170)

#132's root-rename detection normalizes watch roots with `filepath.Abs`+`Clean` (no symlink resolution) so it can compare event paths against the stored root. fsnotify reports event paths exactly as they were passed to `Add`. With this PR, paths passed to `fsnotify.Add` are resolved-real paths, so #132 will compare against resolved roots — that's still consistent (both sides see the resolved form), it just means the user-visible event path will be the real path, not the symlink path. Worth flagging during the #132 merge.

## Test plan

- [x] `TestWatch_SymlinkedRoot_DetectsChanges`: real dir + symlink + watcher on the symlink, write to file in real dir, expect event. Fails on `main`, passes here.
- [x] `TestPolling_SymlinkedRoot_Snapshots`: same setup for the polling fallback. Fails on `main`, passes here.
- [x] `gofmt -w internal cmd` clean.
- [x] `go test -race -count=1 ./internal/watcher/...` passes (full suite, including pre-existing tests and the May 2026 audit edge cases).
- [x] No changes to `typescript-go/` submodule or `shim/`.

Skipped Windows-junction-specific tests as suggested in the issue: `mklink /J` shows as `os.ModeSymlink` on Windows, so the symlink test exercises the same code path.