### PR TITLE
test(buildcache,pathalias): normalize path separators for Windows

### DIFF
--- a/internal/buildcache/cache_test.go
+++ b/internal/buildcache/cache_test.go
@@ -19,7 +19,7 @@ func TestCachePath(t *testing.T) {
 			{"dist", "tsconfig.json", "dist/.tsgonest-cache"},
 		}
 		for _, tt := range tests {
-			got := CachePath(tt.outDir, tt.tsconf)
+			got := filepath.ToSlash(CachePath(tt.outDir, tt.tsconf))
 			if got != tt.want {
 				t.Errorf("CachePath(%q, %q) = %q, want %q", tt.outDir, tt.tsconf, got, tt.want)
 			}
@@ -37,7 +37,7 @@ func TestCachePath(t *testing.T) {
 			{"tsconfig.json", "tsconfig.tsgonest-cache"},
 		}
 		for _, tt := range tests {
-			got := CachePath("", tt.tsconf)
+			got := filepath.ToSlash(CachePath("", tt.tsconf))
 			if got != tt.want {
 				t.Errorf("CachePath(\"\", %q) = %q, want %q", tt.tsconf, got, tt.want)
 			}
@@ -57,7 +57,7 @@ func TestBuildcache_CachePath_CaseInsensitive(t *testing.T) {
 		{"/foo/tsconfig.build.JSON", "/foo/tsconfig.build.tsgonest-cache"},
 	}
 	for _, tt := range tests {
-		got := CachePath("", tt.tsconf)
+		got := filepath.ToSlash(CachePath("", tt.tsconf))
 		if got != tt.want {
 			t.Errorf("CachePath(\"\", %q) = %q, want %q", tt.tsconf, got, tt.want)
 		}

--- a/internal/pathalias/pathalias_test.go
+++ b/internal/pathalias/pathalias_test.go
@@ -384,7 +384,7 @@ func TestSourceToOutput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.resolver.sourceToOutput(tt.srcPath)
+			got := filepath.ToSlash(tt.resolver.sourceToOutput(tt.srcPath))
 			if got != tt.want {
 				t.Errorf("sourceToOutput(%s) = %s, want %s", tt.srcPath, got, tt.want)
 			}
@@ -422,7 +422,7 @@ func TestInferRootDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := InferRootDir(tt.files)
+			got := filepath.ToSlash(InferRootDir(tt.files))
 			if got != tt.want {
 				t.Errorf("InferRootDir() = %q, want %q", got, tt.want)
 			}

--- a/justfile
+++ b/justfile
@@ -62,13 +62,13 @@ build:
 
 test: build
   go test -race ./internal/...
-  cd e2e && pnpm run test --run && cd ..
+  pnpm --dir e2e run test --run
 
 test-unit:
   go test -race ./internal/...
 
 test-e2e: build
-  cd e2e && pnpm run test --run && cd ..
+  pnpm --dir e2e run test --run
 
 fmt:
   gofmt -w internal cmd tools

--- a/justfile
+++ b/justfile
@@ -62,13 +62,13 @@ build:
 
 test: build
   go test -race ./internal/...
-  pnpm --dir e2e run test --run
+  cd e2e && pnpm run test --run && cd ..
 
 test-unit:
   go test -race ./internal/...
 
 test-e2e: build
-  pnpm --dir e2e run test --run
+  cd e2e && pnpm run test --run && cd ..
 
 fmt:
   gofmt -w internal cmd tools


### PR DESCRIPTION
## Summary
- Three tests had hardcoded forward-slash path expectations and compared directly against `filepath.Join`/`CachePath` output, which uses backslashes on Windows. The production code is correct — the tests were the bug.
- Wrap the actual values in `filepath.ToSlash` before comparing, so the table data stays forward-slash-readable while the comparison is platform-agnostic. No production code changed.

## What's covered
- `internal/buildcache/cache_test.go`: `TestCachePath/with_outDir`, `TestCachePath/without_outDir_fallback`, `TestBuildcache_CachePath_CaseInsensitive`
- `internal/pathalias/pathalias_test.go`: `TestSourceToOutput/rootDir_and_outDir`, `TestSourceToOutput/outDir_only`, `TestInferRootDir/all_under_src`, `TestInferRootDir/different_roots`, `TestInferRootDir/single_file`

## Test plan
- [x] `go test -race ./internal/buildcache/ ./internal/pathalias/` — passes locally on macOS (`filepath.ToSlash` is a no-op on Unix).
- [ ] `windows-latest` CI passes the previously-failing baseline tests.

Closes #188.