### PR TITLE
test(sdk): invoke tsc via node tsc.js to fix Windows EINVAL

### DIFF
--- a/e2e/sdk.test.ts
+++ b/e2e/sdk.test.ts
@@ -194,9 +194,11 @@ describe("generated SDK compiles with tsc", () => {
       })
     );
 
-    // Use absolute path to tsc from e2e workspace's node_modules
-    const tscBin = resolve(__dirname, "node_modules/.bin/tsc");
-    const tscResult = spawnSync(tscBin, ["--noEmit", "--project", resolve(outputDir, "tsconfig.json")], {
+    // Invoke tsc.js with node directly. spawnSync can't run the .cmd shim on
+    // Windows without shell:true (Node CVE-2024-27980 mitigation), and
+    // node_modules/.bin/tsc lacks a recognized extension on Windows entirely.
+    const tscJs = resolve(__dirname, "node_modules/typescript/lib/tsc.js");
+    const tscResult = spawnSync(process.execPath, [tscJs, "--noEmit", "--project", resolve(outputDir, "tsconfig.json")], {
       cwd: outputDir,
       encoding: "utf-8",
       timeout: 30000,


### PR DESCRIPTION
## Summary

The SDK tsc-compiles tests failed on Windows with `expected 1 to be 0` and durations under 70ms — too fast for tsc to have run at all. Direct `spawnSync` of `node_modules/.bin/tsc` returned `EINVAL` because:

- Node 20.12+ refuses to spawn `.cmd`/`.bat` files directly without `shell: true` (CVE-2024-27980 mitigation).
- The bare `tsc` shim has no recognized extension on Windows.

Fix: invoke `tsc.js` with `process.execPath`. Works identically on every platform, avoids the `shell: true` quoting hazard.

## Verification

- macOS: 45/45 sdk.test.ts (no regression)
- Windows VM: 45/45 sdk.test.ts (was 5 failed, 40 passed)

## Test plan

- [x] Verified on Windows 11 ARM VM
- [x] macOS sdk tests still green
- [ ] CI matrix