### PR TITLE
chore(justfile): use pnpm --dir for e2e to fix Windows CI parser error

### DIFF
--- a/justfile
+++ b/justfile
@@ -62,13 +62,13 @@ build:
 
 test: build
   go test -race ./internal/...
-  cd e2e && pnpm run test --run && cd ..
+  pnpm --dir e2e run test --run
 
 test-unit:
   go test -race ./internal/...
 
 test-e2e: build
-  cd e2e && pnpm run test --run && cd ..
+  pnpm --dir e2e run test --run
 
 fmt:
   gofmt -w internal cmd tools


### PR DESCRIPTION
## Summary

\`just test-e2e\` runs \`cd e2e && pnpm run test --run && cd ..\`. On the GitHub Actions \`windows-latest\` runner, just defaults to Windows PowerShell 5.1, which does not accept \`&&\` as a statement separator. Every Windows CI run has been failing the e2e step at the parser stage, *before vitest ever ran* — so the e2e suite was never actually exercised on Windows.

\`pnpm --dir e2e run test --run\` runs the script in the target package without changing directories at all and works on every shell.

## Heads up

With the runner repaired, several pre-existing Windows-specific e2e failures surface. They are tracked in #199 and have in-flight fixes:
- #200 — Cluster A (\`dev-racecondition.test.ts\` EPERM tempdir cleanup)
- #201 — Cluster B (integration tests exit 1 / diagnostics)
- Cluster C (SDK + tsc compile failures) — not yet root-caused

This PR makes Windows CI accurately reflect those problems instead of hiding them. Merge with \`--admin\` is appropriate until the cluster PRs land.

## Test plan
- [x] \`just test-e2e\` runs locally on macOS (no regression).
- [ ] Windows CI now actually runs vitest (will be red until #200/#201/Cluster C land).

Closes #198.