### PR TITLE
fix(dev): handle backslash separators in --entry path (#160)

### DIFF
--- a/cmd/tsgonest/dev.go
+++ b/cmd/tsgonest/dev.go
@@ -223,20 +223,12 @@ func runDevLoop(flags *devFlags, sigCh chan os.Signal) devLoopResult {
 	// Determine entry point (after build, so dist/ exists)
 	if entryPoint == "" {
 		entryPoint = detectEntryPoint(cwd)
-	} else if !filepath.IsAbs(entryPoint) && !strings.HasPrefix(entryPoint, "dist/") {
-		if !strings.HasSuffix(entryPoint, ".js") {
-			entryPoint = entryPoint + ".js"
-		}
+	} else {
 		sourceRoot := "src"
 		if cfg != nil && cfg.SourceRoot != "" {
 			sourceRoot = cfg.SourceRoot
 		}
-		withSR := filepath.Join(cwd, "dist", sourceRoot, entryPoint)
-		if _, err := os.Stat(withSR); err == nil {
-			entryPoint = withSR
-		} else {
-			entryPoint = filepath.Join(cwd, "dist", entryPoint)
-		}
+		entryPoint = resolveEntryPoint(entryPoint, cwd, sourceRoot, os.Stat)
 	}
 
 	// Resolve runtime: CLI flag > config > default "node"
@@ -645,4 +637,38 @@ func pickExecShellFor(goos, execCmd string) (string, []string) {
 
 func pickExecShell(execCmd string) (string, []string) {
 	return pickExecShellFor(runtime.GOOS, execCmd)
+}
+
+// hasDistPrefix reports whether p already refers to a path inside (or equal to)
+// the "dist" directory. Separator-normalized so that Windows backslash paths
+// like "dist\main.js" are treated the same as "dist/main.js".
+func hasDistPrefix(p string) bool {
+	n := filepath.ToSlash(p)
+	return strings.HasPrefix(n, "dist/") || n == "dist"
+}
+
+// resolveEntryPoint turns a relative, non-absolute entry point string into an
+// absolute path under <cwd>/dist. statFn is injectable for testing.
+//
+// Rules:
+//   - Absolute paths are returned unchanged.
+//   - Paths that already start with "dist/" (or "dist\" on Windows) are
+//     returned unchanged; they will be made absolute by the caller if needed.
+//   - Otherwise: append ".js" if missing, probe <cwd>/dist/<sourceRoot>/<entry>,
+//     fall back to <cwd>/dist/<entry>.
+func resolveEntryPoint(entry, cwd, sourceRoot string, statFn func(string) (os.FileInfo, error)) string {
+	if filepath.IsAbs(entry) {
+		return entry
+	}
+	if hasDistPrefix(entry) {
+		return entry
+	}
+	if !strings.HasSuffix(entry, ".js") {
+		entry = entry + ".js"
+	}
+	withSR := filepath.Join(cwd, "dist", sourceRoot, entry)
+	if _, err := statFn(withSR); err == nil {
+		return withSR
+	}
+	return filepath.Join(cwd, "dist", entry)
 }

--- a/cmd/tsgonest/dev_test.go
+++ b/cmd/tsgonest/dev_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// ── hasDistPrefix ────────────────────────────────────────────────────────────
+
+func TestHasDistPrefix(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		// Forward-slash forms (all platforms)
+		{"dist/main.js", true},
+		{"dist/sub/x.js", true},
+		{"dist", true},
+
+		// Must NOT match — different prefix
+		{"main.js", false},
+		{"notdist/x.js", false},
+		{"dist-extra/x.js", false}, // substring trap: "dist-" is not "dist/"
+		{"src/main.js", false},
+		{"", false},
+	}
+
+	// On Windows, backslash is the path separator so filepath.ToSlash converts it.
+	if runtime.GOOS == "windows" {
+		cases = append(cases,
+			struct {
+				input string
+				want  bool
+			}{`dist\main.js`, true},
+			struct {
+				input string
+				want  bool
+			}{`dist\sub\x.js`, true},
+			struct {
+				input string
+				want  bool
+			}{`dist\`, true},
+		)
+	}
+
+	for _, tc := range cases {
+		got := hasDistPrefix(tc.input)
+		if got != tc.want {
+			t.Errorf("hasDistPrefix(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+// ── resolveEntryPoint ────────────────────────────────────────────────────────
+
+// noStat always returns "not found" — simulates the withSR probe failing.
+func noStat(string) (os.FileInfo, error) { return nil, errors.New("not found") }
+
+// yesStat always succeeds — simulates the withSR probe succeeding.
+func yesStat(string) (os.FileInfo, error) { return nil, nil }
+
+func TestResolveEntryPoint_AbsolutePassthrough(t *testing.T) {
+	abs := filepath.Join(string(filepath.Separator), "absolute", "path", "main.js")
+	got := resolveEntryPoint(abs, "/some/cwd", "src", noStat)
+	if got != abs {
+		t.Errorf("absolute path should be returned unchanged; got %q", got)
+	}
+}
+
+func TestResolveEntryPoint_AlreadyUnderDist_ForwardSlash(t *testing.T) {
+	got := resolveEntryPoint("dist/main.js", "/cwd", "src", noStat)
+	if got != "dist/main.js" {
+		t.Errorf("dist/ path should be returned unchanged; got %q", got)
+	}
+}
+
+func TestResolveEntryPoint_BareRelative_FallsBackToDist(t *testing.T) {
+	cwd := "/project"
+	got := resolveEntryPoint("main.js", cwd, "src", noStat)
+	want := filepath.Join(cwd, "dist", "main.js")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveEntryPoint_BareRelative_NoExtension_FallsBackToDist(t *testing.T) {
+	cwd := "/project"
+	got := resolveEntryPoint("main", cwd, "src", noStat)
+	want := filepath.Join(cwd, "dist", "main.js")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveEntryPoint_BareRelative_UsesSourceRoot(t *testing.T) {
+	cwd := "/project"
+	// yesStat means the withSR probe succeeds
+	got := resolveEntryPoint("main.js", cwd, "src", yesStat)
+	want := filepath.Join(cwd, "dist", "src", "main.js")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveEntryPoint_BareRelative_CustomSourceRoot(t *testing.T) {
+	cwd := "/project"
+	got := resolveEntryPoint("main.js", cwd, "lib", yesStat)
+	want := filepath.Join(cwd, "dist", "lib", "main.js")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestResolveEntryPoint_WindowsBackslash_NeverDoublesDistPrefix is the core
+// regression for #160. On Windows a user may type --entry 'dist\main.js'.
+// With the old byte-exact HasPrefix("dist/") check this would enter the
+// prefixing branch and produce <cwd>\dist\src\dist\main.js (doubled dist).
+// hasDistPrefix normalizes separators first, so the path is left unchanged.
+func TestResolveEntryPoint_WindowsBackslash_NeverDoublesDistPrefix(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("backslash as path separator only applies on Windows")
+	}
+	cwd := `C:\project`
+	input := `dist\main.js`
+	got := resolveEntryPoint(input, cwd, "src", noStat)
+	normalized := filepath.ToSlash(got)
+	if strings.Contains(normalized, "dist/dist") {
+		t.Errorf("double dist in resolved path: %q (input %q)", got, input)
+	}
+	if got != input {
+		t.Errorf(`dist\ path should be returned unchanged; got %q`, got)
+	}
+}


### PR DESCRIPTION
Fixes #160

## Root cause

`runDevLoop` checked `strings.HasPrefix(entryPoint, "dist/")` to detect whether the user already supplied a `dist/`-rooted path. On Windows the path separator is `\`, so `dist\main.js` failed the byte-exact check and entered the prefixing branch, producing `<cwd>\dist\src\dist\main.js` (doubled `dist`).

## Fix

- Added `hasDistPrefix(p string) bool` that normalizes separators with `filepath.ToSlash` before the prefix check, so both `dist/main.js` and `dist\main.js` are recognized correctly.
- Extracted the resolution logic into `resolveEntryPoint(entry, cwd, sourceRoot string, statFn func(string)(os.FileInfo,error)) string` with an injectable stat function for clean unit testing. Absolute paths and already-dist-prefixed paths are returned unchanged; only bare relative entries go through the `dist/<sourceRoot>/` probe + `dist/` fallback.
- Scope is strictly the entry-point resolution — no other changes to dev.go.

## Test plan

- `TestHasDistPrefix`: table-driven covering `dist/main.js`, `dist/sub/x.js`, `dist`, `dist-extra/x.js` (must NOT match), `notdist/x.js` (must NOT match); backslash cases gated on `runtime.GOOS == "windows"`.
- `TestResolveEntryPoint_*`: covers absolute passthrough, `dist/`-prefixed passthrough, bare relative with/without extension, sourceRoot probe success, custom sourceRoot, and the Windows-backslash regression (skipped on non-Windows).
- All pass: `go test -race -count=1 ./cmd/tsgonest/...` ✓