### PR TITLE
fix(watcher): use symlink-resolved paths in roots map

### DIFF
--- a/internal/watcher/edge_cases_test.go
+++ b/internal/watcher/edge_cases_test.go
@@ -157,6 +157,13 @@ func TestWatch_RootRemove_SurfacesError(t *testing.T) {
 // Create events for every file matching the configured extensions.
 func TestWatch_AtomicSubdirPopulation_FilesAreSynthesized(t *testing.T) {
 	root := t.TempDir()
+	// fsnotify reports events with EvalSymlinks-resolved paths (addRecursive
+	// resolves the watch root before adding). On macOS, t.TempDir() returns
+	// /var/folders/... which resolves to /private/var/folders/... — assertions
+	// must use the resolved form to match the synthesizer's emitted paths.
+	if r, err := filepath.EvalSymlinks(root); err == nil {
+		root = r
+	}
 
 	staging := filepath.Join(t.TempDir(), "package")
 	if err := os.MkdirAll(staging, 0755); err != nil {
@@ -214,6 +221,10 @@ func TestWatch_AtomicSubdirPopulation_FilesAreSynthesized(t *testing.T) {
 // multi-level package directory.
 func TestWatch_AtomicSubdirPopulation_DeeplyNested(t *testing.T) {
 	root := t.TempDir()
+	// See note in TestWatch_AtomicSubdirPopulation_FilesAreSynthesized.
+	if r, err := filepath.EvalSymlinks(root); err == nil {
+		root = r
+	}
 
 	staging := filepath.Join(t.TempDir(), "package")
 	want := []string{

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -146,12 +146,18 @@ func (w *Watcher) watchFsnotify() error {
 	defer fsw.Close()
 
 	// Capture the watch roots, normalized, so we can detect when one of
-	// them is renamed or removed mid-flight. Symlink-resolved paths are
-	// preferred because fsnotify reports events using the resolved path
-	// on platforms where the watch was added via a symlinked input.
+	// them is renamed or removed mid-flight. The key is symlink-resolved
+	// because addRecursive passes the EvalSymlinks-resolved path to
+	// fsnotify, and fsnotify reports event paths exactly as added — so the
+	// lookup side must match. The map value is the original (unresolved)
+	// dir so error messages show what the user configured.
 	roots := make(map[string]string, len(w.dirs))
 	for _, dir := range w.dirs {
-		roots[normalizeWatchPath(dir)] = dir
+		resolved := dir
+		if r, err := filepath.EvalSymlinks(dir); err == nil {
+			resolved = r
+		}
+		roots[normalizeWatchPath(resolved)] = dir
 	}
 
 	// Recursively add all directories under each watched root.


### PR DESCRIPTION
Fixes a regression introduced when the May 2026 watcher fix batch all landed on main. After PR #176 (#152, EvalSymlinks at watch root) and PR #170 (#132, root-rename detection) coexisted, four tests started failing:

- \`TestWatch_RootRename_SurfacesError\`
- \`TestWatch_RootRemove_SurfacesError\`
- \`TestWatch_AtomicSubdirPopulation_FilesAreSynthesized\`
- \`TestWatch_AtomicSubdirPopulation_DeeplyNested\`

## Root cause

\`addRecursive()\` resolves symlinks before calling \`fsnotify.Add\` (per #176). fsnotify reports event paths exactly as added, i.e. in the resolved form. The roots map (per #170) was keyed by \`normalizeWatchPath\` which is \`Abs+Clean\` only — never \`EvalSymlinks\`. On macOS, \`/var/folders/...\` resolves to \`/private/var/folders/...\`, so the lookup against the unresolved key always missed and \`ErrWatchRootGone\` was never returned.

The synthesizer (\`synthesizeCreatesForExistingFiles\`) emits paths reachable through fsnotify's resolved-path event — but the affected tests asserted on \`filepath.Join(root, ...)\` where \`root = t.TempDir()\` (unresolved). Path mismatch → no event observed.

## Fix

1. Resolve symlinks when building the roots map so the key matches what fsnotify will report. Keep the original dir as the value for human-readable error messages.
2. Update the two atomic-subdir tests to resolve \`root\` once at the top.

## Test plan

- [x] \`go test -race -count=1 ./internal/watcher/...\` clean
- [x] \`go test -race -count=1 ./internal/...\` clean
- [x] \`go test -race -count=1 ./cmd/...\` clean