### PR TITLE
fix(runner): honor ResumeThread return value (#153)

### DIFF
--- a/internal/runner/runner_windows.go
+++ b/internal/runner/runner_windows.go
@@ -5,6 +5,7 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 	"time"
@@ -23,6 +24,37 @@ const createSuspended = 0x00000004
 
 // startProcess is overridable in tests to exercise the breakaway-denied retry path.
 var startProcess = func(cmd *exec.Cmd) error { return cmd.Start() }
+
+var (
+	modKernel32      = windows.NewLazySystemDLL("kernel32.dll")
+	procResumeThread = modKernel32.NewProc("ResumeThread")
+)
+
+// openThreadFn and resumeFn are package-level seams so unit tests can
+// inject deterministic open/resume behavior without spawning a real
+// suspended Windows process. Production code uses the real syscalls.
+var (
+	openThreadFn = openThreadForResume
+	resumeFn     = resumeThreadChecked
+)
+
+func openThreadForResume(tid uint32) (windows.Handle, error) {
+	return windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, tid)
+}
+
+// resumeThreadChecked invokes ResumeThread and treats the documented
+// failure return (-1 / 0xFFFFFFFF) as an error even if the wrapper does
+// not surface one. Returns the previous suspend count on success.
+func resumeThreadChecked(h windows.Handle) (uint32, error) {
+	r1, _, e1 := procResumeThread.Call(uintptr(h))
+	if uint32(r1) == 0xFFFFFFFF {
+		if e1 != nil && e1 != syscall.Errno(0) {
+			return 0, e1
+		}
+		return 0, fmt.Errorf("ResumeThread failed (handle %v)", h)
+	}
+	return uint32(r1), nil
+}
 
 // Start starts the child process inside a Windows Job Object.
 // The process is created suspended, assigned to the Job Object, then resumed.
@@ -220,34 +252,76 @@ func isBreakawayDenied(err error) bool {
 	return err != nil && errors.Is(err, syscall.ERROR_ACCESS_DENIED)
 }
 
-// resumeProcessThreads enumerates and resumes all threads of a suspended process.
-// Returns an error if no threads were found or resumed for the target PID.
+// resumeProcessThreads enumerates the threads owned by pid and resumes each.
+// It distinguishes "no threads found" (snapshot or filter empty), "all resumes
+// failed" (every ResumeThread returned -1), and partial success (some resumed,
+// some failed — likely benign because the main thread usually succeeds first).
 func resumeProcessThreads(pid int) error {
+	tids, err := snapshotThreadIDsForPID(uint32(pid))
+	if err != nil {
+		return err
+	}
+	return resumeThreadIDs(pid, tids)
+}
+
+func snapshotThreadIDsForPID(pid uint32) ([]uint32, error) {
 	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
 	if err != nil {
-		return fmt.Errorf("creating thread snapshot: %w", err)
+		return nil, fmt.Errorf("creating thread snapshot: %w", err)
 	}
 	defer windows.CloseHandle(snapshot)
 
 	var te windows.ThreadEntry32
 	te.Size = uint32(unsafe.Sizeof(te))
 
-	resumed := 0
+	var tids []uint32
 	err = windows.Thread32First(snapshot, &te)
 	for err == nil {
-		if te.OwnerProcessID == uint32(pid) {
-			th, thErr := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, te.ThreadID)
-			if thErr == nil {
-				windows.ResumeThread(th)
-				windows.CloseHandle(th)
-				resumed++
-			}
+		if te.OwnerProcessID == pid {
+			tids = append(tids, te.ThreadID)
 		}
 		err = windows.Thread32Next(snapshot, &te)
 	}
+	return tids, nil
+}
 
-	if resumed == 0 {
+func resumeThreadIDs(pid int, tids []uint32) error {
+	opened := 0
+	resumed := 0
+	var firstErr error
+
+	for _, tid := range tids {
+		h, openErr := openThreadFn(tid)
+		if openErr != nil {
+			if firstErr == nil {
+				firstErr = openErr
+			}
+			continue
+		}
+		opened++
+		_, resumeErr := resumeFn(h)
+		windows.CloseHandle(h)
+		if resumeErr != nil {
+			if firstErr == nil {
+				firstErr = resumeErr
+			}
+			continue
+		}
+		resumed++
+	}
+
+	if opened == 0 {
+		if firstErr != nil {
+			return fmt.Errorf("no threads opened for pid %d: %w", pid, firstErr)
+		}
 		return fmt.Errorf("no threads found for pid %d", pid)
+	}
+	if resumed == 0 {
+		return fmt.Errorf("failed to resume any thread for pid %d: %w", pid, firstErr)
+	}
+	if resumed < opened {
+		fmt.Fprintf(os.Stderr, "tsgonest: resumed %d/%d threads for pid %d (first failure: %v)\n",
+			resumed, opened, pid, firstErr)
 	}
 	return nil
 }

--- a/internal/runner/runner_windows_test.go
+++ b/internal/runner/runner_windows_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -483,6 +484,151 @@ func TestRunner_StartReturnsRealErrorWhenRetryFails(t *testing.T) {
 	}
 	if attempts != 1 {
 		t.Errorf("non-breakaway failures should NOT trigger the retry; attempts=%d", attempts)
+	}
+}
+
+// --- resumeProcessThreads unit tests (#153) ---
+//
+// These exercise the open/resume aggregation logic via the package-level
+// openThreadFn / resumeFn seams without spawning a real suspended process.
+
+func withResumeSeams(t *testing.T, openFn func(uint32) (windows.Handle, error), resFn func(windows.Handle) (uint32, error)) {
+	t.Helper()
+	prevOpen, prevRes := openThreadFn, resumeFn
+	openThreadFn = openFn
+	resumeFn = resFn
+	t.Cleanup(func() {
+		openThreadFn = prevOpen
+		resumeFn = prevRes
+	})
+}
+
+func TestResumeProcessThreads_AllSucceed(t *testing.T) {
+	openCalls := atomic.Int32{}
+	resumeCalls := atomic.Int32{}
+	withResumeSeams(t,
+		func(tid uint32) (windows.Handle, error) {
+			openCalls.Add(1)
+			return windows.Handle(uintptr(tid)), nil
+		},
+		func(h windows.Handle) (uint32, error) {
+			resumeCalls.Add(1)
+			return 1, nil
+		},
+	)
+
+	if err := resumeThreadIDs(1234, []uint32{10, 20, 30}); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got := openCalls.Load(); got != 3 {
+		t.Errorf("expected 3 open calls, got %d", got)
+	}
+	if got := resumeCalls.Load(); got != 3 {
+		t.Errorf("expected 3 resume calls, got %d", got)
+	}
+}
+
+func TestResumeProcessThreads_AllFail(t *testing.T) {
+	sentinel := errors.New("simulated ResumeThread failure")
+	withResumeSeams(t,
+		func(tid uint32) (windows.Handle, error) {
+			return windows.Handle(uintptr(tid)), nil
+		},
+		func(h windows.Handle) (uint32, error) {
+			return 0, sentinel
+		},
+	)
+
+	err := resumeThreadIDs(4321, []uint32{10, 20, 30})
+	if err == nil {
+		t.Fatal("expected error when all resumes fail, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to resume any thread") {
+		t.Errorf("expected 'failed to resume any thread' in error, got %v", err)
+	}
+}
+
+func TestResumeProcessThreads_PartialSuccess(t *testing.T) {
+	sentinel := errors.New("simulated first-thread failure")
+	var resumeCount atomic.Int32
+	withResumeSeams(t,
+		func(tid uint32) (windows.Handle, error) {
+			return windows.Handle(uintptr(tid)), nil
+		},
+		func(h windows.Handle) (uint32, error) {
+			n := resumeCount.Add(1)
+			if n == 1 {
+				return 0, sentinel
+			}
+			return 1, nil
+		},
+	)
+
+	stderrBack := os.Stderr
+	rPipe, wPipe, _ := os.Pipe()
+	os.Stderr = wPipe
+	t.Cleanup(func() { os.Stderr = stderrBack })
+
+	err := resumeThreadIDs(99, []uint32{1, 2, 3})
+
+	wPipe.Close()
+	buf := make([]byte, 4096)
+	n, _ := rPipe.Read(buf)
+	logged := string(buf[:n])
+
+	if err != nil {
+		t.Fatalf("expected nil error on partial success, got %v", err)
+	}
+	if !strings.Contains(logged, "resumed 2/3 threads for pid 99") {
+		t.Errorf("expected partial-success warning on stderr, got %q", logged)
+	}
+}
+
+func TestResumeProcessThreads_NoThreads(t *testing.T) {
+	withResumeSeams(t,
+		func(tid uint32) (windows.Handle, error) {
+			t.Fatalf("openThreadFn should not be called when tids is empty")
+			return 0, nil
+		},
+		func(h windows.Handle) (uint32, error) {
+			t.Fatalf("resumeFn should not be called when tids is empty")
+			return 0, nil
+		},
+	)
+
+	err := resumeThreadIDs(7, nil)
+	if err == nil {
+		t.Fatal("expected error when no threads are found, got nil")
+	}
+	if !strings.Contains(err.Error(), "no threads found for pid 7") {
+		t.Errorf("expected 'no threads found for pid 7', got %v", err)
+	}
+}
+
+func TestResumeProcessThreads_OpenFailsAll(t *testing.T) {
+	sentinel := errors.New("OpenThread denied")
+	withResumeSeams(t,
+		func(tid uint32) (windows.Handle, error) {
+			return 0, sentinel
+		},
+		func(h windows.Handle) (uint32, error) {
+			t.Fatalf("resumeFn should not be called when all opens fail")
+			return 0, nil
+		},
+	)
+
+	err := resumeThreadIDs(11, []uint32{1, 2})
+	if err == nil {
+		t.Fatal("expected error when every OpenThread fails, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no threads opened for pid 11") {
+		t.Errorf("expected 'no threads opened' in error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #153.

## Root cause

`internal/runner/runner_windows.go::resumeProcessThreads` walked the Toolhelp32 thread snapshot and called `windows.ResumeThread(th)` while *ignoring* its return value. The success counter `resumed` was incremented based on `OpenThread` — so as long as we could *open* a thread handle, we declared resume successful, even if `ResumeThread` actually returned `0xFFFFFFFF` (the documented failure value).

Result: if anti-malware, an EDR hook, sandbox restrictions, or a terminated-thread race caused even one `ResumeThread` to fail, the child process stayed suspended. The runner returned no error, so the dev-loop thought "process started." The user saw `starting...` for the full 5-second graceful-shutdown timeout, then `TerminateProcess` fired and the dev session looked broken.

## Fix

Track `opened` and `resumed` counts separately. Wrap `ResumeThread` in `resumeThreadChecked`, which calls `procResumeThread.Call` directly and treats `0xFFFFFFFF` as an error even when the `x/sys` wrapper happens not to surface one (defensive against future wrapper changes — current `x/sys@v0.43.0` does set err, but we shouldn't rely on it).

Three failure modes, three distinct errors:

- `opened == 0` → "no threads found for pid N" (or wraps the open error if every open failed)
- `resumed == 0 && opened > 0` → "failed to resume any thread for pid N: <first err>"
- `resumed < opened` → log a warning to stderr but return nil (best-effort; the main thread is almost always the first one resumed and usually succeeds)

Refactored the Toolhelp32 enumeration into `snapshotThreadIDsForPID` and the open/resume loop into `resumeThreadIDs(pid, tids)`. Two package-level seams (`openThreadFn`, `resumeFn`) let unit tests inject deterministic behavior without spawning a real suspended Windows process.

## Test plan

New Windows-only unit tests in `internal/runner/runner_windows_test.go`:

- `TestResumeProcessThreads_AllSucceed` — every resume returns nil; expect nil error and 3 open + 3 resume calls.
- `TestResumeProcessThreads_AllFail` — every resume returns sentinel error; expect wrapped sentinel and `failed to resume any thread` in the message.
- `TestResumeProcessThreads_PartialSuccess` — first resume fails, others succeed; expect nil error but a `resumed 2/3 threads for pid 99` warning on stderr (verified via stderr pipe capture).
- `TestResumeProcessThreads_NoThreads` — empty TID list; expect `no threads found for pid 7`, no calls to either seam.
- `TestResumeProcessThreads_OpenFailsAll` — every open fails; expect wrapped sentinel and `no threads opened for pid 11`.

### Local verification

- [x] `gofmt -w cmd internal` — clean
- [x] `GOOS=windows GOARCH=amd64 go vet ./internal/runner/...` — clean
- [x] `GOOS=windows GOARCH=amd64 go test -c ./internal/runner/` — Windows test binary compiles
- [x] `go test -count=1 ./internal/runner/...` — all existing non-Windows tests pass
- [ ] Windows CI must confirm new unit tests pass on actual Windows runner

The pre-existing `-race` failures in `TestRunner_StartStop` / `TestRunner_Restart` reproduce on `main@f05cb00` and are documented as KNOWN ISSUE G in `runner_test.go` — not introduced by this change, owned by a separate fix.

## Coordination note

Scoped strictly to `resumeProcessThreads` and a new helper, plus the new test seams + unit tests. No changes to `Start`, `Stop`, `Wait`, `closeJob`, or any other code path also touched by the parallel agents working on #144, #146, #150, #155, #157.