### PR TITLE
fix: propagate alias-site JSDoc through type aliases and emit runtime constraint checks

### DIFF
--- a/e2e/incremental.test.ts
+++ b/e2e/incremental.test.ts
@@ -122,7 +122,7 @@ describe("tsgonest incremental post-processing cache", () => {
 
     expect(existsSync(cacheFile)).toBe(true);
     const cache = JSON.parse(readFileSync(cacheFile, "utf-8"));
-    expect(cache.v).toBe(1);
+    expect(cache.v).toBe(2);
     expect(cache.configHash).toBeTruthy();
     expect(cache.outputs).toBeInstanceOf(Array);
     expect(cache.outputs.length).toBeGreaterThanOrEqual(1);
@@ -218,7 +218,7 @@ describe("tsgonest incremental post-processing cache", () => {
     expect(stderr).toContain("companion");
     const cacheContent = readFileSync(cacheFile, "utf-8");
     const cache = JSON.parse(cacheContent);
-    expect(cache.v).toBe(1);
+    expect(cache.v).toBe(2);
   });
 
   it("--clean flag should force full rebuild", () => {
@@ -254,7 +254,7 @@ describe("tsgonest incremental post-processing cache", () => {
     expect(stderr).toContain("companion");
 
     const newCache = JSON.parse(readFileSync(cacheFile, "utf-8"));
-    expect(newCache.v).toBe(1);
+    expect(newCache.v).toBe(2);
   });
 
   it("successive warm builds should all skip consistently", () => {

--- a/internal/analyzer/testutil_test.go
+++ b/internal/analyzer/testutil_test.go
@@ -253,6 +253,69 @@ func (env *walkerEnv) walkExportedTypeWithRegistry(t *testing.T, typeName string
 	return metadata.Metadata{}, nil
 }
 
+// walkAliasType walks a top-level type alias via its referencing AST position
+// to mirror production parameter/return-type walks (which call WalkTypeNode on
+// the type annotation node). Requires the source file to contain a probe
+// declaration `declare const __probe: <typeName>;` so the helper can locate an
+// AST type node that references the alias by name.
+func (env *walkerEnv) walkAliasType(t *testing.T, typeName string) metadata.Metadata {
+	t.Helper()
+	return env.walkProbeType(t, "__probe", typeName)
+}
+
+// walkProbeType locates `declare const <probeName>: <expectedAlias>;` in the
+// source file and walks the variable's type annotation via WalkTypeNode. This
+// exercises the same AST-driven code path used in production. expectedAlias is
+// optional — pass "" to skip the alias-name assertion.
+func (env *walkerEnv) walkProbeType(t *testing.T, probeName string, expectedAlias string) metadata.Metadata {
+	t.Helper()
+
+	walker := analyzer.NewTypeWalker(env.checker)
+
+	for _, stmt := range env.sourceFile.Statements.Nodes {
+		if stmt == nil || stmt.Kind != ast.KindVariableStatement {
+			continue
+		}
+		vs := stmt.AsVariableStatement()
+		if vs == nil || vs.DeclarationList == nil {
+			continue
+		}
+		declList := vs.DeclarationList.AsVariableDeclarationList()
+		if declList == nil {
+			continue
+		}
+		for _, declNode := range declList.Declarations.Nodes {
+			if declNode == nil || declNode.Kind != ast.KindVariableDeclaration {
+				continue
+			}
+			decl := declNode.AsVariableDeclaration()
+			if decl == nil || decl.Name() == nil {
+				continue
+			}
+			if decl.Name().Text() != probeName {
+				continue
+			}
+			typeNode := decl.Type
+			if typeNode == nil {
+				t.Fatalf("probe %q has no type annotation", probeName)
+			}
+			if expectedAlias != "" {
+				if typeNode.Kind != ast.KindTypeReference {
+					t.Fatalf("probe %q type annotation is not a TypeReference (kind=%v)", probeName, typeNode.Kind)
+				}
+				ref := typeNode.AsTypeReferenceNode()
+				if ref == nil || ref.TypeName == nil || ref.TypeName.Text() != expectedAlias {
+					t.Fatalf("probe %q expected to reference %q", probeName, expectedAlias)
+				}
+			}
+			return walker.WalkTypeNode(typeNode)
+		}
+	}
+
+	t.Fatalf("probe variable %q not found in source file", probeName)
+	return metadata.Metadata{}
+}
+
 // walkAllNamedTypes walks all type aliases in the source file using WalkNamedType
 // (matching production behavior in generateCompanionsInMemory), then returns the
 // walker for inspection. This is critical for testing sub-field type registration.

--- a/internal/analyzer/type_walker.go
+++ b/internal/analyzer/type_walker.go
@@ -251,15 +251,119 @@ func (w *TypeWalker) WalkType(t *shimchecker.Type) metadata.Metadata {
 
 	flags := t.Flags()
 
-	// Handle union and intersection first (they may contain null/undefined members)
-	if flags&shimchecker.TypeFlagsUnion != 0 {
-		return w.walkUnion(t)
-	}
-	if flags&shimchecker.TypeFlagsIntersection != 0 {
-		return w.walkIntersection(t)
+	var result metadata.Metadata
+	switch {
+	case flags&shimchecker.TypeFlagsUnion != 0:
+		result = w.walkUnion(t)
+	case flags&shimchecker.TypeFlagsIntersection != 0:
+		result = w.walkIntersection(t)
+	default:
+		result = w.walkSingleType(t)
 	}
 
-	return w.walkSingleType(t)
+	return w.applyAliasJSDoc(t, result)
+}
+
+// extractAliasJSDocFromTypeNode returns JSDoc constraints found on the alias
+// declaration that the given type node references, or nil if no alias-JSDoc
+// is found. Handles primitive aliases like `type MongoId = string;` where the
+// resolved Type carries no AliasSymbol (TypeScript collapses primitive aliases
+// to the shared singleton, so we recover the alias via the AST type node).
+func (w *TypeWalker) extractAliasJSDocFromTypeNode(typeNode *ast.Node) *metadata.Constraints {
+	if typeNode == nil {
+		return nil
+	}
+	// Unwrap parenthesized types so `(MongoId)` is handled too.
+	for typeNode != nil && typeNode.Kind == ast.KindParenthesizedType {
+		typeNode = typeNode.Type()
+	}
+	if typeNode == nil || typeNode.Kind != ast.KindTypeReference {
+		return nil
+	}
+	ref := typeNode.AsTypeReferenceNode()
+	if ref == nil || ref.TypeName == nil {
+		return nil
+	}
+	sym := w.checker.GetSymbolAtLocation(ref.TypeName)
+	if sym == nil {
+		return nil
+	}
+	// For cross-file imports, GetSymbolAtLocation returns an import-alias symbol
+	// whose declarations are ImportSpecifier nodes. Resolve to the original
+	// symbol so we reach the TypeAliasDeclaration carrying the JSDoc.
+	if sym.Flags&ast.SymbolFlagsAlias != 0 {
+		if original := w.checker.GetAliasedSymbol(sym); original != nil {
+			sym = original
+		}
+	}
+	if sym.Declarations == nil {
+		return nil
+	}
+	for _, decl := range sym.Declarations {
+		if decl == nil || decl.Kind != ast.KindTypeAliasDeclaration {
+			continue
+		}
+		if c := w.extractJSDocConstraints(decl); c != nil {
+			return c
+		}
+	}
+	return nil
+}
+
+// applyAliasJSDoc enriches result.Constraints with JSDoc tags found on the
+// type's alias declaration (e.g. /** @pattern */ type MongoId = string).
+// Only applies to atomic/array kinds where JSDoc validation tags are
+// semantically meaningful. Existing constraints (branded inline tags) take
+// precedence over alias-site JSDoc, mirroring the broader → narrower
+// precedence already used between branded and property-site JSDoc.
+//
+// Note: this only catches aliases whose info is attached directly on the type
+// (object/array aliases). Primitive aliases (`type MongoId = string`) collapse
+// to a shared singleton with no AliasSymbol, so AST-position-based extraction
+// via extractAliasJSDocFromTypeNode is required at call sites that have the
+// originating TypeNode in hand (e.g. WalkTypeNode, analyzeObjectProperties).
+func (w *TypeWalker) applyAliasJSDoc(t *shimchecker.Type, result metadata.Metadata) metadata.Metadata {
+	if result.Kind != metadata.KindAtomic && result.Kind != metadata.KindArray {
+		return result
+	}
+	var aliasJSDoc *metadata.Constraints
+
+	// Fast path: alias info is attached directly on the type (object/array aliases).
+	if alias := shimchecker.Type_alias(t); alias != nil {
+		if sym := alias.Symbol(); sym != nil {
+			name := sym.Name
+			if !(name == "" || name == "__type" || name == "__object" || (len(name) > 0 && name[0] == '\xfe')) && sym.Declarations != nil {
+				for _, decl := range sym.Declarations {
+					if decl == nil || decl.Kind != ast.KindTypeAliasDeclaration {
+						continue
+					}
+					if c := w.extractJSDocConstraints(decl); c != nil {
+						aliasJSDoc = c
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return w.mergeAliasJSDocInto(result, aliasJSDoc)
+}
+
+// mergeAliasJSDocInto merges alias-site JSDoc constraints into result.Constraints
+// using the precedence rule shared by applyAliasJSDoc and WalkTypeNode: existing
+// (branded/inline) constraints win over alias-site JSDoc.
+func (w *TypeWalker) mergeAliasJSDocInto(result metadata.Metadata, aliasJSDoc *metadata.Constraints) metadata.Metadata {
+	if aliasJSDoc == nil {
+		return result
+	}
+	if result.Constraints == nil {
+		result.Constraints = aliasJSDoc
+		return result
+	}
+	merged := *aliasJSDoc
+	mergeConstraints(&merged, result.Constraints)
+	result.Constraints = &merged
+	return result
 }
 
 // walkSingleType handles a non-union, non-intersection type.
@@ -1232,20 +1336,50 @@ func (w *TypeWalker) analyzeObjectProperties(t *shimchecker.Type, name string) m
 
 		isReadonly := shimchecker.Checker_isReadonlySymbol(w.checker, prop)
 
-		// Extract constraints from two sources:
-		// 1. Branded phantom types (e.g., string & tags.Format<"email">)
-		// 2. JSDoc tags (e.g., @format email)
-		// JSDoc takes precedence over branded types for the same constraint.
+		// Extract constraints from three sources, broadest → narrowest:
+		// 1. Alias-site JSDoc (e.g. /** @pattern */ type MongoId = string)
+		// 2. Branded phantom types (e.g., string & tags.Format<"email">)
+		// 3. Property-site JSDoc (e.g. /** @format email */ on the field)
+		// Later sources override earlier ones — property-site is the most specific.
 		var constraints *metadata.Constraints
 
-		// Start with branded type constraints (if any)
+		// Seed with alias-site JSDoc when the property type is a TypeReference
+		// to a type alias whose declaration has JSDoc tags. Primitive aliases
+		// like `type MongoId = string` lose AliasSymbol on the resolved Type,
+		// so we recover the alias via the property's AST type node.
+		if prop.ValueDeclaration != nil {
+			if aliasJSDoc := w.extractAliasJSDocFromTypeNode(prop.ValueDeclaration.Type()); aliasJSDoc != nil {
+				c := *aliasJSDoc // copy so subsequent merges don't mutate the source
+				constraints = &c
+			}
+		}
+
+		// Layer in branded type constraints (override alias-site for any same fields)
 		if propMeta.Constraints != nil {
-			c := *propMeta.Constraints // copy
-			constraints = &c
+			if constraints == nil {
+				c := *propMeta.Constraints // copy
+				constraints = &c
+			} else {
+				mergeConstraints(constraints, propMeta.Constraints)
+			}
 			propMeta.Constraints = nil // don't leak to codegen
 		}
 
-		// Merge JSDoc constraints (takes precedence) and extract property annotations
+		// Element-level alias-JSDoc: for `userIds: MongoId[]`, the property's type
+		// node is an ArrayType. Recurse into its ElementType to recover alias-JSDoc
+		// on the element, and attach to propMeta.ElementType.Constraints so codegen's
+		// per-element loop can emit the runtime check.
+		if prop.ValueDeclaration != nil && propMeta.Kind == metadata.KindArray && propMeta.ElementType != nil {
+			if typeNode := prop.ValueDeclaration.Type(); typeNode != nil && typeNode.Kind == ast.KindArrayType {
+				elemNode := typeNode.AsArrayTypeNode().ElementType
+				if elemAliasJSDoc := w.extractAliasJSDocFromTypeNode(elemNode); elemAliasJSDoc != nil {
+					merged := w.mergeAliasJSDocInto(*propMeta.ElementType, elemAliasJSDoc)
+					propMeta.ElementType = &merged
+				}
+			}
+		}
+
+		// Merge property-site JSDoc (most specific — takes precedence) and extract annotations
 		var ann propertyAnnotations
 		if prop.ValueDeclaration != nil {
 			jsdocConstraints := w.extractJSDocConstraints(prop.ValueDeclaration)
@@ -1412,6 +1546,28 @@ func (w *TypeWalker) getTypeName(t *shimchecker.Type) string {
 func (w *TypeWalker) WalkTypeNode(node *ast.Node) metadata.Metadata {
 	t := w.checker.GetTypeFromTypeNode(node)
 	result := w.WalkType(t)
+
+	// Recover alias-site JSDoc constraints for primitive aliases via the AST
+	// position. TypeScript collapses `type MongoId = string` to the shared
+	// primitive singleton, so applyAliasJSDoc's type-driven fast path misses
+	// these. extractAliasJSDocFromTypeNode resolves the symbol referenced at
+	// this exact AST position, which is unambiguous even when many aliases
+	// share the same underlying primitive type.
+	if result.Kind == metadata.KindAtomic || result.Kind == metadata.KindArray {
+		if aliasJSDoc := w.extractAliasJSDocFromTypeNode(node); aliasJSDoc != nil {
+			result = w.mergeAliasJSDocInto(result, aliasJSDoc)
+		}
+	}
+
+	// Element-level alias-JSDoc on top-level array walks (e.g. `@Param('ids') ids: MongoId[]`
+	// or method return type `MongoId[]`). Attaches to result.ElementType.Constraints.
+	if result.Kind == metadata.KindArray && result.ElementType != nil && node != nil && node.Kind == ast.KindArrayType {
+		elemNode := node.AsArrayTypeNode().ElementType
+		if elemAliasJSDoc := w.extractAliasJSDocFromTypeNode(elemNode); elemAliasJSDoc != nil {
+			merged := w.mergeAliasJSDocInto(*result.ElementType, elemAliasJSDoc)
+			result.ElementType = &merged
+		}
+	}
 
 	// Preserve the type name for named type references.
 	// Skip wrapper types (Promise, Observable) — their inner type is already unwrapped.

--- a/internal/analyzer/type_walker_test.go
+++ b/internal/analyzer/type_walker_test.go
@@ -7198,3 +7198,307 @@ type Container = {
 		t.Errorf("expected a type-name-collision warning for LeaderboardResponse, got warnings: %v", warnings)
 	}
 }
+
+// --- JSDoc on type alias declarations must propagate to property constraints ---
+//
+// extractJSDocConstraints is currently invoked only against prop.ValueDeclaration
+// (the property-line declaration), never against a TypeAliasDeclaration. JSDoc
+// tags placed on `type Alias = ...` are silently dropped at every reference site.
+
+func TestWalkJSDocOnTypeAlias_PatternPropagatesToProperty(t *testing.T) {
+	env := setupWalker(t, `
+/** @pattern ^[0-9a-fA-F]{24}$ */
+type MongoId = string;
+
+interface User {
+  id: MongoId;
+}
+`)
+	defer env.release()
+
+	m := env.walkExportedType(t, "User")
+	if m.Kind == metadata.KindRef {
+		reg := env.walkExportedTypeWithRegistryOnly(t, "User")
+		if resolved := reg.Types[m.Ref]; resolved != nil {
+			m = *resolved
+		}
+	}
+
+	idProp := findProperty(t, m.Properties, "id")
+	if idProp.Constraints == nil {
+		t.Fatal("id should have constraints from alias-site JSDoc @pattern")
+	}
+	if idProp.Constraints.Pattern == nil || *idProp.Constraints.Pattern != "^[0-9a-fA-F]{24}$" {
+		t.Errorf("expected pattern '^[0-9a-fA-F]{24}$', got %v", idProp.Constraints.Pattern)
+	}
+}
+
+func TestWalkJSDocOnTypeAlias_FormatPropagatesToProperty(t *testing.T) {
+	env := setupWalker(t, `
+/** @format email */
+type EmailString = string;
+
+interface Account {
+  email: EmailString;
+}
+`)
+	defer env.release()
+
+	m := env.walkExportedType(t, "Account")
+	if m.Kind == metadata.KindRef {
+		reg := env.walkExportedTypeWithRegistryOnly(t, "Account")
+		if resolved := reg.Types[m.Ref]; resolved != nil {
+			m = *resolved
+		}
+	}
+
+	emailProp := findProperty(t, m.Properties, "email")
+	if emailProp.Constraints == nil {
+		t.Fatal("email should have constraints from alias-site JSDoc @format")
+	}
+	if emailProp.Constraints.Format == nil || *emailProp.Constraints.Format != "email" {
+		t.Errorf("expected format 'email', got %v", emailProp.Constraints.Format)
+	}
+}
+
+func TestWalkJSDocOnTypeAlias_MinMaxLengthPropagateToProperty(t *testing.T) {
+	env := setupWalker(t, `
+/**
+ * @minLength 1
+ * @maxLength 32
+ */
+type ShortString = string;
+
+interface Slug {
+  value: ShortString;
+}
+`)
+	defer env.release()
+
+	m := env.walkExportedType(t, "Slug")
+	if m.Kind == metadata.KindRef {
+		reg := env.walkExportedTypeWithRegistryOnly(t, "Slug")
+		if resolved := reg.Types[m.Ref]; resolved != nil {
+			m = *resolved
+		}
+	}
+
+	valueProp := findProperty(t, m.Properties, "value")
+	if valueProp.Constraints == nil {
+		t.Fatal("value should have constraints from alias-site JSDoc @minLength/@maxLength")
+	}
+	if valueProp.Constraints.MinLength == nil || *valueProp.Constraints.MinLength != 1 {
+		t.Errorf("expected minLength 1, got %v", valueProp.Constraints.MinLength)
+	}
+	if valueProp.Constraints.MaxLength == nil || *valueProp.Constraints.MaxLength != 32 {
+		t.Errorf("expected maxLength 32, got %v", valueProp.Constraints.MaxLength)
+	}
+}
+
+func TestWalkJSDocOnTypeAlias_PropertyJSDocOverridesAliasJSDoc(t *testing.T) {
+	env := setupWalker(t, `
+/** @pattern ^[0-9a-fA-F]{24}$ */
+type MongoId = string;
+
+interface Foo {
+  /** @pattern ^[a-z]+$ */
+  id: MongoId;
+}
+`)
+	defer env.release()
+
+	m := env.walkExportedType(t, "Foo")
+	if m.Kind == metadata.KindRef {
+		reg := env.walkExportedTypeWithRegistryOnly(t, "Foo")
+		if resolved := reg.Types[m.Ref]; resolved != nil {
+			m = *resolved
+		}
+	}
+
+	idProp := findProperty(t, m.Properties, "id")
+	if idProp.Constraints == nil {
+		t.Fatal("id should have constraints (property JSDoc at minimum)")
+	}
+	// Property-site JSDoc must win over alias-site JSDoc — same precedence
+	// rule as branded-vs-JSDoc at type_walker.go:1238.
+	if idProp.Constraints.Pattern == nil || *idProp.Constraints.Pattern != "^[a-z]+$" {
+		t.Errorf("expected property JSDoc pattern '^[a-z]+$' to override alias JSDoc, got %v", idProp.Constraints.Pattern)
+	}
+}
+
+func TestWalkJSDocOnTypeAlias_AliasUsedAsParameterType_ConstraintsOnMetadata(t *testing.T) {
+	env := setupWalker(t, `
+/** @pattern ^[0-9a-fA-F]{24}$ */
+type MongoId = string;
+
+declare const __probe: MongoId;
+`)
+	defer env.release()
+
+	// Walk the alias via its referencing AST position — mirrors production
+	// (parameter/return-type walks call WalkTypeNode on the type annotation).
+	m := env.walkAliasType(t, "MongoId")
+
+	if m.Kind != metadata.KindAtomic || m.Atomic != "string" {
+		t.Fatalf("expected atomic string, got kind=%v atomic=%q", m.Kind, m.Atomic)
+	}
+	if m.Constraints == nil {
+		t.Fatal("MongoId metadata should carry constraints from alias-site JSDoc @pattern")
+	}
+	if m.Constraints.Pattern == nil || *m.Constraints.Pattern != "^[0-9a-fA-F]{24}$" {
+		t.Errorf("expected pattern '^[0-9a-fA-F]{24}$', got %v", m.Constraints.Pattern)
+	}
+}
+
+// TestWalkJSDocOnTypeAlias_NoCrossContaminationBetweenPrimitiveAliases pins
+// that primitive aliases sharing the same underlying type (e.g. multiple
+// `type X = string` declarations) do not leak each other's alias-JSDoc.
+// Resolving by AST position via GetSymbolAtLocation gives an unambiguous
+// answer even though Type.Id() is identical across these aliases.
+func TestWalkJSDocOnTypeAlias_NoCrossContaminationBetweenPrimitiveAliases(t *testing.T) {
+	env := setupWalker(t, `
+/** @pattern ^[0-9a-fA-F]{24}$ */
+type MongoId = string;
+
+/** @format email */
+type EmailStr = string;
+
+declare const __mongo: MongoId;
+declare const __email: EmailStr;
+`)
+	defer env.release()
+
+	mongo := env.walkProbeType(t, "__mongo", "MongoId")
+	if mongo.Constraints == nil || mongo.Constraints.Pattern == nil || *mongo.Constraints.Pattern != "^[0-9a-fA-F]{24}$" {
+		t.Errorf("MongoId pattern lost or wrong: %+v", mongo.Constraints)
+	}
+	if mongo.Constraints != nil && mongo.Constraints.Format != nil {
+		t.Errorf("MongoId leaked Format=%v from another alias", *mongo.Constraints.Format)
+	}
+
+	email := env.walkProbeType(t, "__email", "EmailStr")
+	if email.Constraints == nil || email.Constraints.Format == nil || *email.Constraints.Format != "email" {
+		t.Errorf("EmailStr format lost or wrong: %+v", email.Constraints)
+	}
+	if email.Constraints != nil && email.Constraints.Pattern != nil {
+		t.Errorf("EmailStr leaked Pattern=%v from another alias", *email.Constraints.Pattern)
+	}
+}
+
+// TestWalkJSDocOnTypeAlias_CrossFileImport_PropagatesToProperty verifies that
+// alias-site JSDoc constraints survive a cross-file `import { MongoId } from './utils'`.
+// The reporter's main scenario: the alias is declared in one module and consumed
+// in another via an import specifier. GetSymbolAtLocation on the type-reference
+// identifier returns an import-alias symbol whose Declarations are ImportSpecifier
+// nodes — not the original TypeAliasDeclaration. The alias must be resolved through
+// GetAliasedSymbol (see internal/analyzer/decorator_origin.go for the precedent).
+func TestWalkJSDocOnTypeAlias_CrossFileImport_PropagatesToProperty(t *testing.T) {
+	env := setupWalkerMultiFile(t, map[string]string{
+		"utils.ts": `
+/** @pattern ^[0-9a-fA-F]{24}$ */
+export type MongoId = string;
+`,
+		"consumer.ts": `
+import { MongoId } from './utils';
+export interface User { id: MongoId; }
+`,
+	}, "consumer.ts")
+	defer env.release()
+
+	m := env.walkExportedType(t, "User")
+	if m.Kind == metadata.KindRef {
+		reg := env.walkExportedTypeWithRegistryOnly(t, "User")
+		if resolved := reg.Types[m.Ref]; resolved != nil {
+			m = *resolved
+		}
+	}
+
+	idProp := findProperty(t, m.Properties, "id")
+	if idProp.Constraints == nil {
+		t.Fatal("id should have constraints from cross-file alias-site JSDoc @pattern")
+	}
+	if idProp.Constraints.Pattern == nil || *idProp.Constraints.Pattern != "^[0-9a-fA-F]{24}$" {
+		t.Errorf("expected pattern '^[0-9a-fA-F]{24}$', got %v", idProp.Constraints.Pattern)
+	}
+}
+
+// TestWalkJSDocOnTypeAlias_ArrayElement_PropagatesToElement verifies that
+// alias-site JSDoc constraints reach the per-element metadata when the alias
+// is used as an array element type (`items: MongoId[]`). The property's type
+// annotation is a KindArrayType, not a KindTypeReference, so the alias-JSDoc
+// extraction must walk into the array's element type node.
+func TestWalkJSDocOnTypeAlias_ArrayElement_PropagatesToElement(t *testing.T) {
+	env := setupWalker(t, `
+/** @pattern ^[0-9a-fA-F]{24}$ */
+type MongoId = string;
+export interface Bag { items: MongoId[]; }
+`)
+	defer env.release()
+
+	m := env.walkExportedType(t, "Bag")
+	if m.Kind == metadata.KindRef {
+		reg := env.walkExportedTypeWithRegistryOnly(t, "Bag")
+		if resolved := reg.Types[m.Ref]; resolved != nil {
+			m = *resolved
+		}
+	}
+
+	itemsProp := findProperty(t, m.Properties, "items")
+	if itemsProp.Type.Kind != metadata.KindArray {
+		t.Fatalf("expected items.Type.Kind == KindArray, got %q", itemsProp.Type.Kind)
+	}
+	if itemsProp.Type.ElementType == nil {
+		t.Fatal("items.Type.ElementType is nil — array element metadata missing")
+	}
+	if itemsProp.Type.ElementType.Constraints == nil {
+		t.Fatal("items.Type.ElementType.Constraints is nil — alias-site JSDoc did not reach array element")
+	}
+	if itemsProp.Type.ElementType.Constraints.Pattern == nil {
+		t.Fatalf("items.Type.ElementType.Constraints.Pattern is nil, got %+v", itemsProp.Type.ElementType.Constraints)
+	}
+	if *itemsProp.Type.ElementType.Constraints.Pattern != "^[0-9a-fA-F]{24}$" {
+		t.Errorf("expected element pattern '^[0-9a-fA-F]{24}$', got %q", *itemsProp.Type.ElementType.Constraints.Pattern)
+	}
+}
+
+// TestWalkJSDocOnTypeAlias_CrossFileImport_ArrayElement_PropagatesToElement
+// combines the cross-file import gap and the array-element gap. This is the
+// exact AddParticipantsDTO.userIds scenario the reporter hit in production.
+func TestWalkJSDocOnTypeAlias_CrossFileImport_ArrayElement_PropagatesToElement(t *testing.T) {
+	env := setupWalkerMultiFile(t, map[string]string{
+		"utils.ts": `
+/** @pattern ^[0-9a-fA-F]{24}$ */
+export type MongoId = string;
+`,
+		"consumer.ts": `
+import { MongoId } from './utils';
+export interface Bag { items: MongoId[]; }
+`,
+	}, "consumer.ts")
+	defer env.release()
+
+	m := env.walkExportedType(t, "Bag")
+	if m.Kind == metadata.KindRef {
+		reg := env.walkExportedTypeWithRegistryOnly(t, "Bag")
+		if resolved := reg.Types[m.Ref]; resolved != nil {
+			m = *resolved
+		}
+	}
+
+	itemsProp := findProperty(t, m.Properties, "items")
+	if itemsProp.Type.Kind != metadata.KindArray {
+		t.Fatalf("expected items.Type.Kind == KindArray, got %q", itemsProp.Type.Kind)
+	}
+	if itemsProp.Type.ElementType == nil {
+		t.Fatal("items.Type.ElementType is nil — array element metadata missing")
+	}
+	if itemsProp.Type.ElementType.Constraints == nil {
+		t.Fatal("items.Type.ElementType.Constraints is nil — cross-file alias-site JSDoc did not reach array element")
+	}
+	if itemsProp.Type.ElementType.Constraints.Pattern == nil {
+		t.Fatalf("items.Type.ElementType.Constraints.Pattern is nil, got %+v", itemsProp.Type.ElementType.Constraints)
+	}
+	if *itemsProp.Type.ElementType.Constraints.Pattern != "^[0-9a-fA-F]{24}$" {
+		t.Errorf("expected element pattern '^[0-9a-fA-F]{24}$', got %q", *itemsProp.Type.ElementType.Constraints.Pattern)
+	}
+}

--- a/internal/buildcache/cache.go
+++ b/internal/buildcache/cache.go
@@ -28,7 +28,12 @@ var removeFn = os.Remove
 
 // SchemaVersion is bumped when the cache format or analysis output format changes.
 // A mismatch forces a full rebuild, ensuring binary upgrades don't produce stale outputs.
-const SchemaVersion = 1
+//
+// v2: alias-site JSDoc now propagates through type aliases (cross-file imports,
+// arrays of aliased types) and per-element constraint checks are emitted in
+// companion JS. Older caches predate these emits and must be invalidated so the
+// new binary regenerates affected companions.
+const SchemaVersion = 2
 
 // Cache represents the on-disk post-processing cache.
 // It records what was true when post-processing last ran successfully.

--- a/internal/codegen/codegen_test.go
+++ b/internal/codegen/codegen_test.go
@@ -4154,3 +4154,100 @@ func TestExternalRecursive_NoSourceFile_AllHelperCallsResolve(t *testing.T) {
 		}
 	}
 }
+
+// --- GAP-2: per-element constraints on array of aliased atomic types ---
+
+// intPtr is a small file-local helper for building Constraints fields that take
+// *int. Kept here instead of metadata-side so it stays test-only.
+func intPtrLocal(n int) *int { return &n }
+
+func TestValidateArrayElementWithPattern_EmitsRegexInLoop(t *testing.T) {
+	reg := metadata.NewTypeRegistry()
+	pattern := "^[0-9a-fA-F]{24}$"
+	elem := metadata.Metadata{
+		Kind:        metadata.KindAtomic,
+		Atomic:      "string",
+		Constraints: &metadata.Constraints{Pattern: &pattern},
+	}
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Name: "AddParticipantsDTO",
+		Properties: []metadata.Property{
+			{Name: "userIds", Type: metadata.Metadata{Kind: metadata.KindArray, ElementType: &elem, Optional: true}, Required: false},
+		},
+	}
+
+	code := GenerateCompanionSelective("AddParticipantsDTO", meta, reg, true, false)
+
+	// Sanity baseline — array shape is recognised
+	assertContains(t, code, "Array.isArray(input.userIds)")
+	// Real fix — per-element regex inside the array loop
+	assertContains(t, code, "/^[0-9a-fA-F]{24}$/.test(input.userIds[i1])")
+}
+
+func TestValidateArrayElementWithMaxLength_EmitsLengthCheckInLoop(t *testing.T) {
+	reg := metadata.NewTypeRegistry()
+	elem := metadata.Metadata{
+		Kind:   metadata.KindAtomic,
+		Atomic: "string",
+		Constraints: &metadata.Constraints{
+			MaxLength: intPtrLocal(24),
+		},
+	}
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Name: "IdsDTO",
+		Properties: []metadata.Property{
+			{Name: "ids", Type: metadata.Metadata{Kind: metadata.KindArray, ElementType: &elem, Optional: true}, Required: false},
+		},
+	}
+
+	code := GenerateCompanionSelective("IdsDTO", meta, reg, true, false)
+
+	assertContains(t, code, "Array.isArray(input.ids)")
+	assertContains(t, code, "input.ids[i1].length > 24")
+}
+
+func TestAssertArrayElementWithPattern_EmitsRegexInLoop(t *testing.T) {
+	reg := metadata.NewTypeRegistry()
+	pattern := "^[0-9a-fA-F]{24}$"
+	elem := metadata.Metadata{
+		Kind:        metadata.KindAtomic,
+		Atomic:      "string",
+		Constraints: &metadata.Constraints{Pattern: &pattern},
+	}
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Name: "AddParticipantsDTO",
+		Properties: []metadata.Property{
+			{Name: "userIds", Type: metadata.Metadata{Kind: metadata.KindArray, ElementType: &elem, Optional: true}, Required: false},
+		},
+	}
+
+	code := GenerateCompanionSelective("AddParticipantsDTO", meta, reg, true, false)
+
+	// Sanity — assert function is emitted into the same string
+	assertContains(t, code, "function assertAddParticipantsDTO(input)")
+	// Real fix — regex appears at all in the combined validate+assert output
+	assertContains(t, code, "/^[0-9a-fA-F]{24}$/.test(input.userIds[i1])")
+}
+
+func TestValidate_AliasArrayMongoIdEndToEnd_EmitsRegex(t *testing.T) {
+	reg := metadata.NewTypeRegistry()
+	pattern := "^[0-9a-fA-F]{24}$"
+	elemType := metadata.Metadata{
+		Kind:        metadata.KindAtomic,
+		Atomic:      "string",
+		Constraints: &metadata.Constraints{Pattern: &pattern},
+	}
+	meta := &metadata.Metadata{
+		Kind: metadata.KindObject,
+		Name: "AddParticipantsDTO",
+		Properties: []metadata.Property{
+			{Name: "userIds", Type: metadata.Metadata{Kind: metadata.KindArray, ElementType: &elemType, Optional: true}, Required: false},
+		},
+	}
+
+	code := GenerateCompanionSelective("AddParticipantsDTO", meta, reg, true, false)
+	assertContains(t, code, "/^[0-9a-fA-F]{24}$/.test(input.userIds[i1])")
+}

--- a/internal/codegen/validate.go
+++ b/internal/codegen/validate.go
@@ -669,6 +669,10 @@ func generateTypeCheckWithPathInner(e *Emitter, accessor string, pathExpr string
 			elemAccessor := fmt.Sprintf("%s[%s]", accessor, idx)
 			elemPathExpr := fmt.Sprintf("%s + \"[\" + %s + \"]\"", pathExpr, idx)
 			generateTypeCheckWithPath(e, elemAccessor, elemPathExpr, meta.ElementType, registry, depth+1, ctx)
+			// Per-element constraint checks from alias-site JSDoc or branded tags.
+			if meta.ElementType.Constraints != nil {
+				generateValidateConstraintChecksDynamicPath(e, elemAccessor, elemPathExpr, meta.ElementType.Constraints)
+			}
 			e.EndBlock()
 		}
 		e.indent--

--- a/internal/codegen/validate_assert.go
+++ b/internal/codegen/validate_assert.go
@@ -153,6 +153,17 @@ func generateAssertChecksInner(e *Emitter, accessor string, pathExpr string, met
 			elemAccessor := fmt.Sprintf("%s[%s]", accessor, idx)
 			elemPathExpr := fmt.Sprintf("%s + \"[\" + %s + \"]\"", pathExpr, idx)
 			generateAssertChecks(e, elemAccessor, elemPathExpr, meta.ElementType, registry, depth+1, ctx, isRecursive)
+			// Per-element constraint checks from alias-site JSDoc or branded tags.
+			// generateAssertConstraintChecks already accepts a JS pathExpr, so dynamic
+			// element paths produce correct error.path values like "input.userIds[0]".
+			if meta.ElementType.Constraints != nil {
+				elemProp := metadata.Property{
+					Name:        "",
+					Type:        *meta.ElementType,
+					Constraints: meta.ElementType.Constraints,
+				}
+				generateAssertConstraintChecks(e, elemAccessor, elemPathExpr, &elemProp)
+			}
 			e.EndBlock()
 		}
 		e.indent--

--- a/internal/codegen/validate_constraints.go
+++ b/internal/codegen/validate_constraints.go
@@ -318,6 +318,79 @@ func generateConstraintChecksInner(e *Emitter, accessor string, path string, pro
 	}
 }
 
+// generateValidateConstraintChecksDynamicPath emits validate-side per-element
+// constraint checks where the error path is a JS expression (e.g.
+// `"input" + ".userIds" + "[" + i1 + "]"`) rather than a static string.
+//
+// Mirrors generateAssertConstraintChecks but pushes into the shared `errors`
+// array instead of throwing. Used by the KindArray loop to enforce constraints
+// declared on the element type (alias-site JSDoc or branded tags).
+//
+// Type guards (`typeof X === "string"` / `=== "number"`) are kept inside the
+// conditions so the emitted check is correct even though the element type was
+// already verified earlier in the loop — a tiny double-guard for safety.
+// Coerce/Transforms are intentionally skipped: those run before the type check,
+// not per element.
+func generateValidateConstraintChecksDynamicPath(e *Emitter, accessor string, pathExpr string, c *metadata.Constraints) {
+	if c == nil {
+		return
+	}
+
+	errMsg := func(constraintKey string, defaultMsg string) string {
+		if c.Errors != nil {
+			if msg, ok := c.Errors[constraintKey]; ok {
+				return jsStringEscape(msg)
+			}
+		}
+		if c.ErrorMessage != nil {
+			return jsStringEscape(*c.ErrorMessage)
+		}
+		return defaultMsg
+	}
+
+	if c.Minimum != nil {
+		e.Block("if (typeof %s === \"number\" && %s < %v)", accessor, accessor, *c.Minimum)
+		e.Line("errors.push({ path: %s, expected: \"%s\", received: \"\" + %s });", pathExpr, errMsg("minimum", fmt.Sprintf("minimum %v", *c.Minimum)), accessor)
+		e.EndBlock()
+	}
+	if c.Maximum != nil {
+		e.Block("if (typeof %s === \"number\" && %s > %v)", accessor, accessor, *c.Maximum)
+		e.Line("errors.push({ path: %s, expected: \"%s\", received: \"\" + %s });", pathExpr, errMsg("maximum", fmt.Sprintf("maximum %v", *c.Maximum)), accessor)
+		e.EndBlock()
+	}
+	if c.MinLength != nil {
+		e.Block("if (typeof %s === \"string\" && %s.length < %d)", accessor, accessor, *c.MinLength)
+		e.Line("errors.push({ path: %s, expected: \"%s\", received: \"length \" + %s.length });", pathExpr, errMsg("minLength", fmt.Sprintf("minLength %d", *c.MinLength)), accessor)
+		e.EndBlock()
+	}
+	if c.MaxLength != nil {
+		e.Block("if (typeof %s === \"string\" && %s.length > %d)", accessor, accessor, *c.MaxLength)
+		e.Line("errors.push({ path: %s, expected: \"%s\", received: \"length \" + %s.length });", pathExpr, errMsg("maxLength", fmt.Sprintf("maxLength %d", *c.MaxLength)), accessor)
+		e.EndBlock()
+	}
+	if c.Pattern != nil {
+		escapedPattern := escapeForRegexLiteral(*c.Pattern)
+		e.Block("if (typeof %s === \"string\" && !/%s/.test(%s))", accessor, escapedPattern, accessor)
+		e.Line("errors.push({ path: %s, expected: \"%s\", received: %s });", pathExpr, errMsg("pattern", fmt.Sprintf("pattern %s", *c.Pattern)), accessor)
+		e.EndBlock()
+	}
+	if c.Format != nil {
+		pattern, ok := formatRegexes[*c.Format]
+		if ok && pattern != "" {
+			flags := formatFlags[*c.Format]
+			var regexLiteral string
+			if flags != "" {
+				regexLiteral = fmt.Sprintf("/%s/%s", pattern, flags)
+			} else {
+				regexLiteral = fmt.Sprintf("/%s/", pattern)
+			}
+			e.Block("if (typeof %s === \"string\" && !%s.test(%s))", accessor, regexLiteral, accessor)
+			e.Line("errors.push({ path: %s, expected: \"%s\", received: %s });", pathExpr, errMsg("format", fmt.Sprintf("format %s", *c.Format)), accessor)
+			e.EndBlock()
+		}
+	}
+}
+
 // generateNumericTypeCheck emits validation for @type int32/uint32/int64/uint64/float/double.
 // Checks perConstraintErrors["type"] first, then customError (global), then default.
 func generateNumericTypeCheck(e *Emitter, accessor string, path string, numType string, customError *string, perConstraintErrors map[string]string, typeVerified bool) {

--- a/internal/rewrite/controllers.go
+++ b/internal/rewrite/controllers.go
@@ -83,11 +83,19 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 		paramName  string
 		atomic     string // "number" or "boolean"
 	}
+	type scalarConstraintCheck struct {
+		className   string
+		methodName  string
+		paramName   string
+		atomic      string // "string" or "number"
+		constraints *metadata.Constraints
+	}
 
 	var validations []bodyValidation
 	var transforms []returnTransform
 	var primitiveTransforms []primitiveReturnTransform
 	var scalarCoercions []scalarCoercion
+	var scalarConstraintChecks []scalarConstraintCheck
 	var sseTransforms []sseTransform
 	neededTypes := make(map[string]bool)
 	neededTransformTypes := make(map[string]bool)
@@ -169,6 +177,25 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 								methodName: route.MethodName,
 								paramName:  paramName,
 								atomic:     param.Type.Atomic,
+							})
+							needsHelpersImport = true
+						}
+						// Constraint-based runtime checks for named scalar string/number
+						// params. Strings get checks even without coercion; numbers get
+						// checks layered on top of coercion (priority 32 > 31) so the
+						// numeric bounds run against the coerced numeric value.
+						if param.Type.Kind == metadata.KindAtomic && param.Type.Constraints != nil &&
+							(param.Type.Atomic == "string" || param.Type.Atomic == "number") {
+							paramName := param.LocalName
+							if paramName == "" {
+								paramName = param.Name
+							}
+							scalarConstraintChecks = append(scalarConstraintChecks, scalarConstraintCheck{
+								className:   ctrl.Name,
+								methodName:  route.MethodName,
+								paramName:   paramName,
+								atomic:      param.Type.Atomic,
+								constraints: param.Type.Constraints,
 							})
 							needsHelpersImport = true
 						}
@@ -256,7 +283,7 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 		}
 	}
 
-	if len(validations) == 0 && len(transforms) == 0 && len(primitiveTransforms) == 0 && len(scalarCoercions) == 0 && len(sseTransforms) == 0 && !needsSseInterceptor {
+	if len(validations) == 0 && len(transforms) == 0 && len(primitiveTransforms) == 0 && len(scalarCoercions) == 0 && len(scalarConstraintChecks) == 0 && len(sseTransforms) == 0 && !needsSseInterceptor {
 		return text
 	}
 
@@ -268,6 +295,9 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 		controllersWithWork[v.className] = true
 	}
 	for _, sc := range scalarCoercions {
+		controllersWithWork[sc.className] = true
+	}
+	for _, sc := range scalarConstraintChecks {
 		controllersWithWork[sc.className] = true
 	}
 	for _, tr := range transforms {
@@ -410,6 +440,27 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 				newText:  coercionCode,
 			})
 		}
+	}
+
+	// (b2) Inline constraint checks for named scalar @Param/@Query params.
+	// Runs at priority 32 — after scalar coercion (31) so number bounds are
+	// evaluated against the coerced numeric value, never the original string.
+	for _, sc := range scalarConstraintChecks {
+		ml := lookupMethod(sc.className, sc.methodName)
+		if ml == nil {
+			warnMethodMissing(sc.className, sc.methodName, "query/param scalar constraint check")
+			continue
+		}
+		checkCode := buildScalarConstraintCheck(sc.paramName, sc.atomic, sc.constraints)
+		if checkCode == "" {
+			continue
+		}
+		edits = append(edits, prioritizedEdit{
+			pos:      ml.BodyOpenBrace + 1,
+			end:      ml.BodyOpenBrace + 1,
+			priority: 32,
+			newText:  checkCode,
+		})
 	}
 
 	// (c) Return expression wrapping for DTO transforms
@@ -1036,4 +1087,140 @@ func injectAtMethodStart(text string, methodName string, line string) string {
 		}
 	}
 	return text
+}
+
+// jsStringEscape makes a Go string safe to embed inside a JS double-quoted
+// string literal. Mirrors internal/codegen/validate_util.go jsStringEscape —
+// kept local to avoid an internal/codegen → internal/rewrite import cycle.
+//
+// Omits U+2028/U+2029 escapes intentionally: those only matter when the emit
+// is embedded inside an HTML <script> tag (ES5 line-terminator parsing). Our
+// emit is consumed by Node, and JSDoc @pattern values don't realistically
+// contain these characters.
+func jsStringEscape(s string) string {
+	var buf strings.Builder
+	buf.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case '\\':
+			buf.WriteString(`\\`)
+		case '"':
+			buf.WriteString(`\"`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\r':
+			buf.WriteString(`\r`)
+		case '\t':
+			buf.WriteString(`\t`)
+		case '\b':
+			buf.WriteString(`\b`)
+		case '\f':
+			buf.WriteString(`\f`)
+		default:
+			if r < 0x20 {
+				buf.WriteString(fmt.Sprintf(`\x%02x`, r))
+			} else {
+				buf.WriteRune(r)
+			}
+		}
+	}
+	return buf.String()
+}
+
+// escapeForRegexLiteral escapes forward slashes for safe embedding in a JS
+// regex literal /…/. Mirrors internal/codegen/validate_util.go escapeForRegexLiteral —
+// kept local to avoid an internal/codegen → internal/rewrite import cycle.
+func escapeForRegexLiteral(pattern string) string {
+	var buf strings.Builder
+	escaped := false
+	for _, r := range pattern {
+		if escaped {
+			buf.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			buf.WriteRune(r)
+			escaped = true
+			continue
+		}
+		if r == '/' {
+			buf.WriteString(`\/`)
+			continue
+		}
+		buf.WriteRune(r)
+	}
+	return buf.String()
+}
+
+// buildScalarConstraintCheck composes the inline JS for runtime constraint
+// checks on a single named scalar @Param/@Query parameter. All applicable
+// checks for the param are concatenated into one returned string so the caller
+// can emit them as a single prioritized edit. Order: Pattern → MinLength →
+// MaxLength → Minimum → Maximum → MultipleOf. Constraints that don't apply to
+// the atomic are silently skipped (defensive — analyzer shouldn't produce
+// them, but we never want a misapplied check to slip through).
+func buildScalarConstraintCheck(paramName, atomic string, c *metadata.Constraints) string {
+	if c == nil {
+		return ""
+	}
+	var b strings.Builder
+
+	if atomic == "string" {
+		if c.Pattern != nil {
+			raw := *c.Pattern
+			// raw lands in two slots with different escaping rules:
+			//   - regex literal /…/ — `/` must be escaped
+			//   - JS string literal "pattern …" — `"`, `\`, control chars must be escaped
+			// Without jsStringEscape, a pattern containing `"` would terminate the JS
+			// string mid-emit and corrupt the surrounding object literal.
+			b.WriteString(fmt.Sprintf("\n    if (!/%s/.test(%s)) throw new __e([{path:%q,expected:\"pattern %s\",received:%s}]);",
+				escapeForRegexLiteral(raw), paramName, paramName, jsStringEscape(raw), paramName))
+		}
+		if c.MinLength != nil {
+			n := *c.MinLength
+			b.WriteString(fmt.Sprintf("\n    if (%s.length < %d) throw new __e([{path:%q,expected:\"minLength %d\",received:\"length \"+%s.length}]);",
+				paramName, n, paramName, n, paramName))
+		}
+		if c.MaxLength != nil {
+			n := *c.MaxLength
+			b.WriteString(fmt.Sprintf("\n    if (%s.length > %d) throw new __e([{path:%q,expected:\"maxLength %d\",received:\"length \"+%s.length}]);",
+				paramName, n, paramName, n, paramName))
+		}
+	}
+
+	if atomic == "number" {
+		if c.Minimum != nil {
+			v := formatNumber(*c.Minimum)
+			b.WriteString(fmt.Sprintf("\n    if (%s < %s) throw new __e([{path:%q,expected:\"minimum %s\",received:\"\"+%s}]);",
+				paramName, v, paramName, v, paramName))
+		}
+		if c.Maximum != nil {
+			v := formatNumber(*c.Maximum)
+			b.WriteString(fmt.Sprintf("\n    if (%s > %s) throw new __e([{path:%q,expected:\"maximum %s\",received:\"\"+%s}]);",
+				paramName, v, paramName, v, paramName))
+		}
+		if c.MultipleOf != nil {
+			v := *c.MultipleOf
+			// Only emit the simple integer modulo form. Non-integer multipleOf
+			// requires an epsilon comparison (see validate_constraints.go) and
+			// is out of scope for this scalar fast-path — skipped silently.
+			if v == float64(int64(v)) {
+				vs := formatNumber(v)
+				b.WriteString(fmt.Sprintf("\n    if (%s %% %s !== 0) throw new __e([{path:%q,expected:\"multipleOf %s\",received:\"\"+%s}]);",
+					paramName, vs, paramName, vs, paramName))
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// formatNumber renders a float64 as the shortest JS-equivalent literal: integers
+// print without a trailing ".0", non-integers use %g.
+func formatNumber(f float64) string {
+	if f == float64(int64(f)) {
+		return fmt.Sprintf("%d", int64(f))
+	}
+	return fmt.Sprintf("%g", f)
 }

--- a/internal/rewrite/controllers_test.go
+++ b/internal/rewrite/controllers_test.go
@@ -2022,3 +2022,419 @@ func TestRewriteController_BodyThirdParam_Destructured(t *testing.T) {
 		t.Errorf("expected destructuring reconstruction, got:\n%s", result)
 	}
 }
+
+// --- Gap A: named scalar @Param/@Query constraint emit (regex/length/numeric bounds) ---
+//
+// These tests pin the rewriter's responsibility to translate
+// metadata.Constraints captured by the analyzer (see
+// internal/analyzer/nestjs_test.go around line 4135) into runtime checks for
+// named scalar @Param('id') / @Query('q') parameters. Today the rewriter at
+// internal/rewrite/controllers.go only emits coercion when the atomic type is
+// number or boolean and never reads param.Type.Constraints, so a path param
+// declared as `string & Pattern<"...">` produces zero runtime validation.
+//
+// The emit shape mirrors the companion validator codegen in
+// internal/codegen/validate_constraints.go (e.g. `!/PATTERN/.test(id)`,
+// `id.length < N`, `id.length > N`).
+
+func strPtr(s string) *string { return &s }
+
+func intPtr(n int) *int { return &n }
+
+func floatPtr(f float64) *float64 { return &f }
+
+func TestRewriteController_StringParamWithPattern_EmitsRegexCheck(t *testing.T) {
+	input := `class UserController {
+    async findOne(id) {
+        return this.service.findOne(id);
+    }
+}`
+
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "UserController",
+			SourceFile: "/src/user.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					OperationID: "findOne",
+					MethodName:  "findOne",
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "param",
+							Name:      "id",
+							LocalName: "id",
+							Type: metadata.Metadata{
+								Kind:   metadata.KindAtomic,
+								Atomic: "string",
+								Constraints: &metadata.Constraints{
+									Pattern: strPtr("^[0-9a-fA-F]{24}$"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	companionMap := map[string]string{}
+
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
+
+	if !strings.Contains(result, `/^[0-9a-fA-F]{24}$/.test(id)`) {
+		t.Errorf("expected regex pattern test for @Param('id'), got:\n%s", result)
+	}
+	if !strings.Contains(result, "throw new __e(") {
+		t.Errorf("expected validation-error throw for @Param('id') pattern, got:\n%s", result)
+	}
+	if !strings.Contains(result, "TsgonestValidationError as __e") {
+		t.Errorf("expected helpers import for scalar constraint emit, got:\n%s", result)
+	}
+}
+
+func TestRewriteController_StringQueryWithPattern_EmitsRegexCheck(t *testing.T) {
+	input := `class SearchController {
+    async search(q) {
+        return this.service.search(q);
+    }
+}`
+
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "SearchController",
+			SourceFile: "/src/search.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					OperationID: "search",
+					MethodName:  "search",
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "query",
+							Name:      "q",
+							LocalName: "q",
+							Type: metadata.Metadata{
+								Kind:   metadata.KindAtomic,
+								Atomic: "string",
+								Constraints: &metadata.Constraints{
+									Pattern: strPtr("^[a-z0-9-]+$"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	companionMap := map[string]string{}
+
+	result := rewriteController(input, "/dist/search.controller.js", controllers, companionMap, "esm", nil)
+
+	if !strings.Contains(result, `/^[a-z0-9-]+$/.test(q)`) {
+		t.Errorf("expected regex pattern test for @Query('q'), got:\n%s", result)
+	}
+	if !strings.Contains(result, "throw new __e(") {
+		t.Errorf("expected validation-error throw for @Query('q') pattern, got:\n%s", result)
+	}
+}
+
+func TestRewriteController_StringParamWithMaxLength_EmitsLengthCheck(t *testing.T) {
+	input := `class UserController {
+    async findOne(id) {
+        return this.service.findOne(id);
+    }
+}`
+
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "UserController",
+			SourceFile: "/src/user.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					OperationID: "findOne",
+					MethodName:  "findOne",
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "param",
+							Name:      "id",
+							LocalName: "id",
+							Type: metadata.Metadata{
+								Kind:   metadata.KindAtomic,
+								Atomic: "string",
+								Constraints: &metadata.Constraints{
+									MaxLength: intPtr(24),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	companionMap := map[string]string{}
+
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
+
+	if !strings.Contains(result, "id.length > 24") {
+		t.Errorf("expected MaxLength check for @Param('id'), got:\n%s", result)
+	}
+	if !strings.Contains(result, "throw new __e(") {
+		t.Errorf("expected validation-error throw for @Param('id') MaxLength, got:\n%s", result)
+	}
+}
+
+func TestRewriteController_StringParamWithMinLength_EmitsLengthCheck(t *testing.T) {
+	input := `class UserController {
+    async findOne(id) {
+        return this.service.findOne(id);
+    }
+}`
+
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "UserController",
+			SourceFile: "/src/user.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					OperationID: "findOne",
+					MethodName:  "findOne",
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "param",
+							Name:      "id",
+							LocalName: "id",
+							Type: metadata.Metadata{
+								Kind:   metadata.KindAtomic,
+								Atomic: "string",
+								Constraints: &metadata.Constraints{
+									MinLength: intPtr(1),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	companionMap := map[string]string{}
+
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
+
+	if !strings.Contains(result, "id.length < 1") {
+		t.Errorf("expected MinLength check for @Param('id'), got:\n%s", result)
+	}
+	if !strings.Contains(result, "throw new __e(") {
+		t.Errorf("expected validation-error throw for @Param('id') MinLength, got:\n%s", result)
+	}
+}
+
+func TestRewriteController_NumberParamWithMinMax_CoerceAndCheck(t *testing.T) {
+	input := `class UserController {
+    async findByAge(age) {
+        return this.service.findByAge(age);
+    }
+}`
+
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "UserController",
+			SourceFile: "/src/user.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					OperationID: "findByAge",
+					MethodName:  "findByAge",
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "param",
+							Name:      "age",
+							LocalName: "age",
+							Type: metadata.Metadata{
+								Kind:   metadata.KindAtomic,
+								Atomic: "number",
+								Constraints: &metadata.Constraints{
+									Minimum: floatPtr(0),
+									Maximum: floatPtr(120),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	companionMap := map[string]string{}
+
+	result := rewriteController(input, "/dist/user.controller.js", controllers, companionMap, "esm", nil)
+
+	if !strings.Contains(result, "age = +age") {
+		t.Errorf("expected number coercion to remain for constrained @Param('age'), got:\n%s", result)
+	}
+	if !strings.Contains(result, "Number.isNaN(age)") {
+		t.Errorf("expected NaN guard for constrained @Param('age'), got:\n%s", result)
+	}
+	if !strings.Contains(result, "age < 0") {
+		t.Errorf("expected Minimum check for @Param('age'), got:\n%s", result)
+	}
+	if !strings.Contains(result, "age > 120") {
+		t.Errorf("expected Maximum check for @Param('age'), got:\n%s", result)
+	}
+	if !strings.Contains(result, "throw new __e(") {
+		t.Errorf("expected validation-error throw for numeric bounds, got:\n%s", result)
+	}
+}
+
+// SCOPE-PROBE: pins today's behavior that named scalar @Headers() short-circuits
+// before constraint emit (controllers.go:161 has `param.Category != "headers"`).
+// This test PASSES today and documents the boundary of the Gap A fix: header
+// scalar constraints are future work and intentionally not emitted yet.
+func TestRewriteController_StringHeaderWithPattern_EmitsRegexCheck_OR_RemainsUnvalidatedDocumented(t *testing.T) {
+	input := `class TraceController {
+    async ping(trace) {
+        return this.service.ping(trace);
+    }
+}`
+
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "TraceController",
+			SourceFile: "/src/trace.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					OperationID: "ping",
+					MethodName:  "ping",
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "headers",
+							Name:      "x-trace",
+							LocalName: "trace",
+							Type: metadata.Metadata{
+								Kind:   metadata.KindAtomic,
+								Atomic: "string",
+								Constraints: &metadata.Constraints{
+									Pattern: strPtr("^[0-9a-f]{32}$"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	companionMap := map[string]string{}
+
+	result := rewriteController(input, "/dist/trace.controller.js", controllers, companionMap, "esm", nil)
+
+	// Future work: when Gap A is extended to headers, this test should be flipped
+	// to assert the regex emit (mirroring TestRewriteController_StringParamWithPattern_EmitsRegexCheck).
+	// Until then, named scalar @Headers() should remain unchanged.
+	if result != input {
+		t.Errorf("named scalar @Headers() should remain unchanged today, got:\n%s", result)
+	}
+}
+
+// TestRewriteController_StringParamWithPatternContainingQuote_EscapesSafely pins
+// the Item-1 escape fix: a @pattern value containing a `"` must not break the
+// emitted JS by terminating the `expected: "pattern …"` string literal early.
+// Without jsStringEscape on the embedded pattern, the emit would be invalid JS.
+func TestRewriteController_StringParamWithPatternContainingQuote_EscapesSafely(t *testing.T) {
+	input := `class UserController {
+    async findByLabel(label) {
+        return this.service.findByLabel(label);
+    }
+}`
+
+	pattern := `^a"b$` // contains a literal double-quote — the danger case
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "UserController",
+			SourceFile: "/src/user.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					OperationID: "findByLabel",
+					MethodName:  "findByLabel",
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "param",
+							Name:      "label",
+							LocalName: "label",
+							Type: metadata.Metadata{
+								Kind:        metadata.KindAtomic,
+								Atomic:      "string",
+								Constraints: &metadata.Constraints{Pattern: strPtr(pattern)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := rewriteController(input, "/dist/user.controller.js", controllers, map[string]string{}, "esm", nil)
+
+	// The escaped pattern in the error message must read `^a\"b$`, not `^a"b$`.
+	// If unescaped, the JS string literal terminates after `^a` and the rest is garbage.
+	if !strings.Contains(result, `expected:"pattern ^a\"b$"`) {
+		t.Errorf("expected escaped pattern in error message (`expected:\"pattern ^a\\\"b$\"`), got:\n%s", result)
+	}
+	// The regex literal itself is fine with an unescaped `"` (regex literals allow quotes).
+	if !strings.Contains(result, `/^a"b$/.test(label)`) {
+		t.Errorf("expected regex literal /^a\"b$/ in test call, got:\n%s", result)
+	}
+	// Sanity: validation-error throw is still present.
+	if !strings.Contains(result, "throw new __e(") {
+		t.Errorf("expected throw new __e( in emit, got:\n%s", result)
+	}
+}
+
+// TestRewriteController_StringParamWithPatternContainingBackslash_EscapesSafely
+// covers the related escaping case where a pattern ends with a backslash. An
+// unescaped trailing `\` would cause the emitted JS string literal to continue
+// past its closing quote, breaking the surrounding object literal.
+func TestRewriteController_StringParamWithPatternContainingBackslash_EscapesSafely(t *testing.T) {
+	input := `class UserController {
+    async find(id) {
+        return this.service.find(id);
+    }
+}`
+
+	pattern := `\d+` // contains backslash + a control-char-like sequence
+	controllers := []analyzer.ControllerInfo{
+		{
+			Name:       "UserController",
+			SourceFile: "/src/user.controller.ts",
+			Routes: []analyzer.Route{
+				{
+					OperationID: "find",
+					MethodName:  "find",
+					Parameters: []analyzer.RouteParameter{
+						{
+							Category:  "param",
+							Name:      "id",
+							LocalName: "id",
+							Type: metadata.Metadata{
+								Kind:        metadata.KindAtomic,
+								Atomic:      "string",
+								Constraints: &metadata.Constraints{Pattern: strPtr(pattern)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := rewriteController(input, "/dist/user.controller.js", controllers, map[string]string{}, "esm", nil)
+
+	// In the JS string literal, `\` must be doubled: `pattern \\d+`.
+	if !strings.Contains(result, `expected:"pattern \\d+"`) {
+		t.Errorf("expected doubled backslash in error message (`expected:\"pattern \\\\d+\"`), got:\n%s", result)
+	}
+	// Regex literal preserves the single backslash: /\d+/
+	if !strings.Contains(result, `/\d+/.test(id)`) {
+		t.Errorf("expected regex literal /\\d+/ in test call, got:\n%s", result)
+	}
+}

--- a/internal/rewrite/mongoid_integration_test.go
+++ b/internal/rewrite/mongoid_integration_test.go
@@ -1,0 +1,223 @@
+package rewrite
+
+import (
+	"context"
+	"path"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	shimchecker "github.com/microsoft/typescript-go/shim/checker"
+	shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tsoptions"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/tsgonest/tsgonest/internal/analyzer"
+	"github.com/tsgonest/tsgonest/internal/testutil"
+)
+
+// rewriteIntegrationEnv mirrors analyzer_test.walkerEnv but lives in package rewrite
+// so the integration tests below can drive both layers (analyzer + rewriter) from
+// the same compiled tsgo program.
+type rewriteIntegrationEnv struct {
+	program    *shimcompiler.Program
+	checker    *shimchecker.Checker
+	sourceFile *ast.SourceFile
+	release    func()
+}
+
+func setupRewriteIntegration(t *testing.T, tsSource string) *rewriteIntegrationEnv {
+	t.Helper()
+	_, filename, _, _ := runtime.Caller(0)
+	rootDir := path.Join(path.Dir(filename), "..", "..", "testdata", "walker")
+	fileName := "test.ts"
+	filePath := tspath.ResolvePath(rootDir, fileName)
+
+	fs := testutil.NewDefaultOverlayVFS(map[string]string{filePath: tsSource})
+	host := shimcompiler.NewCompilerHost(rootDir, fs, bundled.LibPath(), nil, nil)
+
+	parsed, diags := tsoptions.GetParsedCommandLineOfConfigFile("tsconfig.json", &core.CompilerOptions{}, nil, host, nil)
+	if len(diags) > 0 {
+		t.Fatalf("tsconfig parse errors: %v", diags[0].String())
+	}
+
+	program := shimcompiler.NewProgram(shimcompiler.ProgramOptions{
+		Config:                      parsed,
+		SingleThreaded:              core.TSTrue,
+		Host:                        host,
+		UseSourceOfProjectReference: true,
+	})
+	if program == nil {
+		t.Fatal("failed to create program")
+	}
+	program.BindSourceFiles()
+
+	sf := program.GetSourceFile(fileName)
+	if sf == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	ck, rel := program.GetTypeChecker(context.Background())
+	if ck == nil {
+		t.Fatal("failed to get type checker")
+	}
+	return &rewriteIntegrationEnv{program: program, checker: ck, sourceFile: sf, release: rel}
+}
+
+// TestIntegration_MongoIdAliasOnNamedParam_EmitsRuntimeRegexCheck exercises the
+// full pipeline reported in the issue: a JSDoc-annotated string alias used as
+// the type of a named @Param() must flow through the analyzer (Gap B) and into
+// the controller rewriter (Gap A) to produce an inline regex check in JS.
+//
+// The test deliberately asserts the analyzer-side outcome first, then the
+// rewriter-side outcome. A failure in the first assertion pinpoints the analyzer
+// layer; a failure only in the second pinpoints the rewriter layer.
+func TestIntegration_MongoIdAliasOnNamedParam_EmitsRuntimeRegexCheck(t *testing.T) {
+	env := setupRewriteIntegration(t, `
+		function Controller(path: string): ClassDecorator { return (target) => target; }
+		function Get(path?: string): MethodDecorator { return (t, k, d) => d; }
+		function Param(name: string): ParameterDecorator { return () => {}; }
+
+		/** @pattern ^[0-9a-fA-F]{24}$ */
+		type MongoId = string;
+
+		@Controller("projects")
+		class ProjectController {
+			@Get(":projectID")
+			findOne(@Param("projectID") projectID: MongoId): {} { return {}; }
+		}
+	`)
+	defer env.release()
+
+	ca, caRelease := analyzer.NewControllerAnalyzer(env.program)
+	defer caRelease()
+
+	controllers := ca.AnalyzeSourceFile(env.sourceFile)
+	if len(controllers) != 1 {
+		t.Fatalf("expected 1 controller, got %d", len(controllers))
+	}
+	if len(controllers[0].Routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(controllers[0].Routes))
+	}
+	route := controllers[0].Routes[0]
+	if len(route.Parameters) != 1 {
+		t.Fatalf("expected 1 parameter, got %d", len(route.Parameters))
+	}
+	param := route.Parameters[0]
+
+	// Analyzer-side assertion (Gap B): the JSDoc @pattern on the MongoId alias
+	// must surface as Constraints.Pattern on the route parameter's Type.
+	if param.Type.Constraints == nil {
+		t.Fatal("analyzer gap: expected Constraints on @Param('projectID') projectID: MongoId, got nil")
+	}
+	if param.Type.Constraints.Pattern == nil {
+		t.Fatal("analyzer gap: expected Constraints.Pattern set from JSDoc @pattern, got nil")
+	}
+	if got := *param.Type.Constraints.Pattern; got != "^[0-9a-fA-F]{24}$" {
+		t.Fatalf("analyzer gap: expected Pattern=%q, got %q", "^[0-9a-fA-F]{24}$", got)
+	}
+
+	// Rewriter-side assertion (Gap A): given the analyzer captured the pattern,
+	// the controller rewriter must inline a runtime regex check for the named
+	// scalar @Param. The synthetic JS mirrors what tsgo would emit for the
+	// stripped controller body.
+	syntheticJS := `class ProjectController {
+    findOne(projectID) {
+        return {};
+    }
+}`
+
+	result := rewriteController(syntheticJS, "/dist/project.controller.js", controllers, map[string]string{}, "esm", nil)
+
+	if !strings.Contains(result, `/^[0-9a-fA-F]{24}$/.test(projectID)`) {
+		t.Errorf("rewriter gap: expected regex check `/^[0-9a-fA-F]{24}$/.test(projectID)`, got:\n%s", result)
+	}
+	if !strings.Contains(result, "throw new __e(") {
+		t.Errorf("rewriter gap: expected `throw new __e(` to surround the regex check, got:\n%s", result)
+	}
+}
+
+// TestIntegration_MongoIdAliasOnPropertyOfBody_EmitsCompanionConstraint proves
+// that Gap B also reaches DTO properties: the JSDoc @pattern on the MongoId
+// alias propagates onto a property of a CreateDto used as @Body(). This is the
+// metadata the .tsgonest.js companion codegen consumes. The rewriter does NOT
+// emit inline checks for @Body — it emits an `assertCreateDto(body)` call that
+// defers to the companion file — so this test stops at the analyzer assertion.
+func TestIntegration_MongoIdAliasOnPropertyOfBody_EmitsCompanionConstraint(t *testing.T) {
+	env := setupRewriteIntegration(t, `
+		function Controller(path: string): ClassDecorator { return (target) => target; }
+		function Post(path?: string): MethodDecorator { return (t, k, d) => d; }
+		function Body(): ParameterDecorator { return () => {}; }
+
+		/** @pattern ^[0-9a-fA-F]{24}$ */
+		type MongoId = string;
+
+		interface CreateDto {
+			projectID: MongoId;
+		}
+
+		@Controller("projects")
+		class ProjectController {
+			@Post()
+			create(@Body() dto: CreateDto): {} { return {}; }
+		}
+	`)
+	defer env.release()
+
+	ca, caRelease := analyzer.NewControllerAnalyzer(env.program)
+	defer caRelease()
+
+	controllers := ca.AnalyzeSourceFile(env.sourceFile)
+	if len(controllers) != 1 {
+		t.Fatalf("expected 1 controller, got %d", len(controllers))
+	}
+	if len(controllers[0].Routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(controllers[0].Routes))
+	}
+	route := controllers[0].Routes[0]
+	if len(route.Parameters) != 1 {
+		t.Fatalf("expected 1 parameter, got %d", len(route.Parameters))
+	}
+	param := route.Parameters[0]
+	if param.Category != "body" {
+		t.Fatalf("expected Category='body', got %q", param.Category)
+	}
+
+	// Resolve KindRef to the registered object so we can inspect properties.
+	bodyType := param.Type
+	if bodyType.Kind == "ref" {
+		reg := ca.Registry()
+		if resolved, ok := reg.Types[bodyType.Ref]; ok && resolved != nil {
+			bodyType = *resolved
+		}
+	}
+	if len(bodyType.Properties) == 0 {
+		t.Fatalf("expected CreateDto to have properties, got %d", len(bodyType.Properties))
+	}
+
+	var projectIDProp = -1
+	for i := range bodyType.Properties {
+		if bodyType.Properties[i].Name == "projectID" {
+			projectIDProp = i
+			break
+		}
+	}
+	if projectIDProp < 0 {
+		t.Fatal("expected property 'projectID' on CreateDto")
+	}
+	prop := bodyType.Properties[projectIDProp]
+
+	// Gap B reaches into property types too: the JSDoc @pattern on MongoId
+	// must propagate to the projectID property's Constraints.Pattern, which is
+	// what companion codegen reads when emitting assertCreateDto.
+	if prop.Constraints == nil {
+		t.Fatal("analyzer gap: expected Constraints on projectID property, got nil")
+	}
+	if prop.Constraints.Pattern == nil {
+		t.Fatal("analyzer gap: expected Constraints.Pattern on projectID property from JSDoc @pattern, got nil")
+	}
+	if got := *prop.Constraints.Pattern; got != "^[0-9a-fA-F]{24}$" {
+		t.Fatalf("analyzer gap: expected Pattern=%q on projectID property, got %q", "^[0-9a-fA-F]{24}$", got)
+	}
+}


### PR DESCRIPTION
## Summary

Three independent gaps were causing JSDoc constraints on type aliases (e.g. `/** @pattern */ type MongoId = string`) to silently disappear at runtime, despite appearing in OpenAPI output. This PR closes all three and bumps the build-cache schema so upgrading users get a fresh build.

## What's fixed

### 1. Cross-file imported aliases
`GetSymbolAtLocation` on a `TypeReference` returns an import-alias symbol whose `Declarations` are `ImportSpecifier` nodes, not the original `TypeAliasDeclaration`. The analyzer now follows `GetAliasedSymbol` to reach the real declaration, so `import { MongoId } from './utils'` works the same as a same-file alias.

### 2. Array elements of aliased types
- Analyzer recurses into `KindArrayType.ElementType` and attaches alias-JSDoc to `propMeta.ElementType.Constraints`.
- Codegen emits per-element constraint checks inside both `assertX` and `validateX` iteration loops. The assert path reuses the existing `generateAssertConstraintChecks` (which already accepts a JS path expression). The validate path gets a new sibling `generateValidateConstraintChecksDynamicPath` for parity.

### 3. Named scalar `@Param('id')` / `@Query('q')` constraint emit
The rewriter previously only emitted coercion for `number`/`boolean` named scalars; `param.Type.Constraints` was never consulted. Now emits runtime checks for Pattern/MinLength/MaxLength (strings) and Minimum/Maximum/MultipleOf (numbers), alongside existing coercion. Pattern strings are passed through `jsStringEscape` before embedding into emitted `expected: "pattern …"` JS literals, defending against patterns containing `"` or `\`.

## Cache invalidation

`SchemaVersion` 1 → 2. Older `.tsgonest-cache` files predate the new emissions and would cause stale companions to be retained across a binary upgrade. Bumping forces a one-time full rebuild on first run with the new binary.

## Test coverage

20+ new tests:

| Package | Tests added |
|---|---|
| `internal/analyzer` | 9 (`TestWalkJSDocOnTypeAlias_*`) — same-file scalar, format/minMax, precedence, parameter-position, no-cross-contamination, cross-file import, array element, cross-file array element |
| `internal/codegen` | 4 (`TestValidateArrayElement*`, `TestAssertArrayElement*`, `TestValidate_AliasArrayMongoIdEndToEnd_EmitsRegex`) |
| `internal/rewrite` | 6 unit + 2 escape regression + 2 integration (`TestRewriteController_String*`, `TestRewriteController_Number*`, `TestRewriteController_StringHeader*`, `TestRewriteController_StringParamWithPatternContaining{Quote,Backslash}_EscapesSafely`, `TestIntegration_MongoIdAlias*`) |

Full Go suite (1,446 tests across 13 packages) passes under `-race`. E2e suite passes (270 passed, 16 skipped, 1 pre-existing flake — see below).

End-to-end smoke against a real NestJS project shape confirms:
```js
// dist/meeting/controllers/meeting.controller.js
async getMeeting(workspaceID, meetingID) {
    if (!/^[0-9a-fA-F]{24}$/.test(workspaceID)) throw new __e([{path:"workspaceID",...}]);
    if (!/^[0-9a-fA-F]{24}$/.test(meetingID)) throw new __e([{path:"meetingID",...}]);
}

// dist/meeting/dto/meeting.dto.AddParticipantsDTO.tsgonest.js
for (let i1 = 0; i1 < input.userIds.length; i1++) {
    if (typeof input.userIds[i1] !== "string") throw new __e(...);
    if (typeof input.userIds[i1] === "string" && !/^[0-9a-fA-F]{24}$/.test(input.userIds[i1])) {
        throw new __e([{path: "input" + ".userIds" + "[" + i1 + "]", expected: "pattern ^[0-9a-fA-F]{24}$", ...}]);
    }
}
```

## Known follow-ups (not in this PR)

- **`Array<T>` / `ReadonlyArray<T>` syntax** — current fix handles `T[]` but not the generic form. Both shapes were equally broken before this PR; the fix doesn't yet extend to the generic form. AST kind there is `TypeReference` with `TypeArguments[0]`, not `ArrayType`.
- **Pre-existing path-quoting bug in `generateArrayCheck` (`validate.go:1135`)** — `path: %q` with a dynamic path expression emits broken JS error paths (`path: "input.userIds[\" + i1 + \"]"` instead of a real concatenation). Affects only `validateX`; production NestJS uses `assertX` (unaffected). Predates this PR.
- **`applyAliasJSDoc` `Type_alias`-based fast path** — currently lands constraints in places downstream doesn't consume for the object-alias case. Could be removed or documented as defensive.

## Pre-existing e2e flake

`check.test.ts > tsgonest check > should not emit any files` is racy when run as part of the full e2e suite: `testdata/simple/dist` gets repopulated by a parallel test file between this test's `rmSync` and its `existsSync` assertion. Passes 9/9 in isolation. Predates this PR and unrelated to these changes.

## Commit structure

4 logically-scoped commits for review-friendliness:
- `fix(analyzer): propagate JSDoc on type-alias declarations through imports and arrays`
- `fix(codegen): emit per-element constraint checks in array iteration loops`
- `fix(rewrite): runtime constraint checks for named scalar @Param/@Query params`
- `chore(cache): bump SchemaVersion to 2 for new analysis output format`
