### PR TITLE
fix(runner): allow Start under parent Job Objects on Windows (#150)

### DIFF
--- a/internal/runner/runner_windows.go
+++ b/internal/runner/runner_windows.go
@@ -3,7 +3,9 @@
 package runner
 
 import (
+	"errors"
 	"fmt"
+	"os/exec"
 	"syscall"
 	"time"
 	"unsafe"
@@ -19,12 +21,22 @@ var generateConsoleCtrlEvent = func(event uint32, pid uint32) error {
 
 const createSuspended = 0x00000004
 
+// startProcess is overridable in tests to exercise the breakaway-denied retry path.
+var startProcess = func(cmd *exec.Cmd) error { return cmd.Start() }
+
 // Start starts the child process inside a Windows Job Object.
 // The process is created suspended, assigned to the Job Object, then resumed.
 // This eliminates the race where the child could spawn grandchildren before
 // being assigned to the job. The Job Object is configured with
 // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so all processes in the job are
 // terminated when the handle is closed (including on parent death).
+//
+// CREATE_BREAKAWAY_FROM_JOB is requested first so tsgonest can run inside a
+// CI-provided parent Job Object (GitHub Actions, TeamCity, Azure DevOps, some
+// IDE task runners) without nested-job conflicts. If the parent job disallows
+// breakaway, CreateProcess returns ERROR_ACCESS_DENIED; we then rebuild the
+// *exec.Cmd (Start can only be called once) and retry without the flag, which
+// matches Node.js's behavior for spawned children on Windows.
 func (r *Runner) Start() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -33,13 +45,11 @@ func (r *Runner) Start() error {
 		return ErrRunnerStopped
 	}
 
-	r.cmd = r.newCmd()
+	baseFlags := uint32(syscall.CREATE_NEW_PROCESS_GROUP | createSuspended)
 
-	// CREATE_NEW_PROCESS_GROUP: allows sending CTRL_BREAK_EVENT for graceful shutdown.
-	// CREATE_SUSPENDED: process starts frozen so we can assign the Job Object before
-	// any child processes are spawned.
+	r.cmd = r.newCmd()
 	r.cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | createSuspended,
+		CreationFlags: baseFlags | windows.CREATE_BREAKAWAY_FROM_JOB,
 	}
 
 	// Create a Job Object with KILL_ON_JOB_CLOSE.
@@ -63,10 +73,20 @@ func (r *Runner) Start() error {
 		return fmt.Errorf("configuring job object: %w", err)
 	}
 
-	if err := r.cmd.Start(); err != nil {
-		windows.CloseHandle(job)
-		r.cmd = nil
-		return fmt.Errorf("starting process: %w", err)
+	if err := startProcess(r.cmd); err != nil {
+		if isBreakawayDenied(err) {
+			// Parent Job Object disallows breakaway; rebuild *exec.Cmd
+			// (Start may only be called once per Cmd) and retry without the
+			// CREATE_BREAKAWAY_FROM_JOB flag.
+			r.cmd = r.newCmd()
+			r.cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: baseFlags}
+			err = startProcess(r.cmd)
+		}
+		if err != nil {
+			windows.CloseHandle(job)
+			r.cmd = nil
+			return fmt.Errorf("starting process: %w", err)
+		}
 	}
 
 	// Assign the suspended process to the Job Object BEFORE resuming it.
@@ -191,6 +211,13 @@ func (r *Runner) cleanupSuspendedChild(job windows.Handle, procHandle windows.Ha
 	}
 	r.cmd = nil
 	r.jobHandle = 0
+}
+
+// isBreakawayDenied reports whether err is the ERROR_ACCESS_DENIED that
+// CreateProcess returns when CREATE_BREAKAWAY_FROM_JOB is requested but the
+// parent Job Object's JOB_OBJECT_LIMIT_BREAKAWAY_OK flag is not set.
+func isBreakawayDenied(err error) bool {
+	return err != nil && errors.Is(err, syscall.ERROR_ACCESS_DENIED)
 }
 
 // resumeProcessThreads enumerates and resumes all threads of a suspended process.

--- a/internal/runner/runner_windows_test.go
+++ b/internal/runner/runner_windows_test.go
@@ -3,13 +3,17 @@
 package runner
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 func processAlive(pid int) bool {
@@ -353,6 +357,132 @@ func TestRunner_DoubleStopSafe(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("second Stop() deadlocked")
+	}
+}
+
+// --- CREATE_BREAKAWAY_FROM_JOB retry tests (issue #150) ---
+
+func TestIsBreakawayDenied(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"ERROR_ACCESS_DENIED direct", syscall.ERROR_ACCESS_DENIED, true},
+		{"wrapped ERROR_ACCESS_DENIED", fmt.Errorf("wrap: %w", syscall.ERROR_ACCESS_DENIED), true},
+		{"PathError wrapping ERROR_ACCESS_DENIED", &os.PathError{Op: "x", Path: "y", Err: syscall.ERROR_ACCESS_DENIED}, true},
+		{"unrelated error", errors.New("nope"), false},
+		{"different errno", syscall.Errno(2), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isBreakawayDenied(tc.err); got != tc.want {
+				t.Errorf("isBreakawayDenied(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunner_StartFallsBackWhenBreakawayDenied simulates the CI-with-parent-Job
+// scenario by injecting a startProcess that fails the first attempt (the one
+// with CREATE_BREAKAWAY_FROM_JOB) with ERROR_ACCESS_DENIED, then defers to the
+// real exec on the retry. The retry must succeed and the runner must still
+// assign the child to its Job Object normally.
+func TestRunner_StartFallsBackWhenBreakawayDenied(t *testing.T) {
+	originalStart := startProcess
+	t.Cleanup(func() { startProcess = originalStart })
+
+	var attempts int
+	var sawBreakawayFlag, retriedWithoutFlag bool
+	startProcess = func(cmd *exec.Cmd) error {
+		attempts++
+		flags := cmd.SysProcAttr.CreationFlags
+		hasBreakaway := flags&windows.CREATE_BREAKAWAY_FROM_JOB != 0
+		if attempts == 1 {
+			sawBreakawayFlag = hasBreakaway
+			return &os.PathError{Op: "CreateProcess", Path: cmd.Path, Err: syscall.ERROR_ACCESS_DENIED}
+		}
+		retriedWithoutFlag = !hasBreakaway
+		return cmd.Start()
+	}
+
+	r := New("ping", []string{"-n", "300", "127.0.0.1"}, "")
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start should succeed via fallback, got: %v", err)
+	}
+	defer r.Stop()
+
+	if attempts != 2 {
+		t.Errorf("expected 2 startProcess attempts (denied + retry), got %d", attempts)
+	}
+	if !sawBreakawayFlag {
+		t.Error("first attempt should have included CREATE_BREAKAWAY_FROM_JOB")
+	}
+	if !retriedWithoutFlag {
+		t.Error("retry should have dropped CREATE_BREAKAWAY_FROM_JOB")
+	}
+	if !r.Running() {
+		t.Error("runner should be running after the fallback succeeded")
+	}
+}
+
+// TestRunner_StartUsesBreakawayByDefault verifies that the first CreateProcess
+// attempt requests CREATE_BREAKAWAY_FROM_JOB so tsgonest detaches from a parent
+// Job Object whenever the parent permits it.
+func TestRunner_StartUsesBreakawayByDefault(t *testing.T) {
+	originalStart := startProcess
+	t.Cleanup(func() { startProcess = originalStart })
+
+	var firstFlags uint32
+	startProcess = func(cmd *exec.Cmd) error {
+		if firstFlags == 0 {
+			firstFlags = cmd.SysProcAttr.CreationFlags
+		}
+		return cmd.Start()
+	}
+
+	r := New("ping", []string{"-n", "300", "127.0.0.1"}, "")
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer r.Stop()
+
+	if firstFlags&windows.CREATE_BREAKAWAY_FROM_JOB == 0 {
+		t.Errorf("first CreateProcess attempt should request CREATE_BREAKAWAY_FROM_JOB; flags=0x%x", firstFlags)
+	}
+	if firstFlags&syscall.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Errorf("flags should still include CREATE_NEW_PROCESS_GROUP; flags=0x%x", firstFlags)
+	}
+	if firstFlags&createSuspended == 0 {
+		t.Errorf("flags should still include CREATE_SUSPENDED; flags=0x%x", firstFlags)
+	}
+}
+
+// TestRunner_StartReturnsRealErrorWhenRetryFails ensures non-ERROR_ACCESS_DENIED
+// failures from the first attempt are not swallowed by the breakaway fallback.
+func TestRunner_StartReturnsRealErrorWhenRetryFails(t *testing.T) {
+	originalStart := startProcess
+	t.Cleanup(func() { startProcess = originalStart })
+
+	sentinel := errors.New("simulated CreateProcess failure")
+	var attempts int
+	startProcess = func(cmd *exec.Cmd) error {
+		attempts++
+		return sentinel
+	}
+
+	r := New("ping", []string{"-n", "300", "127.0.0.1"}, "")
+	err := r.Start()
+	if err == nil {
+		r.Stop()
+		t.Fatal("expected Start to fail")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel, got: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("non-breakaway failures should NOT trigger the retry; attempts=%d", attempts)
 	}
 }
 


### PR DESCRIPTION
Fixes #150.

## Root cause

`internal/runner/runner_windows.go` unconditionally created the child with `CREATE_NEW_PROCESS_GROUP | CREATE_SUSPENDED`, then called `AssignProcessToJobObject`. When tsgonest itself runs inside a parent Job Object that does not allow nested jobs and does not set `JOB_OBJECT_LIMIT_BREAKAWAY_OK` (common in CI: GitHub Actions, TeamCity, Azure DevOps; some IDE task runners), the assignment fails with `ERROR_ACCESS_DENIED` and `Start()` refuses to launch.

## Fix

Try `CREATE_BREAKAWAY_FROM_JOB` on the first `CreateProcess` call so the child detaches from the parent job whenever the parent permits it. If `CreateProcess` returns `ERROR_ACCESS_DENIED` (the parent job disallows breakaway), rebuild `*exec.Cmd` — `Start` can only be called once — and retry without the flag. This mirrors Node.js's behavior for spawned children on Windows (`libuv`'s `uv__spawn_and_init_child` uses the same try-then-fallback strategy).

`isBreakawayDenied` uses `errors.Is(err, syscall.ERROR_ACCESS_DENIED)` so it works against the wrapped `*os.PathError` that `cmd.Start` surfaces.

A small `var startProcess = func(*exec.Cmd) error { ... }` indirection is added so tests can simulate the denied path without needing a real parent Job Object.

## Diff size

2 files, ~162 insertions / 8 deletions, all in `internal/runner/`.

## Test plan

- [x] `gofmt -w cmd internal` — clean for changed files.
- [x] `GOOS=windows go vet ./internal/runner/` — clean.
- [x] `GOOS=windows go test -c ./internal/runner/` — compiles.
- [x] `go test -count=1 ./internal/runner/...` on darwin — passes (race-detector failure is pre-existing KNOWN ISSUE G in `Running()`, reproducible on `main`, out of scope).
- [x] New Windows-only unit tests cover:
  - `TestIsBreakawayDenied` — table-driven coverage of the helper, including wrapped errors.
  - `TestRunner_StartUsesBreakawayByDefault` — first attempt requests `CREATE_BREAKAWAY_FROM_JOB | CREATE_NEW_PROCESS_GROUP | CREATE_SUSPENDED`.
  - `TestRunner_StartFallsBackWhenBreakawayDenied` — injects an `ERROR_ACCESS_DENIED` first attempt, asserts the runner rebuilds `*exec.Cmd` without the breakaway flag, retries successfully, and is `Running()`.
  - `TestRunner_StartReturnsRealErrorWhenRetryFails` — non-`ERROR_ACCESS_DENIED` failures are not swallowed by the fallback (only one attempt is made, original error is wrapped).
- [ ] **Windows CI coverage requested**: the actual "tsgonest is itself in a parent Job Object that disallows breakaway" scenario is hard to reproduce cross-platform from a unit test. The injected-`startProcess` tests exercise the branching logic; full validation of the real CreateProcess flag interaction needs Windows CI.

## Coordination note

`runner_windows.go` is also being touched in parallel by #144, #146, #153, #155, #157. This change is scoped to Job Object breakaway only.