### PR TITLE
fix(runner): prevent r.done leak on Start() failures (#144)

### DIFF
--- a/internal/runner/runner_start_failure_test.go
+++ b/internal/runner/runner_start_failure_test.go
@@ -1,0 +1,88 @@
+package runner
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestRunner_StartFailureDoesNotLeakDone is the regression test for issue #144.
+//
+// Before the fix, runner_windows.go::Start() allocated r.done before several
+// error-prone steps (cmd.Start, OpenProcess, AssignProcessToJobObject,
+// resumeProcessThreads). On any of those failures the wait goroutine that
+// closes r.done was never spawned, so a subsequent r.Wait() would block
+// forever.
+//
+// The fix moves r.done allocation (and the wait goroutine spawn) to the very
+// last step of Start(), after all error-prone setup has succeeded. The same
+// shape was applied to runner_unix.go for symmetry.
+//
+// This test reproduces the failure mode by pointing Start() at a binary that
+// does not exist (cmd.Start fails) and asserts that Wait() returns promptly.
+func TestRunner_StartFailureDoesNotLeakDone(t *testing.T) {
+	r := New("/this/path/should/not/exist/tsgonest-runner-test-bogus", nil, "")
+
+	if err := r.Start(); err == nil {
+		r.Stop()
+		t.Fatal("Start() should have failed for nonexistent binary")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		r.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Wait() hung after Start() failure — r.done was leaked")
+	}
+}
+
+// TestRunner_StartFailureNoGoroutineLeak stress-tests issue #144 by repeatedly
+// failing Start() and asserting that no wait goroutines accumulate. Before the
+// fix, every failed Start() would also strand a closed-but-unreachable r.done
+// channel and (on Windows) a half-initialized cmd; after the fix, neither
+// resource is allocated until Start() succeeds end-to-end.
+func TestRunner_StartFailureNoGoroutineLeak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping goroutine-leak stress test in -short mode")
+	}
+
+	runtime.GC()
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		r := New("/this/path/should/not/exist/tsgonest-runner-test-bogus", nil, "")
+		if err := r.Start(); err == nil {
+			r.Stop()
+			t.Fatalf("iteration %d: Start() should have failed", i)
+		}
+
+		done := make(chan struct{})
+		go func() {
+			r.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(1 * time.Second):
+			t.Fatalf("iteration %d: Wait() hung after Start() failure", i)
+		}
+	}
+
+	runtime.GC()
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	final := runtime.NumGoroutine()
+	delta := final - baseline
+	if delta > 5 {
+		t.Errorf("goroutine count grew by %d after %d failed Start() iterations (baseline=%d, final=%d)",
+			delta, iterations, baseline, final)
+	}
+}

--- a/internal/runner/runner_unix.go
+++ b/internal/runner/runner_unix.go
@@ -20,13 +20,16 @@ func (r *Runner) Start() error {
 	r.cmd = r.newCmd()
 	r.cmd.SysProcAttr = sysProcAttr()
 
-	r.done = make(chan struct{})
-
 	if err := r.cmd.Start(); err != nil {
 		r.cmd = nil
 		return fmt.Errorf("starting process: %w", err)
 	}
 
+	// Allocate r.done and spawn the wait goroutine ONLY after all error-prone
+	// setup has succeeded. If cmd.Start fails, r.done stays as it was so
+	// Wait() will not block forever on a goroutine that was never spawned.
+	// See issue #144.
+	r.done = make(chan struct{})
 	r.alive.Store(true)
 
 	// Wait for process in background
@@ -49,6 +52,15 @@ func (r *Runner) stop() error {
 	r.stopped = true
 
 	if r.cmd == nil || r.cmd.Process == nil {
+		return nil
+	}
+
+	// If r.done is nil, Start() failed after cmd.Start() succeeded but before
+	// the wait goroutine was spawned (issue #144). Reap directly and return.
+	if r.done == nil {
+		r.cmd.Process.Kill()
+		_, _ = r.cmd.Process.Wait()
+		r.cmd = nil
 		return nil
 	}
 

--- a/internal/runner/runner_windows.go
+++ b/internal/runner/runner_windows.go
@@ -63,8 +63,6 @@ func (r *Runner) Start() error {
 		return fmt.Errorf("configuring job object: %w", err)
 	}
 
-	r.done = make(chan struct{})
-
 	if err := r.cmd.Start(); err != nil {
 		windows.CloseHandle(job)
 		r.cmd = nil
@@ -96,6 +94,12 @@ func (r *Runner) Start() error {
 		return fmt.Errorf("resuming process: %w", err)
 	}
 
+	// Allocate r.done and spawn the wait goroutine ONLY after all error-prone
+	// setup has succeeded. If any step above fails, r.done stays as it was
+	// (nil on first Start, or the closed channel from the previous run), so
+	// Wait() will not block forever waiting for a goroutine that was never
+	// spawned. See issue #144.
+	r.done = make(chan struct{})
 	r.alive.Store(true)
 
 	// Wait for process in background
@@ -119,6 +123,16 @@ func (r *Runner) stop() error {
 
 	if r.cmd == nil || r.cmd.Process == nil {
 		r.closeJob()
+		return nil
+	}
+
+	// If r.done is nil, Start() failed after cmd.Start() succeeded but before
+	// the wait goroutine was spawned (issue #144). The Start() error path
+	// already killed the process, so just clean up handles and return.
+	if r.done == nil {
+		r.cmd.Process.Kill()
+		r.closeJob()
+		r.cmd = nil
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #144.

## Root cause

`internal/runner/runner_windows.go::Start` allocated `r.done = make(chan struct{})` BEFORE several error-prone steps:

- `cmd.Start`
- `OpenProcess`
- `AssignProcessToJobObject`
- `resumeProcessThreads`

On any of those failures the wait goroutine (which is the only thing that ever closes `r.done`) was never spawned. `r.done` was left allocated-but-never-closed, and a subsequent `r.Wait()` would block forever. The same shape was present in `runner_unix.go` between the `r.done` allocation and `cmd.Start`.

## Fix (Option B from the issue)

Move `r.done = make(chan struct{})` and the wait goroutine spawn to the very last step of `Start()`, after every error-prone call has succeeded. Now no error path can leak the channel — the channel does not exist until the goroutine that will close it is also being spawned.

`Wait()` already correctly returned immediately when `r.done` was nil (the snapshot-then-nil-check pattern), so it needed no change.

`stop()` did need one guard: when `Start()` fails after `cmd.Start()` succeeded but before the wait goroutine spawns (Windows-specific — happens with `OpenProcess` / `AssignProcessToJobObject` / `resumeProcessThreads` failures), `r.cmd.Process` is non-nil while `r.done` is nil. Without the guard, `stop()` would block forever on a `<-r.done` receive on a nil channel. The added guard force-kills the process and reaps it directly.

## Test plan

- [x] New cross-platform test `TestRunner_StartFailureDoesNotLeakDone` — calls `Start()` with a nonexistent binary, asserts `Wait()` returns within 1s
- [x] New cross-platform stress test `TestRunner_StartFailureNoGoroutineLeak` — 100 iterations of failed Start → Wait, asserts goroutine count delta ≤ 5
- [x] `gofmt -w cmd internal` — clean
- [x] `go test -count=10 ./internal/runner/...` — passes
- [x] `go test -race -count=10 -run 'TestRunner_StartFailure' ./internal/runner/...` — passes
- [x] `GOOS=windows go vet ./internal/runner/...` — clean
- [x] `GOOS=windows go test -c ./internal/runner/` — Windows test binary compiles

The pre-existing data race in `TestRunner_Restart` and `TestRunner_StartStop` (KNOWN ISSUE G — `Running()` reads `cmd.ProcessState` concurrently with `cmd.Wait()`) reproduces with `-race` on `main` before this change too. That is the subject of the parallel PR #165 (#134), not this one.

## Coordination notes

Scope kept narrow per the issue's instructions:

- `runner_windows.go` is also touched by parallel agents for #146, #150, #153, #155, #157
- This PR changes only the timing of `r.done` allocation and the corresponding nil-channel guard in `stop()`. It does not touch error-path cleanup (#155), `GenerateConsoleCtrlEvent` return-value handling (#146), Job Object breakaway (#150), `ResumeThread` semantics (#153), or `stop()` mutex usage (#157).