### PR TITLE
fix: case-insensitive comparisons for cross-platform correctness (#145 #147 #149)

### DIFF
--- a/cmd/tsgonest/build.go
+++ b/cmd/tsgonest/build.go
@@ -867,7 +867,8 @@ func runBuildWithIncrAndProgram(args []string, oldIncrProgram *shimincremental.P
 // tsbuildInfoPathFromTsconfig derives the .tsbuildinfo path from a resolved tsconfig path.
 // e.g., "/project/tsconfig.json" → "/project/tsconfig.tsbuildinfo"
 func tsbuildInfoPathFromTsconfig(resolvedTsconfigPath string) string {
-	return strings.TrimSuffix(resolvedTsconfigPath, ".json") + ".tsbuildinfo"
+	ext := filepath.Ext(resolvedTsconfigPath)
+	return strings.TrimSuffix(resolvedTsconfigPath, ext) + ".tsbuildinfo"
 }
 
 // validateOutDir checks that outDir is safe to remove. This is the LAST line of

--- a/cmd/tsgonest/build_test.go
+++ b/cmd/tsgonest/build_test.go
@@ -961,3 +961,23 @@ func TestRunBuild_SweepEmptyDir(t *testing.T) {
 	sweepBuildCacheTmp(t.TempDir())
 	sweepBuildCacheTmp("")
 }
+
+func TestTsbuildInfoPathFromTsconfig_CaseInsensitive(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/project/tsconfig.json", "/project/tsconfig.tsbuildinfo"},
+		{"/project/tsconfig.JSON", "/project/tsconfig.tsbuildinfo"},
+		{"/project/tsconfig.Json", "/project/tsconfig.tsbuildinfo"},
+		{"/project/tsconfig.build.json", "/project/tsconfig.build.tsbuildinfo"},
+		{"/project/tsconfig.build.JSON", "/project/tsconfig.build.tsbuildinfo"},
+		{"/project/tsconfig", "/project/tsconfig.tsbuildinfo"},
+	}
+	for _, tt := range tests {
+		got := tsbuildInfoPathFromTsconfig(tt.input)
+		if got != tt.want {
+			t.Errorf("tsbuildInfoPathFromTsconfig(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/buildcache/cache.go
+++ b/internal/buildcache/cache.go
@@ -60,7 +60,8 @@ func CachePath(outDir string, tsconfigPath string) string {
 	// Fallback: sibling of tsconfig
 	dir := filepath.Dir(tsconfigPath)
 	base := filepath.Base(tsconfigPath)
-	name := strings.TrimSuffix(base, ".json")
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
 	return filepath.Join(dir, name+".tsgonest-cache")
 }
 

--- a/internal/buildcache/cache_test.go
+++ b/internal/buildcache/cache_test.go
@@ -45,6 +45,25 @@ func TestCachePath(t *testing.T) {
 	})
 }
 
+func TestBuildcache_CachePath_CaseInsensitive(t *testing.T) {
+	tests := []struct {
+		tsconf string
+		want   string
+	}{
+		{"/foo/tsconfig.json", "/foo/tsconfig.tsgonest-cache"},
+		{"/foo/tsconfig.JSON", "/foo/tsconfig.tsgonest-cache"},
+		{"/foo/tsconfig.Json", "/foo/tsconfig.tsgonest-cache"},
+		{"/foo/tsconfig.build.json", "/foo/tsconfig.build.tsgonest-cache"},
+		{"/foo/tsconfig.build.JSON", "/foo/tsconfig.build.tsgonest-cache"},
+	}
+	for _, tt := range tests {
+		got := CachePath("", tt.tsconf)
+		if got != tt.want {
+			t.Errorf("CachePath(\"\", %q) = %q, want %q", tt.tsconf, got, tt.want)
+		}
+	}
+}
+
 func TestHashFile(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/watcher/edge_cases_test.go
+++ b/internal/watcher/edge_cases_test.go
@@ -9,7 +9,8 @@ package watcher
 //   Leak. AfterFunc/fsnotify goroutines surviving start/stop cycles.
 //
 // Tests marked KnownIssue are documented bugs that pass against the broken
-// behavior. When a fix lands, these tests should be flipped to assert correctness.
+// behavior. When a fix lands, these tests should be flipped to assert
+// correctness (and the KnownIssue suffix dropped).
 
 import (
 	"errors"
@@ -537,26 +538,25 @@ func TestShouldSkipPath_SeparatorNormalization(t *testing.T) {
 	}
 }
 
-// TestShouldSkipPath_CaseSensitive_KnownIssue documents that shouldSkipPath
-// uses case-sensitive Contains. On Windows (case-insensitive filesystem), a
-// path containing "Node_Modules" is not skipped. Fix: strings.EqualFold or
-// a normalized comparison.
-func TestShouldSkipPath_CaseSensitive_KnownIssue(t *testing.T) {
+// TestShouldSkipPath_CaseInsensitive verifies that shouldSkipPath matches skip
+// directories regardless of case, so Windows paths like NODE_MODULES or Dist
+// are treated the same as their lowercase equivalents.
+func TestShouldSkipPath_CaseInsensitive(t *testing.T) {
 	cases := []struct {
 		path        string
 		shouldSkip  bool
 		description string
 	}{
 		{filepath.Join("project", "node_modules", "foo"), true, "lowercase always skipped"},
-		{filepath.Join("project", "Node_Modules", "foo"), true, "Windows-style mixed-case (currently NOT skipped — bug)"},
-		{filepath.Join("project", "NODE_MODULES", "foo"), true, "uppercase (currently NOT skipped — bug)"},
+		{filepath.Join("project", "Node_Modules", "foo"), true, "Windows-style mixed-case"},
+		{filepath.Join("project", "NODE_MODULES", "foo"), true, "all-uppercase"},
 		{filepath.Join("project", ".git", "objects"), true, ".git always skipped"},
 		{filepath.Join("project", "src", "node_modulesFake"), false, "should NOT skip lookalikes"},
 	}
 	for _, c := range cases {
 		got := shouldSkipPath(c.path)
 		if got != c.shouldSkip {
-			t.Logf("shouldSkipPath(%q) = %v, want %v — %s", c.path, got, c.shouldSkip, c.description)
+			t.Errorf("shouldSkipPath(%q) = %v, want %v — %s", c.path, got, c.shouldSkip, c.description)
 		}
 	}
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -328,7 +328,7 @@ func (w *Watcher) Pending() bool {
 func (w *Watcher) matchesExtension(path string) bool {
 	ext := filepath.Ext(path)
 	for _, e := range w.extensions {
-		if ext == e {
+		if strings.EqualFold(ext, e) {
 			return true
 		}
 	}
@@ -373,8 +373,11 @@ func matchedRoot(roots map[string]string, eventPath string) (string, bool) {
 // that should be ignored (e.g., node_modules, .git).
 // Normalizes separators to "/" before matching so that Windows native paths
 // (backslash) and Git Bash / forward-slash paths both match correctly.
+// Comparison is case-insensitive so Windows paths like NODE_MODULES or Dist
+// are treated the same as their lowercase equivalents (skipDirs keys are
+// already lowercase).
 func shouldSkipPath(path string) bool {
-	normalized := filepath.ToSlash(path)
+	normalized := strings.ToLower(filepath.ToSlash(path))
 	for dir := range skipDirs {
 		seg := "/" + dir + "/"
 		if strings.Contains(normalized, seg) ||
@@ -416,7 +419,7 @@ func (w *Watcher) buildSnapshot() map[string]fileInfo {
 			}
 			ext := filepath.Ext(path)
 			for _, e := range w.extensions {
-				if ext == e {
+				if strings.EqualFold(ext, e) {
 					snap[path] = fileInfo{modTime: info.ModTime(), size: info.Size()}
 					break
 				}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -224,3 +224,52 @@ func TestWatcher_Diff_MultipleEvents(t *testing.T) {
 		t.Errorf("expected write, create, and remove events, got %v", events)
 	}
 }
+
+func TestMatchesExtension_CaseInsensitive(t *testing.T) {
+	w := &Watcher{extensions: []string{".ts", ".tsx"}}
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"App.ts", true},
+		{"App.TS", true},
+		{"App.Ts", true},
+		{"App.tsx", true},
+		{"App.TSX", true},
+		{"App.TsX", true},
+		{"App.js", false},
+		{"App.JS", false},
+	}
+	for _, c := range cases {
+		got := w.matchesExtension(c.path)
+		if got != c.want {
+			t.Errorf("matchesExtension(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestShouldSkipPath_WindowsPaths(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{`D:/proj/NODE_MODULES/foo.ts`, true},
+		{`D:/proj/node_modules/foo.ts`, true},
+		{`D:/proj/Node_Modules/foo.ts`, true},
+		{`D:/proj/Dist/x.ts`, true},
+		{`D:/proj/dist/x.ts`, true},
+		{`D:/proj/DIST/x.ts`, true},
+		{`/home/user/project/node_modules/pkg/index.ts`, true},
+		{`/home/user/project/NODE_MODULES/pkg/index.ts`, true},
+		{`/home/user/project/.git/objects/abc`, true},
+		{`/home/user/project/.GIT/objects/abc`, true},
+		{`/home/user/project/src/node_modulesFake/bar.ts`, false},
+		{`/home/user/project/src/notdist/x.ts`, false},
+	}
+	for _, c := range cases {
+		got := shouldSkipPath(c.path)
+		if got != c.want {
+			t.Errorf("shouldSkipPath(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #145, Fixes #147, Fixes #149 — three case-sensitivity bugs that silently break Windows users.

- **#145 — `tsbuildInfoPathFromTsconfig` and `CachePath` strip wrong extension**: `strings.TrimSuffix(..., ".json")` fails when users write `--project tsconfig.JSON`. Fixed by using `filepath.Ext` to capture the actual extension casing, then trimming that.
- **#147 — `matchesExtension` drops uppercase-extension files**: `ext == e` is case-sensitive; `App.TS` is silently ignored by the watcher. Fixed with `strings.EqualFold`. Same fix applied to the identical extension check in `buildSnapshot`.
- **#149 — `shouldSkipPath` misses mixed-case skip dirs**: `strings.Contains(path, "/node_modules/")` does not match `NODE_MODULES` or `Dist`. Fixed by computing `pathLower := strings.ToLower(filepath.ToSlash(path))` once and comparing against the all-lowercase `skipDirs` keys. The `filepath.ToSlash` call composes cleanly with the separator normalization from #136 — when that PR merges, this path is already slash-normalized before the ToSlash no-ops on it.

## Changes

| File | Change |
|---|---|
| `cmd/tsgonest/build.go` | `tsbuildInfoPathFromTsconfig`: use `filepath.Ext` to strip extension |
| `internal/buildcache/cache.go` | `CachePath`: same fix for the tsconfig fallback path |
| `internal/watcher/watcher.go` | `matchesExtension`, `buildSnapshot`: `EqualFold` for ext; `shouldSkipPath`: lowercase + ToSlash before comparing |
| `cmd/tsgonest/build_test.go` | `TestTsbuildInfoPathFromTsconfig_CaseInsensitive` |
| `internal/buildcache/cache_test.go` | `TestBuildcache_CachePath_CaseInsensitive` |
| `internal/watcher/watcher_test.go` | `TestMatchesExtension_CaseInsensitive`, `TestShouldSkipPath_WindowsPaths` |
| `internal/watcher/edge_cases_test.go` | `TestShouldSkipPath_CaseSensitive_KnownIssue` → `TestShouldSkipPath_CaseInsensitive` (real `t.Errorf`) |

## Test plan

- [ ] `go test -race -count=1 ./cmd/tsgonest/... ./internal/watcher/... ./internal/buildcache/...` passes clean
- [ ] `TestTsbuildInfoPathFromTsconfig_CaseInsensitive` covers `.json`, `.JSON`, `.Json`, and no-extension inputs
- [ ] `TestBuildcache_CachePath_CaseInsensitive` covers the same for the cache path
- [ ] `TestMatchesExtension_CaseInsensitive` verifies `App.ts`, `App.TS`, `App.Ts`, `App.tsx`, `App.TSX` all match; `.js`/`.JS` do not
- [ ] `TestShouldSkipPath_CaseInsensitive` (was `_KnownIssue`) now uses `t.Errorf` — green means the bug is fixed
- [ ] `TestShouldSkipPath_WindowsPaths` covers forward-slash Windows-style paths (`D:/proj/NODE_MODULES/foo.ts`) and negative case (`node_modulesFake`)