### PR TITLE
fix(configpoller): suppress double restart on atomic config save (#154)

### DIFF
--- a/internal/watcher/configpoller.go
+++ b/internal/watcher/configpoller.go
@@ -6,6 +6,20 @@ import (
 	"time"
 )
 
+// statFn is the os.Stat implementation used by WatchFiles.
+// Tests may replace it to inject transient or permanent errors.
+var statFn = os.Stat
+
+// statMu guards reads and writes to statFn so tests can safely swap it.
+var statMu sync.RWMutex
+
+func stat(name string) (os.FileInfo, error) {
+	statMu.RLock()
+	fn := statFn
+	statMu.RUnlock()
+	return fn(name)
+}
+
 // WatchFiles polls specific file paths for changes (modification, creation,
 // or deletion). When any watched file changes, onChange is called with the
 // file path. Returns a stop function that halts polling.
@@ -29,12 +43,16 @@ func WatchFiles(paths []string, pollInterval time.Duration, onChange func(path s
 				return
 			case <-ticker.C:
 				for _, path := range paths {
-					info, err := os.Stat(path)
+					info, err := stat(path)
 
 					oldTime := snapshot[path]
 					var newTime time.Time
 					if err == nil {
 						newTime = info.ModTime()
+					} else if !os.IsNotExist(err) {
+						// Transient: lock contention, AV scan, mid-rename window.
+						// Skip this poll; next poll will see the settled state.
+						continue
 					}
 					// zero → non-zero: file created
 					// non-zero → different: file modified
@@ -60,7 +78,7 @@ func WatchFiles(paths []string, pollInterval time.Duration, onChange func(path s
 func snapshotFiles(paths []string) map[string]time.Time {
 	snap := make(map[string]time.Time, len(paths))
 	for _, p := range paths {
-		info, err := os.Stat(p)
+		info, err := stat(p)
 		if err == nil {
 			snap[p] = info.ModTime()
 		}

--- a/internal/watcher/configpoller_test.go
+++ b/internal/watcher/configpoller_test.go
@@ -1,8 +1,10 @@
 package watcher
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -202,3 +204,169 @@ func TestWatchFiles_EmptyPaths(t *testing.T) {
 
 	stop() // Should not panic
 }
+
+// TestWatchFiles_TransientStatErrorSkipsPoll verifies that a non-ENOENT stat
+// error (e.g. lock contention, AV scan, mid-rename) is treated as transient:
+// onChange must NOT fire.
+func TestWatchFiles_TransientStatErrorSkipsPoll(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "tsconfig.json")
+	os.WriteFile(configFile, []byte(`{}`), 0644)
+
+	// Inject a stat function that returns a transient (non-ENOENT) error.
+	var callCount atomic.Int32
+	statMu.Lock()
+	orig := statFn
+	statFn = func(name string) (os.FileInfo, error) {
+		callCount.Add(1)
+		return nil, errors.New("sharing violation: file locked by another process")
+	}
+	statMu.Unlock()
+	t.Cleanup(func() {
+		statMu.Lock()
+		statFn = orig
+		statMu.Unlock()
+	})
+
+	changed := make(chan string, 1)
+	stop := WatchFiles([]string{configFile}, 50*time.Millisecond, func(path string) {
+		changed <- path
+	})
+	defer stop()
+
+	// Wait for several poll cycles.
+	time.Sleep(300 * time.Millisecond)
+
+	select {
+	case path := <-changed:
+		t.Errorf("onChange fired unexpectedly for %s on transient stat error", path)
+	default:
+		// Good — transient errors were skipped
+	}
+
+	if n := callCount.Load(); n == 0 {
+		t.Error("statFn was never called — test is not exercising the poller")
+	}
+}
+
+// TestWatchFiles_DeletionStillFires verifies that a real ENOENT (file removed
+// by the user) still triggers onChange exactly once.
+func TestWatchFiles_DeletionStillFires(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "tsconfig.json")
+	os.WriteFile(configFile, []byte(`{}`), 0644)
+
+	changed := make(chan string, 2)
+	stop := WatchFiles([]string{configFile}, 50*time.Millisecond, func(path string) {
+		changed <- path
+	})
+	defer stop()
+
+	// Let initial snapshot settle.
+	time.Sleep(100 * time.Millisecond)
+
+	os.Remove(configFile)
+
+	select {
+	case path := <-changed:
+		if path != configFile {
+			t.Errorf("expected %s, got %s", configFile, path)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("deletion not detected within 2s")
+	}
+
+	// Ensure only one callback fired (no double-fire for the deletion).
+	time.Sleep(150 * time.Millisecond)
+	select {
+	case extra := <-changed:
+		t.Errorf("spurious second callback for %s", extra)
+	default:
+		// Good
+	}
+}
+
+// TestWatchFiles_AtomicReplaceFiresOnce simulates the Windows atomic-save
+// pattern (delete + rename) and verifies that onChange fires at most once
+// for the net change, not twice (once for delete, once for re-create).
+//
+// The test controls timing by using a stat stub that sequences through phases:
+//  1. Initial: file exists (snapshot is taken with real mtime)
+//  2. Mid-rename polls (up to maxTransient): transient non-ENOENT error
+//  3. Post-rename polls: file exists again with a new mtime
+func TestWatchFiles_AtomicReplaceFiresOnce(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "tsconfig.json")
+	os.WriteFile(configFile, []byte(`{}`), 0644)
+
+	realInfo, err := os.Stat(configFile)
+	if err != nil {
+		t.Fatalf("setup stat failed: %v", err)
+	}
+	originalMtime := realInfo.ModTime()
+
+	// newMtime is what the file reports after the atomic replace.
+	newMtime := originalMtime.Add(2 * time.Second)
+
+	const maxTransient = 3
+	var pollCount atomic.Int32
+
+	statMu.Lock()
+	orig := statFn
+	statFn = func(name string) (os.FileInfo, error) {
+		n := int(pollCount.Add(1))
+		switch {
+		case n == 1:
+			// Snapshot poll: return original mtime so snapshot is non-zero.
+			return &fakeFileInfo{mtime: originalMtime}, nil
+		case n <= 1+maxTransient:
+			// Mid-rename window: transient error.
+			return nil, errors.New("sharing violation")
+		default:
+			// Post-rename: file settled with new mtime.
+			return &fakeFileInfo{mtime: newMtime}, nil
+		}
+	}
+	statMu.Unlock()
+	t.Cleanup(func() {
+		statMu.Lock()
+		statFn = orig
+		statMu.Unlock()
+	})
+
+	changed := make(chan string, 4)
+	stop := WatchFiles([]string{configFile}, 50*time.Millisecond, func(path string) {
+		changed <- path
+	})
+	defer stop()
+
+	// Wait long enough for snapshot + transient polls + at least one settled poll.
+	time.Sleep(time.Duration(1+maxTransient+2) * 60 * time.Millisecond)
+
+	var count int
+drain:
+	for {
+		select {
+		case <-changed:
+			count++
+		default:
+			break drain
+		}
+	}
+
+	if count != 1 {
+		t.Errorf("expected onChange to fire exactly once for atomic replace, got %d", count)
+	}
+}
+
+// fakeFileInfo is a minimal os.FileInfo used by the atomic-replace test.
+type fakeFileInfo struct {
+	mtime time.Time
+}
+
+func (f *fakeFileInfo) Name() string       { return "tsconfig.json" }
+func (f *fakeFileInfo) Size() int64        { return 0 }
+func (f *fakeFileInfo) Mode() os.FileMode  { return 0644 }
+func (f *fakeFileInfo) ModTime() time.Time { return f.mtime }
+func (f *fakeFileInfo) IsDir() bool        { return false }
+func (f *fakeFileInfo) Sys() any           { return nil }


### PR DESCRIPTION
## Summary

Fixes #154

**Root cause**: `configpoller.go` called `os.Stat` and treated _any_ error (including transient sharing-violation / mid-rename-window errors on Windows) as a file deletion by falling through to `newTime = zero`. On the next poll the file was back, which looked like a creation. One `MoveFileEx` atomic save → two `onChange` calls → two full dev-loop restarts.

**Fix** (1 meaningful line): when `os.Stat` returns an error that is _not_ `os.IsNotExist`, skip the current poll with `continue`. `ENOENT` remains a real deletion event (intentional for when the user actually removes their config).

A `statFn`/`statMu` seam was added so tests can inject controlled stat behaviour without touching the filesystem.

## Changes

- `internal/watcher/configpoller.go` — transient-error guard + `statFn`/`statMu`/`stat()` seam
- `internal/watcher/configpoller_test.go` — three new deterministic tests:
  - `TestWatchFiles_TransientStatErrorSkipsPoll` — non-ENOENT error → `onChange` never fires
  - `TestWatchFiles_DeletionStillFires` — real `os.Remove` → `onChange` fires exactly once
  - `TestWatchFiles_AtomicReplaceFiresOnce` — delete+rename sequence via stub → `onChange` fires exactly once (not twice)

## Test plan

```
GOWORK=off go test -race -count=10 ./internal/watcher/...
```

All new tests pass cleanly across all 10 runs (30 total with race detector enabled).

**Pre-existing flake**: `TestWatchFiles_StopsCleanly` remains ~10-30% flaky on `-count=10` — this is a separate pre-existing issue unrelated to this fix.