### PR TITLE
fix(runner): release runner mutex during graceful-stop wait (#157)

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -20,11 +20,19 @@ type Runner struct {
 	// manual restart ("rs") commands without the child consuming input.
 	DisableStdin bool
 
-	mu        sync.Mutex
-	cmd       *exec.Cmd
-	done      chan struct{}
-	stopped   bool    // set by Stop(); prevents Start() after explicit shutdown
-	jobHandle uintptr // Windows Job Object handle; unused on other platforms
+	mu      sync.Mutex
+	cmd     *exec.Cmd
+	done    chan struct{}
+	stopped bool // set by Stop(); prevents Start() after explicit shutdown
+	// stopFinished is non-nil while a stop() invocation is mid-flight.
+	// It closes once the initiating stop() has finished both the kill wait
+	// and its post-wait state cleanup. Concurrent Stop() callers see a
+	// non-nil stopFinished and wait on it instead of issuing duplicate
+	// signals. This is what releases the mutex across the up-to-5s wait
+	// without exposing a window where another goroutine can observe the
+	// runner mid-cleanup.
+	stopFinished chan struct{}
+	jobHandle    uintptr // Windows Job Object handle; unused on other platforms
 
 	// alive is read by Running() without holding r.mu. The stdlib mutates
 	// cmd.ProcessState from inside cmd.Wait() without our lock, so reading

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -243,3 +243,112 @@ func TestRunner_RunningAfterExit(t *testing.T) {
 		t.Error("expected process to not be running after exit")
 	}
 }
+
+// TestRunnerStop_RunningCallsDontBlockBehindWait verifies that callers of
+// r.mu (e.g. Wait()) do not block on Stop()'s 5s graceful-kill wait. We
+// start a child that ignores SIGTERM, fire Stop() in a goroutine, and assert
+// a competing r.mu acquisition returns within 100ms even though Stop() is
+// mid-wait. We acquire r.mu directly rather than calling Running(), because
+// Running() has an orthogonal data race on cmd.ProcessState (KNOWN ISSUE G,
+// fixed separately by #134).
+func TestRunnerStop_RunningCallsDontBlockBehindWait(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test (requires 5s SIGTERM timeout)")
+	}
+
+	script := `trap '' TERM; while true; do sleep 300 & wait $!; done`
+	r := New("sh", []string{"-c", script}, "")
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	stopDone := make(chan struct{})
+	stopStart := time.Now()
+	go func() {
+		r.Stop()
+		close(stopDone)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	muAcquired := make(chan struct{})
+	go func() {
+		r.mu.Lock()
+		_ = r.cmd
+		r.mu.Unlock()
+		close(muAcquired)
+	}()
+
+	select {
+	case <-muAcquired:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("r.mu acquisition blocked behind Stop()'s graceful-kill wait — mutex held across 5s timer")
+	}
+
+	<-stopDone
+	if elapsed := time.Since(stopStart); elapsed < 4*time.Second {
+		t.Logf("Stop() returned in %v (process may have been killed by SIGKILL fallback)", elapsed)
+	}
+}
+
+// TestRunnerStop_ConcurrentStopsDoNotDoubleKill fires 10 simultaneous Stop()
+// calls and asserts they all return promptly without errors and without
+// triggering the race detector. Only one initiator issues the actual kill;
+// the rest serialize on r.stopFinished.
+func TestRunnerStop_ConcurrentStopsDoNotDoubleKill(t *testing.T) {
+	r := New("sleep", []string{"300"}, "")
+	if err := r.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	var errCount atomic.Int32
+	var ready sync.WaitGroup
+	ready.Add(goroutines)
+	gate := make(chan struct{})
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			ready.Done()
+			<-gate
+			if err := r.Stop(); err != nil {
+				errCount.Add(1)
+				t.Errorf("concurrent Stop returned error: %v", err)
+			}
+		}()
+	}
+
+	ready.Wait()
+	close(gate)
+
+	doneAll := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneAll)
+	}()
+
+	select {
+	case <-doneAll:
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent Stop() calls did not all complete within 10s — deadlock or contention")
+	}
+
+	if errCount.Load() != 0 {
+		t.Fatalf("expected zero errors from %d concurrent Stop calls, got %d", goroutines, errCount.Load())
+	}
+
+	r.mu.Lock()
+	stopFinishedNow := r.stopFinished
+	cmdNow := r.cmd
+	r.mu.Unlock()
+	if stopFinishedNow != nil {
+		t.Error("r.stopFinished should be nil after all Stop() calls return")
+	}
+	if cmdNow != nil {
+		t.Error("r.cmd should be nil after Stop()")
+	}
+}

--- a/internal/runner/runner_unix.go
+++ b/internal/runner/runner_unix.go
@@ -45,52 +45,81 @@ func (r *Runner) Start() error {
 }
 
 // stop stops the child process gracefully, with a force-kill timeout.
+//
+// The mutex is released across the up-to-5s graceful-shutdown wait so that
+// concurrent callers of Running(), Wait(), Restart() (and even another Stop())
+// do not block behind us. r.stopFinished serializes Stop() callers: a second
+// Stop() entering while the first is mid-wait waits on the initiator's
+// stopFinished channel — which closes only after cleanup completes — so
+// secondary callers never observe the runner mid-cleanup or race with a
+// follow-up Restart's Start.
 func (r *Runner) stop() error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.stopped = true
 
 	if r.cmd == nil || r.cmd.Process == nil {
+		r.stopped = true
+		r.mu.Unlock()
 		return nil
 	}
 
 	// If r.done is nil, Start() failed after cmd.Start() succeeded but before
-	// the wait goroutine was spawned (issue #144). Reap directly and return.
+	// the wait goroutine was spawned (issue #144). Reap directly and return —
+	// there is no wait goroutine to signal, so the stopFinished dance is
+	// unnecessary.
 	if r.done == nil {
+		r.stopped = true
 		r.cmd.Process.Kill()
 		_, _ = r.cmd.Process.Wait()
 		r.cmd = nil
+		r.mu.Unlock()
 		return nil
 	}
 
-	// Kill the process group
-	pgid, pgidErr := syscall.Getpgid(r.cmd.Process.Pid)
+	if r.stopFinished != nil {
+		wait := r.stopFinished
+		r.mu.Unlock()
+		<-wait
+		return nil
+	}
+
+	finished := make(chan struct{})
+	r.stopFinished = finished
+	r.stopped = true
+	cmd := r.cmd
+	done := r.done
+	r.mu.Unlock()
+
+	pgid, pgidErr := syscall.Getpgid(cmd.Process.Pid)
 	if pgidErr == nil {
 		if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
+			r.mu.Lock()
+			r.stopFinished = nil
+			r.mu.Unlock()
+			close(finished)
 			return fmt.Errorf("sending SIGTERM to process group: %w", err)
 		}
 	} else {
-		r.cmd.Process.Signal(syscall.SIGTERM)
+		cmd.Process.Signal(syscall.SIGTERM)
 	}
 
-	// Wait for it to stop (with timeout)
+	var retErr error
 	select {
-	case <-r.done:
-		r.cmd = nil
-		return nil
+	case <-done:
 	case <-time.After(5 * time.Second):
-		// Force kill
 		if pgidErr == nil {
 			if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
-				r.cmd = nil
-				return fmt.Errorf("force-killing process group: %w", err)
+				retErr = fmt.Errorf("force-killing process group: %w", err)
 			}
 		} else {
-			r.cmd.Process.Kill()
+			cmd.Process.Kill()
 		}
-		<-r.done
-		r.cmd = nil
-		return nil
+		<-done
 	}
+
+	r.mu.Lock()
+	r.cmd = nil
+	r.stopFinished = nil
+	r.mu.Unlock()
+	close(finished)
+	return retErr
 }

--- a/internal/runner/runner_windows.go
+++ b/internal/runner/runner_windows.go
@@ -167,52 +167,77 @@ func (r *Runner) Start() error {
 }
 
 // stop stops the child process gracefully, with a force-kill timeout.
+//
+// The mutex is released across the up-to-5s graceful-shutdown wait so that
+// concurrent callers of Running(), Wait(), Restart() (and even another Stop())
+// do not block behind us. r.stopFinished serializes Stop() callers: a second
+// Stop() entering while the first is mid-wait waits on the initiator's
+// stopFinished channel — which closes only after cleanup completes — so
+// secondary callers never observe the runner mid-cleanup or race with the
+// follow-up Restart's Start.
 func (r *Runner) stop() error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.stopped = true
 
 	if r.cmd == nil || r.cmd.Process == nil {
+		r.stopped = true
 		r.closeJob()
+		r.mu.Unlock()
 		return nil
 	}
 
 	// If r.done is nil, Start() failed after cmd.Start() succeeded but before
 	// the wait goroutine was spawned (issue #144). The Start() error path
-	// already killed the process, so just clean up handles and return.
+	// already killed the process via cleanupSuspendedChild, but be defensive:
+	// kill again, close the job, and return without engaging the stopFinished
+	// dance because there is no wait goroutine to wake.
 	if r.done == nil {
+		r.stopped = true
 		r.cmd.Process.Kill()
 		r.closeJob()
 		r.cmd = nil
+		r.mu.Unlock()
 		return nil
 	}
 
-	// Try graceful shutdown via CTRL_BREAK_EVENT.
-	// Node.js handles this signal and can run cleanup code.
-	if err := generateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(r.cmd.Process.Pid)); err != nil {
-		// Signal not delivered (no console attached, wrong process group, etc.).
-		// Waiting 5s would be futile — r.done will never close on its own.
-		r.cmd.Process.Kill()
-		<-r.done
-		r.closeJob()
-		r.cmd = nil
+	if r.stopFinished != nil {
+		wait := r.stopFinished
+		r.mu.Unlock()
+		<-wait
 		return nil
 	}
 
-	select {
-	case <-r.done:
-		r.closeJob()
-		r.cmd = nil
-		return nil
-	case <-time.After(5 * time.Second):
-		// Graceful shutdown timed out — force kill
-		r.cmd.Process.Kill()
-		<-r.done
-		r.closeJob()
-		r.cmd = nil
-		return nil
+	finished := make(chan struct{})
+	r.stopFinished = finished
+	r.stopped = true
+	cmd := r.cmd
+	done := r.done
+	r.mu.Unlock()
+
+	// Try graceful shutdown via CTRL_BREAK_EVENT outside the mutex. Node.js
+	// handles this signal and can run cleanup code. If the signal cannot be
+	// delivered (no console attached, wrong process group, etc.) waiting 5s
+	// would be futile — done will never close on its own — so jump straight
+	// to Kill (issue #146).
+	ctrlErr := generateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(cmd.Process.Pid))
+	if ctrlErr != nil {
+		cmd.Process.Kill()
+		<-done
+	} else {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			cmd.Process.Kill()
+			<-done
+		}
 	}
+
+	r.mu.Lock()
+	r.closeJob()
+	r.cmd = nil
+	r.stopFinished = nil
+	r.mu.Unlock()
+	close(finished)
+	return nil
 }
 
 // closeJob closes the Windows Job Object handle.


### PR DESCRIPTION
Fixes #157.

## Root cause

`Runner.stop()` (both `runner_windows.go` and `runner_unix.go`) acquired `r.mu` on entry and held it for the entire up-to-5s graceful-shutdown wait. While that wait was in flight, every other `r.mu` caller — `Running()`, `Wait()`, `Restart()`, even another `Stop()` — was blocked. On Windows the 5s fallback fires regularly because `CTRL_BREAK_EVENT` is silently dropped when the parent has no console (see #146), so users routinely felt 5s+ stalls when querying state during shutdown.

## Fix

Release `r.mu` immediately after capturing the local `cmd` handle and `done` channel; only the brief state-mutation phases (entry-check and post-wait cleanup) hold the lock.

For `Stop()` serialization, introduce `r.stopFinished` — a per-invocation `chan struct{}` that the initiating `stop()` closes only after its cleanup completes. Concurrent `Stop()` callers see a non-nil `r.stopFinished`, drop the lock, and wait on that channel. Crucially, they do **not** wait on `r.done` directly: that would let a follow-up `Restart()` race with the initiator's `r.cmd = nil` write (the new Wait goroutine spawned by Start would read `r.cmd` while the old initiator still owned the cleanup). Waiting on `stopFinished` guarantees secondary callers observe a fully-cleaned state.

The same pattern is applied symmetrically to `runner_unix.go` since it had the identical mutex-held-across-wait bug.

## Tests

- `TestRunnerStop_RunningCallsDontBlockBehindWait` — runs a child that ignores `SIGTERM`, fires `Stop()` in a goroutine, and asserts a competing `r.mu` acquisition returns within 100ms despite Stop() being mid-wait. (We acquire `r.mu` directly rather than through `Running()` because `Running()` has an orthogonal `cmd.ProcessState` race covered by #134.)
- `TestRunnerStop_ConcurrentStopsDoNotDoubleKill` — fires 10 simultaneous `Stop()` calls, asserts they all return without errors and without race-detector hits, and verifies `r.stopFinished` is nil and `r.cmd` is nil afterward.

`go test -race -count=10 ./internal/runner/...` passes for all stop-related tests. The two pre-existing race failures (`TestRunner_StartStop`, `TestRunner_Restart`) are KNOWN ISSUE G — `Running()` reads `cmd.ProcessState` concurrently with `cmd.Wait()` in the Start goroutine — and reproduce identically on `main`. They are out of scope for this PR and are addressed by #134/PR #165.

## Coordination

- **#134 (Running data race, PR #165)**: with this fix, `Running()` no longer blocks on `r.mu` for 5s. The `cmd.ProcessState` race fixed there is independent.
- **#146 (CTRL_BREAK return value)**: I did not change the `GenerateConsoleCtrlEvent` error handling — that stays for #146. My structural changes do move the call site outside the mutex, which should make integration with #146 straightforward.
- **#144 (`r.done` leak)**: my code captures `done := r.done` under the lock, compatible with both pre- and post-#144 behavior.
- **#155 (cleanup helper)**: the post-wait cleanup is a small block (`closeJob` / `r.cmd = nil` / `r.stopFinished = nil`), should compose cleanly with an extracted `cleanupSuspendedChild`.

Expected rebase conflicts: `runner_windows.go` and `runner_unix.go` `stop()` bodies overlap with parallel work on #144/#146/#150/#153/#155. The conflicts are localized to the stop() function.

## Test plan

- [x] `go test -race -count=10 -run 'TestRunnerStop_RunningCallsDontBlockBehindWait|TestRunnerStop_ConcurrentStopsDoNotDoubleKill' ./internal/runner/...`
- [x] `go test -race -count=10 -skip 'TestRunner_StartStop$|TestRunner_Restart$' ./internal/runner/...` (full pass; skipped tests are KNOWN ISSUE G, pre-existing on main)
- [x] `go test -count=10 ./internal/runner/...` (no -race)
- [x] `go vet ./internal/runner/...`
- [x] `go build ./...`
- [ ] Windows manual smoke: `tsgonest dev` + Ctrl+C — concurrent `Running()`/state queries should not stall