### PR TITLE
test(e2e): build integration fixture once via globalSetup with stderr capture

### DIFF
--- a/e2e/eventstream-no-companion.test.ts
+++ b/e2e/eventstream-no-companion.test.ts
@@ -26,7 +26,13 @@ let compiled = false;
 function ensureCompiled() {
   if (!compiled) {
     const result = buildIntegrationFixture();
-    expect(result.exitCode).toBe(0);
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `integration fixture build failed (exit ${result.exitCode}).\n` +
+          `--- stdout ---\n${result.stdout}\n` +
+          `--- stderr ---\n${result.stderr}\n`,
+      );
+    }
     compiled = true;
   }
 }

--- a/e2e/eventstream.test.ts
+++ b/e2e/eventstream.test.ts
@@ -12,7 +12,13 @@ let compiled = false;
 function ensureCompiled() {
   if (!compiled) {
     const result = buildIntegrationFixture();
-    expect(result.exitCode).toBe(0);
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `integration fixture build failed (exit ${result.exitCode}).\n` +
+          `--- stdout ---\n${result.stdout}\n` +
+          `--- stderr ---\n${result.stderr}\n`,
+      );
+    }
     compiled = true;
   }
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,63 @@
+/**
+ * Vitest globalSetup — compiles the shared `testdata/integration` fixture
+ * exactly once before any test files start. The compiled output is consumed
+ * by eventstream.test.ts, eventstream-no-companion.test.ts, and upload.test.ts.
+ *
+ * Why this exists: the previous in-test `buildIntegrationFixture()` used a
+ * filesystem marker to coordinate across parallel Vitest workers, but the
+ * check-then-write was TOCTOU-racy. Three test files calling it concurrently
+ * could each see the marker missing and all start `rmSync(distDir)` +
+ * `runTsgonest` against the same output directory — on Windows, the resulting
+ * file-lock collisions cause one or more workers to exit 1 (issue #199
+ * Cluster B). globalSetup runs in the main vitest process before workers fork,
+ * so the build cannot race with itself.
+ *
+ * If the build fails, the captured stdout/stderr is included in the thrown
+ * error so the failing CI run shows the actual tsgonest diagnostics instead
+ * of a bare `expected 1 to be 0`.
+ */
+import { rmSync, existsSync, writeFileSync } from "fs";
+import { resolve } from "path";
+import { runTsgonest, FIXTURES_DIR } from "./helpers";
+
+const INTEGRATION_DIR = resolve(FIXTURES_DIR, "integration");
+const INTEGRATION_DIST = resolve(INTEGRATION_DIR, "dist");
+const MARKER = resolve(INTEGRATION_DIST, ".tsgonest-e2e-built");
+
+export default async function setup() {
+  if (existsSync(INTEGRATION_DIST)) {
+    rmSync(INTEGRATION_DIST, { recursive: true, force: true });
+  }
+
+  const result = runTsgonest([
+    "--project",
+    "testdata/integration/tsconfig.json",
+    "--config",
+    "testdata/integration/tsgonest.config.json",
+  ]);
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `[e2e globalSetup] tsgonest failed to compile testdata/integration ` +
+        `(exit ${result.exitCode}).\n` +
+        `--- stdout ---\n${result.stdout}\n` +
+        `--- stderr ---\n${result.stderr}\n`,
+    );
+  }
+
+  if (!existsSync(INTEGRATION_DIST)) {
+    throw new Error(
+      `[e2e globalSetup] tsgonest exited 0 but ${INTEGRATION_DIST} was not created.\n` +
+        `--- stdout ---\n${result.stdout}\n` +
+        `--- stderr ---\n${result.stderr}\n`,
+    );
+  }
+
+  // Marker tells in-test ensureCompiled() helpers that the build is already
+  // done. Carries the build output so a stale marker (e.g. from a previous
+  // run) is distinguishable from one written this run.
+  writeFileSync(
+    MARKER,
+    JSON.stringify({ at: new Date().toISOString(), pid: process.pid }),
+  );
+}

--- a/e2e/integration-helpers.ts
+++ b/e2e/integration-helpers.ts
@@ -1,43 +1,43 @@
 import { spawn, type ChildProcess } from "child_process";
 import { resolve } from "path";
-import { rmSync, existsSync, writeFileSync } from "fs";
-import { runTsgonest, FIXTURES_DIR } from "./helpers";
+import { existsSync } from "fs";
+import { FIXTURES_DIR } from "./helpers";
 
 export const INTEGRATION_DIR = resolve(FIXTURES_DIR, "integration");
 export const INTEGRATION_DIST = resolve(INTEGRATION_DIR, "dist");
 
 /**
- * Compile the integration fixture with tsgonest.
- * Returns the build result for assertions.
+ * Returns a stub result indicating the integration fixture is already built.
  *
- * Uses a filesystem marker (.tsgonest-e2e-built) to coordinate across parallel
- * Vitest workers — only the first worker cleans and rebuilds. Others skip if
- * the marker already exists (indicating a recent build in this test run).
+ * The actual compile happens in `e2e/global-setup.ts` exactly once before any
+ * test files start. This function only checks the marker dropped by that
+ * global setup. If the marker is missing, the fixture was never built (e.g.
+ * vitest globalSetup misconfigured) — the helper returns exitCode 1 plus a
+ * descriptive stderr so the test failure surfaces the real problem rather
+ * than a bare `expected 1 to be 0`.
+ *
+ * Previous in-test build coordination (TOCTOU marker check + rmSync +
+ * runTsgonest in each worker) raced on Windows: parallel workers would each
+ * see the marker missing, all attempt to rebuild the same dist/, and collide
+ * on file locks (issue #199 Cluster B).
  */
 export function buildIntegrationFixture() {
-  const distDir = resolve(INTEGRATION_DIR, "dist");
-  const marker = resolve(distDir, ".tsgonest-e2e-built");
+  const marker = resolve(INTEGRATION_DIST, ".tsgonest-e2e-built");
 
-  // If another worker already compiled in this run, reuse it.
   if (existsSync(marker)) {
-    return { exitCode: 0, stdout: "(cached)", stderr: "" };
+    return { exitCode: 0, stdout: "(globalSetup cached)", stderr: "" };
   }
 
-  if (existsSync(distDir)) {
-    rmSync(distDir, { recursive: true });
-  }
-  const result = runTsgonest([
-    "--project",
-    "testdata/integration/tsconfig.json",
-    "--config",
-    "testdata/integration/tsgonest.config.json",
-  ]);
-
-  // Write marker so parallel workers skip recompilation.
-  if (result.exitCode === 0 && existsSync(distDir)) {
-    writeFileSync(marker, new Date().toISOString());
-  }
-  return result;
+  return {
+    exitCode: 1,
+    stdout: "",
+    stderr:
+      `integration fixture marker not found at ${marker}.\n` +
+      `globalSetup (e2e/global-setup.ts) is responsible for compiling the\n` +
+      `integration fixture before any test files start. Either globalSetup\n` +
+      `did not run (check vitest.config.ts), or the dist directory was\n` +
+      `wiped between setup and this test.`,
+  };
 }
 
 /**

--- a/e2e/upload.test.ts
+++ b/e2e/upload.test.ts
@@ -8,7 +8,13 @@ let compiled = false;
 function ensureCompiled() {
   if (!compiled) {
     const result = buildIntegrationFixture();
-    expect(result.exitCode).toBe(0);
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `integration fixture build failed (exit ${result.exitCode}).\n` +
+          `--- stdout ---\n${result.stdout}\n` +
+          `--- stderr ---\n${result.stderr}\n`,
+      );
+    }
     compiled = true;
   }
 }

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     testTimeout: 30000,
+    // Compile testdata/integration once before any test files start. See
+    // e2e/global-setup.ts for why this lives outside individual test files.
+    globalSetup: ["./global-setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Three integration test files (\`eventstream-no-companion\`, \`eventstream\`, \`upload\`) each spawn the tsgonest binary against the same \`testdata/integration\` fixture in their \`beforeAll\`. Vitest's default forks pool runs each in a separate worker, so the build runs three times. Move the build into a Vitest \`globalSetup\` hook that runs once before any worker starts, and capture stdout/stderr on failure.

## Note on the original hypothesis

This PR was opened as a candidate fix for #199 Cluster B under the theory that the three-way concurrent build was racing on Windows. **It is not.** With the diagnostic capture in place, CI now shows the real failure is a \`TS2307: Cannot find module '@tsgonest/runtime'\` for the pnpm workspace symlinks on Windows. See https://github.com/tsgonest/tsgonest/issues/199#issuecomment-4415132387 for the unified diagnosis.

## What this PR is, and isn't

- ✅ A build-once optimization (no reason to compile the same fixture three times).
- ✅ Diagnostic plumbing that surfaced the actual root cause and will keep doing so.
- ❌ A fix for Cluster B / Cluster C. Those need a Windows VM to investigate the junction / module-resolution behavior of \`tsgo\`.

Worth landing on those merits even though it does not close anything from #199.