### PR TITLE
fix(buildcache): handle Windows rename contention (#156)

### DIFF
--- a/cmd/tsgonest/build.go
+++ b/cmd/tsgonest/build.go
@@ -124,6 +124,25 @@ func runBuildWithIncr(args []string, oldIncrProgram *shimincremental.Program, ou
 	return runBuildWithIncrAndProgram(args, oldIncrProgram, outIncrProgram, nil)
 }
 
+// sweepBuildCacheTmp removes any orphaned .tsgonest-cache.tmp files left by a
+// previous build that was interrupted before the atomic rename completed.
+// This is cheap and idempotent; errors are silently ignored.
+func sweepBuildCacheTmp(outDir string) {
+	if outDir == "" {
+		return
+	}
+	// Match both ".tsgonest-cache.tmp" and numbered variants like ".tsgonest-cache.tmp.123".
+	for _, pattern := range []string{
+		filepath.Join(outDir, ".tsgonest-cache.tmp"),
+		filepath.Join(outDir, ".tsgonest-cache.tmp.*"),
+	} {
+		matches, _ := filepath.Glob(pattern)
+		for _, m := range matches {
+			_ = os.Remove(m)
+		}
+	}
+}
+
 // runBuildWithIncrAndProgram is the core build pipeline. When prebuiltProgram is
 // non-nil (from UpdateProgram fast path), it skips CreateProgramFromConfig —
 // avoiding re-reading and re-parsing all source files.
@@ -208,6 +227,9 @@ func runBuildWithIncrAndProgram(args []string, oldIncrProgram *shimincremental.P
 		resolvedTsconfigPath = filepath.Join(cwd, resolvedTsconfigPath)
 	}
 	postCachePath := buildcache.CachePath(opts.OutDir, resolvedTsconfigPath)
+
+	// Sweep orphaned .tmp files before any build logic touches the cache.
+	sweepBuildCacheTmp(opts.OutDir)
 
 	// Clean output directory if requested (using parsed OutDir, no re-parsing needed)
 	if clean && opts.OutDir != "" {

--- a/cmd/tsgonest/build_test.go
+++ b/cmd/tsgonest/build_test.go
@@ -909,3 +909,37 @@ func TestCleanDir_DangerousPath(t *testing.T) {
 		}
 	}
 }
+
+// --- sweepBuildCacheTmp tests ---
+
+func TestRunBuild_SweepsTmpOrphans(t *testing.T) {
+	dir := t.TempDir()
+
+	orphan1 := filepath.Join(dir, ".tsgonest-cache.tmp")
+	orphan2 := filepath.Join(dir, ".tsgonest-cache.tmp.123")
+	keeper := filepath.Join(dir, ".tsgonest-cache")
+
+	for _, p := range []string{orphan1, orphan2, keeper} {
+		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sweepBuildCacheTmp(dir)
+
+	if _, err := os.Stat(orphan1); !os.IsNotExist(err) {
+		t.Error(".tsgonest-cache.tmp should be removed by sweep")
+	}
+	if _, err := os.Stat(orphan2); !os.IsNotExist(err) {
+		t.Error(".tsgonest-cache.tmp.123 should be removed by sweep")
+	}
+	if _, err := os.Stat(keeper); os.IsNotExist(err) {
+		t.Error(".tsgonest-cache (no .tmp suffix) should NOT be removed by sweep")
+	}
+}
+
+func TestRunBuild_SweepEmptyDir(t *testing.T) {
+	// Should not panic or error on an empty or nonexistent outDir
+	sweepBuildCacheTmp(t.TempDir())
+	sweepBuildCacheTmp("")
+}

--- a/internal/buildcache/cache.go
+++ b/internal/buildcache/cache.go
@@ -19,7 +19,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+// renameFn and removeFn are package-level vars so tests can inject fakes.
+var renameFn = os.Rename
+var removeFn = os.Remove
 
 // SchemaVersion is bumped when the cache format or analysis output format changes.
 // A mismatch forces a full rebuild, ensuring binary upgrades don't produce stale outputs.
@@ -76,6 +81,24 @@ func Load(path string) *Cache {
 	return &c
 }
 
+// renameWithRetry attempts os.Rename up to 5 times with exponential backoff.
+// Windows AV / file-indexer / OneDrive typically hold handles for 50–200 ms,
+// so a total budget of ~900 ms is sufficient without meaningfully slowing builds.
+func renameWithRetry(tmp, path string) error {
+	var lastErr error
+	for _, delay := range []time.Duration{0, 50 * time.Millisecond, 100 * time.Millisecond, 250 * time.Millisecond, 500 * time.Millisecond} {
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		if err := renameFn(tmp, path); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
 // Save writes the cache to disk atomically (write to temp, rename).
 // Returns an error if the write fails, but callers may choose to log and continue
 // (a failed cache save just means the next build won't benefit from caching).
@@ -97,9 +120,9 @@ func Save(path string, cache *Cache) error {
 		return fmt.Errorf("writing cache temp file: %w", err)
 	}
 
-	if err := os.Rename(tmp, path); err != nil {
-		// Clean up temp file on rename failure
-		os.Remove(tmp)
+	if err := renameWithRetry(tmp, path); err != nil {
+		_ = removeFn(tmp)  // best-effort: clean up the orphaned temp file
+		_ = removeFn(path) // ensure stale cache doesn't satisfy IsValid on the next build
 		return fmt.Errorf("renaming cache file: %w", err)
 	}
 

--- a/internal/buildcache/cache_test.go
+++ b/internal/buildcache/cache_test.go
@@ -1,6 +1,7 @@
 package buildcache
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -304,6 +305,91 @@ func TestSaveCreatesDirectory(t *testing.T) {
 	loaded := Load(nestedPath)
 	if loaded == nil {
 		t.Fatal("failed to load from nested directory")
+	}
+}
+
+func TestSave_RenameSuccess(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, ".tsgonest-cache")
+
+	c := New("hash", nil)
+	if err := Save(cachePath, c); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Error("cache file should exist after successful save")
+	}
+	if _, err := os.Stat(cachePath + ".tmp"); !os.IsNotExist(err) {
+		t.Error("tmp file should not exist after successful save")
+	}
+}
+
+func TestSave_RenameRetriesOnTransientFailure(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, ".tsgonest-cache")
+
+	calls := 0
+	orig := renameFn
+	t.Cleanup(func() { renameFn = orig })
+	renameFn = func(src, dst string) error {
+		calls++
+		if calls <= 2 {
+			return errors.New("transient: access denied")
+		}
+		return os.Rename(src, dst)
+	}
+
+	c := New("hash", nil)
+	if err := Save(cachePath, c); err != nil {
+		t.Fatalf("Save should succeed after retries, got: %v", err)
+	}
+	if calls < 3 {
+		t.Errorf("expected at least 3 rename calls (2 failures + 1 success), got %d", calls)
+	}
+	if _, err := os.Stat(cachePath + ".tmp"); !os.IsNotExist(err) {
+		t.Error("tmp file should not exist after eventual success")
+	}
+}
+
+func TestSave_RenameFailureRemovesStaleCache(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, ".tsgonest-cache")
+
+	// Pre-create a stale cache file on disk.
+	if err := os.WriteFile(cachePath, []byte(`{"v":1,"configHash":"old"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := renameFn
+	t.Cleanup(func() { renameFn = orig })
+	renameFn = func(_, _ string) error { return errors.New("access denied") }
+
+	c := New("new-hash", nil)
+	err := Save(cachePath, c)
+	if err == nil {
+		t.Fatal("Save should return error when rename always fails")
+	}
+
+	// Stale cache must be gone so the next build runs post-processing.
+	if _, statErr := os.Stat(cachePath); !os.IsNotExist(statErr) {
+		t.Error("stale cache file should be removed after permanent rename failure")
+	}
+}
+
+func TestSave_RenameFailureRemovesTmp(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, ".tsgonest-cache")
+
+	orig := renameFn
+	t.Cleanup(func() { renameFn = orig })
+	renameFn = func(_, _ string) error { return errors.New("access denied") }
+
+	c := New("hash", nil)
+	_ = Save(cachePath, c)
+
+	if _, err := os.Stat(cachePath + ".tmp"); !os.IsNotExist(err) {
+		t.Error("tmp file should be best-effort removed after permanent rename failure")
 	}
 }
 


### PR DESCRIPTION
Fixes #156

## Summary

- **Layer 1 — Retry**: `renameWithRetry` retries `os.Rename` up to 5 times with 0/50/100/250/500 ms back-off (~900 ms total budget). Windows Defender / file-indexer / OneDrive typically hold handles for 50–200 ms; this window covers it without meaningfully slowing builds on non-Windows.
- **Layer 2 — Invalidate stale cache**: on permanent rename failure, both the orphaned `.tsgonest-cache.tmp` and the existing `.tsgonest-cache` are removed. Without removing the old cache, the next warm build reads stale data and skips post-processing — silently serving outdated OpenAPI/SDK output.
- **Layer 3 — Orphan sweep**: `sweepBuildCacheTmp(outDir)` runs at the start of every build, removing any `.tsgonest-cache.tmp` or `.tsgonest-cache.tmp.*` orphans left by a previously interrupted build.

Test seam: `renameFn` and `removeFn` package-level vars allow injecting fakes without build tags or interfaces.

## Test plan

- [ ] `TestSave_RenameSuccess` — baseline: normal save leaves no `.tmp`
- [ ] `TestSave_RenameRetriesOnTransientFailure` — fake that fails the first 2 calls then succeeds; asserts success and no leftover `.tmp`
- [ ] `TestSave_RenameFailureRemovesStaleCache` — fake that always fails; asserts error returned AND stale cache file deleted
- [ ] `TestSave_RenameFailureRemovesTmp` — same, asserts `.tmp` also cleaned up
- [ ] `TestRunBuild_SweepsTmpOrphans` — pre-create `.tsgonest-cache.tmp` and `.tsgonest-cache.tmp.123`, call `sweepBuildCacheTmp`, assert both removed, `.tsgonest-cache` intact
- [ ] `TestRunBuild_SweepEmptyDir` — no panic on empty / nonexistent outDir
- [ ] `go test -race -count=1 ./internal/buildcache/... ./cmd/tsgonest/...` — passes clean