### PR TITLE
fix(scripts): quote pnpm filter with double quotes for Windows (closes #199 cluster B/C)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "pnpm -r build",
-    "build:packages": "pnpm --filter './packages/**' build",
+    "build:packages": "pnpm --filter \"./packages/**\" build",
     "build:docs": "pnpm --filter docs build",
     "dev:docs": "pnpm --filter docs dev",
     "start:docs": "pnpm --filter docs start",


### PR DESCRIPTION
## Summary

`pnpm build:packages` silently matched zero workspace packages on Windows. The single-quoted pattern `'./packages/**'` survives bash/zsh quoting but cmd.exe (which Windows uses to spawn npm scripts) treats single quotes as literal, so pnpm received `'./packages/**'` (with quotes) as the filter and matched nothing. Without `packages/runtime/dist` on disk, every e2e fixture that imports `@tsgonest/runtime` cascaded into TS2307 — Cluster B and C of issue #199.

Switching to escaped double quotes makes cmd.exe strip them, pnpm sees the bare glob, all 10 workspace packages match.

## Verification

Tested on a Windows 11 ARM VM (PowerShell + cmd.exe via npm scripts):
- Before: `pnpm build:packages` → `No projects matched the filters in "C:\dev\tsgonest"`, runtime/dist absent
- After: 4 buildable packages compile, runtime/dist populated, e2e fixtures resolve `@tsgonest/runtime`

Re-running the e2e suite on Windows after the fix:
- `eventstream.test.ts`: 15/15 (was Cluster B failure)
- `eventstream-no-companion.test.ts`: 23/23 (was Cluster B failure)
- `upload.test.ts`: 12/12 (was Cluster B failure)
- `returns.test.ts`: 10/10 (was Cluster C failure)
- macOS: still 51/51 on the same files (no regression)

## Remaining Windows failures (separate root causes, follow-up)

7 tests still fail on Windows after this fix — they were previously masked by the TS2307 cascade:
- `sdk.test.ts > generated SDK compiles with tsc` (5): `spawnSync(tscBin)` doesn't pick up `.cmd` extension on Windows
- `migrate.test.ts` (2): `tsgonest migrate` output diverges from expectations on Windows

These need their own PRs.

## Test plan

- [x] Verified fix on Windows 11 ARM VM via SSH
- [x] Verified macOS still passes (51/51 on affected files)
- [x] CI will run the full matrix