### PR TITLE
fix(migrate): chdir to opts.cwd before globbing source files

### DIFF
--- a/packages/core/src/migrate/index.ts
+++ b/packages/core/src/migrate/index.ts
@@ -410,8 +410,12 @@ async function main(): Promise<void> {
     project = new Project({ compilerOptions: { strict: true } });
   }
 
+  // ts-morph's globber uses process.cwd() and its underlying tinyglobby does
+  // not accept absolute Windows-style paths as glob patterns. Switch to opts.cwd
+  // so the include globs resolve correctly on every platform.
+  process.chdir(cwd);
   for (const pattern of opts.include) {
-    project.addSourceFilesAtPaths(resolve(cwd, pattern));
+    project.addSourceFilesAtPaths(pattern);
   }
 
   const files = project.getSourceFiles();


### PR DESCRIPTION
## Summary

`tsgonest migrate --cwd <dir> --include 'src/**/*.ts'` matched zero files on Windows and exited with no transforms applied. ts-morph's underlying `tinyglobby` rejects absolute Windows-style paths used as glob patterns; passing the bare relative pattern with the wrong process cwd silently returned an empty match set.

Fix: `process.chdir(opts.cwd)` before adding source files. Migrate is a short-lived process spawned per invocation, so chdir is safe and matches the documented `--cwd` semantics.

## Verification

- macOS: 6/6 migrate.test.ts (no regression)
- Windows VM: 6/6 migrate.test.ts (was 2 failed: "should apply changes and write files" + "should auto-fix tsconfig.json")

## Test plan

- [x] Verified on Windows 11 ARM VM
- [x] macOS migrate tests still green
- [ ] CI matrix