### PR TITLE
fix: Windows justfile recipes and launcher binary discovery (#158)

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,8 +38,8 @@ init:
   git submodule update --init --depth 1 typescript-go
   git -C typescript-go config user.email "ci@tsgonest"
   git -C typescript-go config user.name  "tsgonest CI"
-  pushd typescript-go; Get-ChildItem ../patches/*.patch -ErrorAction SilentlyContinue | ForEach-Object { git am --3way --no-gpg-sign $_.FullName }; popd
-  New-Item -ItemType Directory -Force -Path internal\collections
+  if ((Get-ChildItem patches/*.patch -ErrorAction SilentlyContinue).Count -gt 0) { Push-Location typescript-go; Get-ChildItem ../patches/*.patch | ForEach-Object { git am --3way --no-gpg-sign $_.FullName; if ($LASTEXITCODE -ne 0) { throw "git am failed for $($_.Name)" } }; Pop-Location }
+  New-Item -ItemType Directory -Force -Path internal\collections | Out-Null
   Get-ChildItem -Path .\typescript-go\internal\collections\* -File | Where-Object { $_.Name -notlike '*_test.go' } | ForEach-Object { Copy-Item $_.FullName -Destination .\internal\collections\ }
   just _patch-collections
 
@@ -56,8 +56,8 @@ build:
 
 [windows]
 build:
-  $env:GOOS="windows"; $env:GOARCH="amd64"; go build -o tsgonest.exe ./cmd/tsgonest
-  New-Item -ItemType Directory -Force -Path packages\core\bin
+  go build -o tsgonest.exe ./cmd/tsgonest
+  New-Item -ItemType Directory -Force -Path packages\core\bin | Out-Null
   Copy-Item tsgonest.exe packages\core\bin\tsgonest.exe
 
 test: build
@@ -82,6 +82,12 @@ bench: build
 bench-json: build
   cd benchmarks && pnpm run build && pnpm run bench:json
 
+[unix]
 clean:
   rm -f tsgonest tsgonest.exe
   rm -rf dist/
+
+[windows]
+clean:
+  Remove-Item -Force -ErrorAction SilentlyContinue tsgonest, tsgonest.exe
+  Remove-Item -Force -Recurse -ErrorAction SilentlyContinue dist


### PR DESCRIPTION
Fixes #158

## Justfile fixes (four bugs)

1. **`init`: `git am` failures swallowed** — replaced `pushd`/`popd` (cmd.exe shell aliases) with `Push-Location`/`Pop-Location` (PowerShell native); added `$LASTEXITCODE` check after every `git am` call with a `throw` to abort on failure.

2. **`init`: empty `patches/` silently skipped** — wrapped the patch loop in `if ((Get-ChildItem patches/*.patch -ErrorAction SilentlyContinue).Count -gt 0)` so a missing/empty patches directory is a clean no-op instead of a silent error.

3. **`build`: `$env:GOARCH="amd64"` hardcoded** — removed the `$env:GOOS`/`$env:GOARCH` overrides entirely. Go automatically targets the host OS and architecture, so Windows ARM64 contributors now get a native ARM64 binary.

4. **`clean`: POSIX `rm -rf` fails on Windows** — split `clean` into `[unix]` (unchanged `rm -f`/`rm -rf`) and `[windows]` (`Remove-Item -Force -ErrorAction SilentlyContinue` / `Remove-Item -Force -Recurse -ErrorAction SilentlyContinue`) variants.

## Launcher change dropped

The original PR also added a Windows-specific local dev binary lookup for `tsgonest-native.exe` in the launcher. This was made redundant by PR #172 (already merged), which adopted a different convention: `just build` on Windows writes `tsgonest.exe` to `packages/core/bin/`, and the launcher's local dev path resolves `tsgonest.exe` on Windows. That approach is already live on main, so the launcher change from this PR has been dropped during rebase and the `[windows] build` recipe now only copies to `tsgonest.exe` (no separate `tsgonest-native.exe` copy needed).

## Manual test plan

- **On Windows**: `just init && just build && node packages/core/bin/tsgonest --version` — should print dev version without error; verifies patch handling, binary copy, and launcher resolution all work end-to-end.
- **On Windows ARM64**: same — binary should now be native ARM64, not x64.
- **After `just clean` on Windows**: `tsgonest.exe` and `dist/` should be removed without PowerShell errors.
- **On macOS/Linux**: `just init && just build && node packages/core/bin/tsgonest --version` — should be unaffected (verified locally).