### PR TITLE
chore(deps): scope dependabot to consumer-facing packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "dependencies"
       - "submodule"
@@ -19,6 +19,9 @@ updates:
       - "npm"
     commit-message:
       prefix: "chore(deps)"
+    exclude-paths:
+      - "apps/docs/**"
+      - "benchmarks/**"
+      - "testdata/**"
     ignore:
-      # Platform binary packages — versions managed by release workflow
       - dependency-name: "@tsgonest/cli-*"


### PR DESCRIPTION
## Summary
- Add `exclude-paths` so dependabot stops opening PRs for `apps/docs/**`, `benchmarks/**`, and `testdata/**` — these packages don't ship to npm consumers.
- Drop the gitsubmodule schedule from `daily` to `weekly` to cut typescript-go bump traffic (was ~5 PRs/week).
- Drop the narration comment on the existing `@tsgonest/cli-*` ignore rule.

## Test plan
- [ ] Merge and confirm next dependabot run skips apps/docs, benchmarks, and testdata.
- [ ] Confirm typescript-go submodule bumps drop to 1/week.