### PR TITLE
feat(mint): Mint framework v1 — all 12 phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
 
+      # Mint e2e fixtures spawn `bun` to boot the compiled server before
+      # exercising routes. Existing testdata/integration e2e tests also use
+      # `runtime: 'bun'` for the eventstream and upload variants.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.12'
+
       - name: Initialize project
         run: just init
 

--- a/.scratch/mint/PRD.md
+++ b/.scratch/mint/PRD.md
@@ -1,0 +1,206 @@
+# PRD: Mint — tiny web framework for Bun, built on tsgonest
+
+Status: ready-for-agent
+
+> Brand: **Mint**. Core package: `@mintkit/core`. Bun adapter package: `@mintkit/bun`.
+> Companion technical spec: [`../../plans/mint-spec.md`](../../plans/mint-spec.md)
+> Implementation plan: [`../../plans/mint-plan.md`](../../plans/mint-plan.md)
+> Implementation issues: [`./issues/`](./issues/)
+
+## Problem Statement
+
+I (a backend developer) am hitting a wall with NestJS + Node. The NestJS mental model (DI, modules, Angular-style organization) fits my brain, but the rest of the stack drags: pipes/interceptors/HttpException ceremony, opaque factory-style decorators that defeat static analysis, runtime baggage inherited from Express, and a request-scoped DI model I've never wanted. I want to keep the parts that work — module system, dependency injection, decorator-driven routing — and discard everything else. Bun is my deployment target; I don't care about Node, Workers, or Deno today, but I don't want the framework to paint itself into a single-platform corner. I need to keep tsgonest's compile-time benefits: validated `@Body`/`@Query`/`@Param`/`@Headers` parameters, OpenAPI 3.2 generation, and SDK generation from TypeScript types.
+
+## Solution
+
+A small web framework whose entire runtime is: a DI container (singleton + transient scope only, no request scope), a module system, a radix router, an `Event` abstraction over Web `Request`/`Response`, an onion-style middleware chain, and a lifecycle subsystem. Decorators (`@Controller`, `@Get`, `@Body`, etc.) are compile-time sugar — at runtime, the framework sees plain function calls that register routes. The runtime depends on no decorator-metadata reflection. Everything beyond core primitives (auth, observability, file storage, rate limiting, CORS, cookies) ships as shadcn-style vendored modules that the user owns and customizes inside their own repo. tsgonest's existing compile-time pipeline is extended (not replaced) to recognize the new framework's decorators and emit registration calls in the generated `*.tsgonest.js` companion files. Web standards are the lingua franca: `Request`, `Response`, `Headers`, `File`, `FormData`, `ReadableStream`. Bun is the only adapter shipped in v1; the design reserves four micro-extensions (middleware return type widened to `Response | Upgrade`, router method slot as a free-form string, token-store as a shared interface, framing-agnostic validator codegen) so that WebSockets and other platform adapters slot in additively rather than as breaking changes.
+
+## User Stories
+
+1. As a backend dev, I want to define a service with constructor-injected dependencies, so that I can write business logic without manually wiring imports.
+2. As a backend dev, I want to declare a controller with route decorators, so that I can group endpoints by domain.
+3. As a backend dev, I want my `@Body` parameter validated against its TypeScript type at request time, so that I never write manual validation.
+4. As a backend dev, I want validation errors to return a standards-compliant problem-details JSON response, so that clients can parse errors uniformly.
+5. As a backend dev, I want to define a module with `imports`, `providers`, `exports`, `controllers`, and module-level `middleware`, so that I can organize features by domain boundary.
+6. As a backend dev, I want to declare a dynamic module as a function returning a static module shape, so that I can pass configuration at boot.
+7. As a backend dev, I want an async-factory provider with `inject`/`useFactory`, so that I can resolve config from another provider before constructing a downstream service.
+8. As a backend dev, I want providers to support an `init()` hook, so that I can open database connections and warm caches before traffic starts.
+9. As a backend dev, I want providers to support `Symbol.asyncDispose`, so that on graceful shutdown I can close resources via the TC39 standard.
+10. As a backend dev, I want the framework to fail-fast on dependency cycles between providers, so that I never debug runtime DI ordering issues.
+11. As a backend dev, I want the framework to fail-fast if any provider's `init()` throws, so that I never serve traffic with a partially-initialized app.
+12. As a backend dev, I want middleware shaped as `(event, next) => Promise<Response | Upgrade>`, so that I compose cross-cutting concerns with async/await rather than Express callbacks.
+13. As a backend dev, I want `app.use(mw)` and `app.use('/prefix', mw)`, so that observability and logging attach app-wide or to URL prefixes.
+14. As a backend dev, I want `defineModule({ middleware: [...] })` to bind middleware to that module's declared controllers without cascading to imports, so that vendored modules are self-contained and predictable.
+15. As a backend dev, I want `@UseMiddleware(mw)` on a controller class or method, so that I attach middleware to a specific scope without route-config noise.
+16. As a backend dev, I want middleware to `await next()` and modify the downstream response, so that I can wrap handlers (timing, headers, transforms).
+17. As a backend dev, I want middleware to throw to short-circuit, so that auth failures stop the chain without callback contortions.
+18. As a backend dev, I want middleware to pass data downstream via typed tokens (`event.set(USER, u)`, `event.require(USER)`), so that handlers receive typed context without `declare module` augmentation.
+19. As a backend dev, I want to define typed context tokens with `defineToken<User>(...)`, so that set/get sites are type-checked at compile time.
+20. As a backend dev, I want `event.request` to be the raw Web `Request`, so that I work with headers, method, and URL via standards I already know.
+21. As a backend dev, I want `event.body.bytes()` / `text()` / `json()` / `formData()` to memoize, so that middleware and the handler can both read the body without manual caching.
+22. As a backend dev, I want `event.body.stream()` to return the underlying ReadableStream once, so that I can pipe large payloads to disk without buffering.
+23. As a backend dev, I want `event.response.headers` (a real `Headers` instance) and `event.response.status` (a number), so that I work with the Web platform API directly.
+24. As a backend dev, I want file uploads typed as `File` (buffered) or `FileStream` (streaming) with `MaxSize<N>`, `MinSize<N>`, `MimeTypes<U>` tag constraints, so that uploads validate at the byte level without a multer/decorator pipeline.
+25. As a backend dev, I want streaming uploads to abort the connection at the configured byte limit, so that abuse cannot fill server memory.
+26. As a backend dev, I want SSE handlers via `sse(async function* () { yield ...; })`, so that I can implement server-sent events without writing the framing code.
+27. As a backend dev, I want errors to be thrown (not returned as `Result`), so that I use try/catch and async/await naturally.
+28. As a backend dev, I want a typed `HttpError` hierarchy (`BadRequestError`, `NotFoundError`, `UnauthorizedError`, `ForbiddenError`, `ConflictError`, `InternalServerError`, …), so that I express HTTP semantics by throwing.
+29. As a backend dev, I want to register custom mappings via `app.onError`, so that domain exceptions map to HTTP responses outside the domain layer.
+30. As a backend dev, I want `event.waitUntil(promise)` for after-response work, so that logging/metrics run after responding without blocking and remain portable across platforms.
+31. As a backend dev, I want all framework decorators to be fully erased at runtime, so that nothing depends on `reflect-metadata`.
+32. As a backend dev, I want `@Ctx(TOKEN)` on handler parameters, so that I declare typed context dependencies per-handler with type checking against the token's `T`.
+33. As a backend dev, I want `createContext({ imports })` for headless apps, so that I can use DI/modules for CLIs, queue consumers, cron, and migrations without HTTP.
+34. As a backend dev, I want headless contexts to support `await using`, so that short-lived CLI tools auto-dispose on scope exit.
+35. As a backend dev, I want `App extends Context`, so that helpers written against `Context` work inside HTTP apps too.
+36. As a backend dev, I want decorator metadata to be statically analyzable by the existing tsgonest analyzer, so that no new infrastructure is needed for validators or OpenAPI.
+37. As a backend dev using Bun, I want a vendored `wrap(app)` adapter plus a vendored `gracefulShutdown(app, { signals, timeout })` helper, so that I can serve traffic and shut down cleanly on SIGTERM.
+38. As a backend dev, I want a `BUN_SERVER` token from the Bun adapter, so that I can access Bun's `Server` instance for advanced cases (e.g., future WS upgrades) without leaking platform types into core.
+39. As an ecosystem module author, I want to ship a shadcn-style vendored module with its own typed tokens, so that consumers import named tokens rather than augmenting global types.
+40. As an ecosystem module author, I want to declare module-level middleware that auto-attaches to my module's controllers, so that vendoring my module gives users the expected behavior without per-route wiring.
+41. As an ecosystem module author, I want to ship both `Module(opts)` and `ModuleAsync({ inject, useFactory })` shapes, so that consumers configure synchronously or via injection.
+42. As an ecosystem module author, I want the module-shape conventions (`*.module.ts`, `*.service.ts`, `*.controller.ts`, `*.config.ts`, `*.types.ts`, `*.middleware.ts`) to be documented but not enforced, so that my recipes feel native while users retain full ownership.
+43. As a future maintainer, I want WS support to require no breaking changes to the middleware return type, so that I can add WebSockets later additively.
+44. As a future maintainer, I want the router's method slot to accept arbitrary strings (`'GET' | 'POST' | ... | 'WS'`), so that WS routes register through the existing matcher.
+45. As a future maintainer, I want the token-store interface shared by `Event` and a future `Session`, so that adding WS does not fragment the context API.
+46. As a future maintainer, I want compile-time validator generation to be framing-agnostic, so that the same generator emits HTTP body validators today and WS message validators later.
+47. As an ops engineer, I want graceful shutdown to drain in-flight requests before disposing providers, so that no request dies mid-flight on deploys.
+48. As an ops engineer, I want `Symbol.asyncDispose` to run providers in reverse topological order, so that downstream services aren't torn down before their dependents.
+49. As a CI engineer, I want fast-fail boot semantics, so that bad config or missing dependencies surface at deploy rather than under load.
+50. As a backend dev, I want the boot sequence documented as a fixed six-step order, so that I know where to hang startup logic.
+51. As a backend dev, I want explicit module imports (no glob auto-discovery), so that the dependency graph is grep-able and reproducible.
+52. As a backend dev, I want providers private to their declaring module by default, so that I get encapsulation without ceremony.
+53. As a backend dev, I want to opt providers into cross-module visibility via `exports`, so that the API surface of each module is explicit.
+54. As a backend dev, I want re-exports through import chains to be explicit, so that there are no surprise leaks.
+55. As a backend dev, I want serializer behavior customizable via type tags (`Date & DateFormat<'iso'>`), so that customization stays at the type-system layer and the compile-time guarantee holds.
+56. As a backend dev, I want OpenAPI 3.2 + SDK generation to include all framework routes automatically, so that I never write API docs by hand.
+57. As a backend dev, I want middleware to access DI via `event.resolve(Token)`, so that middleware can use injected services without class wrappers.
+58. As a backend dev, I want only function-shaped middleware (no class middleware), so that I have a single mental model for composition.
+59. As a backend dev, I want no built-in `defineGuard` sugar, so that guards are just middleware and arrive via the ecosystem rather than core API surface.
+60. As a backend dev, I want the framework footprint to remain small (just container, router, event, middleware chain, lifecycle), so that my bundle stays small and the framework doesn't dictate my architecture.
+61. As a backend dev, I want shadcn-style ecosystem modules (auth, storage, observability) installed via copy-paste into my repo, so that I own and customize them rather than depending on a versioned third-party package.
+62. As a backend dev, I want a strict middleware order (registration order at each layer; outer-to-inner across `app` → module → controller → method), so that I never have to memorize precedence rules.
+63. As a backend dev, I want `event.get(TOKEN)` to return `T | undefined` and `event.require(TOKEN)` to return `T` or throw, so that I have explicit handling for optional vs required context.
+64. As a backend dev, I want the headless `Context` API to expose only `resolve` and `Symbol.asyncDispose`, so that the surface is minimal and discoverable.
+65. As a backend dev, I want no string-key DI tokens in v1, so that all DI is type-safe; string tokens can be added later if real demand emerges.
+
+## Implementation Decisions
+
+### Modules (13)
+
+The framework decomposes into 13 modules. Each is sized to be testable in isolation; the first four are deep modules (encapsulated complexity, simple interface).
+
+**Deep core modules:**
+
+1. **Container.** Token-typed DI. `Token<T>` is a class with a phantom generic carrying the value type; `defineToken<T>(name)` produces one. Two provider forms: class shorthand (`UserService`) and object form (`{ provide: TOKEN, useValue }` or `{ provide: TOKEN, useFactory, inject }`). Singleton (default) and transient scope only. Topological construction order. Cycle detection at boot. No `useExisting`, no multi-providers, no string tokens (v1). Resolves via `container.resolve(token)`; class refs are tokens for free.
+2. **Module resolver.** Flattens import graph, dedupes by identity, validates: no duplicate provider tokens across the graph, no cycles between providers, every `@Inject(TOKEN)` resolves to a visible provider. Enforces visibility — providers are private unless listed in `exports`; controllers are always globally registered.
+3. **Router.** Radix tree. Method slot is a free-form string (`'GET'`, `'POST'`, …, `'WS'`). Param extraction by name. Returns route metadata (the registered handler reference, params).
+4. **Middleware chain.** Onion-style composition. Four attach points: app (global or prefix), module (declaration-site, no cascade to imports), controller (`@UseMiddleware` on class), method (`@UseMiddleware` on method). Execution order: outer-to-inner across layers, registration order within each layer. `await next()` returns the downstream Response. Throwing skips to the error mapper. Handlers and middleware return `Promise<Response | Upgrade>`; v1 produces no `Upgrade` values, but the union is reserved for future WS without breaking changes.
+
+**Runtime state modules:**
+
+5. **Event.** Per-request state object. `event.request: Request` (raw Web Request). `event.body` is a memoized accessor: `bytes()`/`text()`/`json()`/`formData()` read once and cache; `stream()` returns the raw `ReadableStream` once. `event.response = { headers: Headers, status: number }` — mutated directly via the Web `Headers` API and a plain number. Token store: `event.set(token, value)`, `event.get(token): T | undefined`, `event.require(token): T`. `event.waitUntil(promise)` for after-response work; delegates to platform via adapter. `event.resolve(token)` for DI access from middleware.
+6. **Error mapper.** Pluggable. Default handlers map `HttpError` subclasses to their status + JSON body, map `TsgonestValidationError` to RFC 9457 `application/problem+json` (status 400, `type`/`title`/`detail`/per-field errors), and fall through to a 500 mapper for unhandled errors. Users register additional handlers via `app.onError(predicate, handler)`.
+7. **App / Context factory.** `createContext({ imports })` is the headless primitive; `createApp({ imports })` extends it with router + middleware chain + `fetch`. Both are async. `App extends Context`. The boot sequence is fixed:
+   1. Flatten module graph; dedupe by identity.
+   2. Validate configuration (cycles, duplicate tokens, missing exports). Fail fast.
+   3. Construct providers in topological order (deps before dependents).
+   4. Run `init()` on each provider that implements it, in topological order. If any throws, dispose already-initialized providers in reverse topological order and reject.
+   5. Register all controllers' routes via tsgonest-generated `registerXxxController(app)` calls (app only, skipped for context-only).
+   6. Resolve `createApp` / `createContext`. App is `fetch`-ready.
+
+   `Symbol.asyncDispose` drains in-flight requests, then runs each provider's `Symbol.asyncDispose` in reverse topological order.
+
+**Compile-time extensions to tsgonest:**
+
+8. **Decorator analyzer extension.** Recognizes the framework's decorators: `@Controller(path)`, the HTTP verb decorators, `@Body`, `@Query`, `@Param`, `@Headers`, `@Ctx`, `@UseMiddleware`. Resolves them through TypeScript's checker the same way the existing NestJS analyzer does — supporting import aliases, blocking factory-wrapped decorators (per the existing tsgonest constraint). Records controller/route metadata into the existing metadata model. Validates that `@Ctx(TOKEN) name: T` parameters type-match the token's `T`.
+9. **Route registration codegen.** Generates per-controller companion exports inside the existing `*.tsgonest.js` files: `registerXxxController(app)` functions that call `app.router.add(method, path, wrappedHandler)`. The wrapped handler reads validated parameters from the event, invokes the controller method, and serializes the return value. Reuses the existing companion-emission infrastructure; the new code is additive (current controller-skip logic gives way to controller-registration emission).
+
+**Runtime utilities:**
+
+10. **`sse()` helper.** `sse(generator: () => AsyncGenerator<T>)` returns a streaming `Response` with `text/event-stream` content type and proper framing. Typed via `SSEStream<T>` so OpenAPI/SDK can pick up the event type.
+11. **`HttpError` hierarchy.** `class HttpError extends Error` carries `status: number` and `body: unknown`. Subclasses: `BadRequestError`, `UnauthorizedError`, `ForbiddenError`, `NotFoundError`, `ConflictError`, `UnprocessableEntityError`, `TooManyRequestsError`, `InternalServerError`. Default error mapper handles all of them.
+12. **Public primitives.** `defineToken`, `defineModule`, `defineHandler`, `defineMiddleware` — typed pass-throughs for inference; exist to give users one canonical surface for each concept.
+
+**Vendored adapter (single package, copy-paste into user repo):**
+
+13. **Bun adapter.** Single vendored package providing `wrap(app)` (passes `app.fetch` to `Bun.serve` plus per-request token injection), `BUN_SERVER` token (typed Bun `Server` reference, set on each event by the adapter), and `gracefulShutdown(app, { signals, timeout })` helper that wires SIGTERM/SIGINT to `app[Symbol.asyncDispose]()` with a configurable drain timeout.
+
+### Architectural decisions
+
+- **Web standards as the lingua franca.** `Request`, `Response`, `Headers`, `File`, `Blob`, `FormData`, `ReadableStream`. No framework-specific wrappers for things the platform already provides. The narrow exceptions: `event.body` (memoized over `Request.body`) to solve the once-only-read footgun, and the framework's own `Event`/`Token`/lifecycle primitives.
+- **Decorators are pure compile-time anchors.** Erased at runtime. tsgonest's analyzer reads them; the runtime sees only function calls registering routes. No `reflect-metadata`.
+- **Throw-based error contract.** No `Result` types in core. `app.onError(predicate, handler)` is the extensibility point. RFC 9457 problem-details is the default response shape; users can override.
+- **Singleton + transient only.** No request scope, no per-connection scope. Per-request state lives on the event (via tokens or `event.set/get`). This is the single biggest source of complexity in Nest's DI that we deliberately omit.
+- **Module-level middleware binds at declaration site.** No cascade to imported modules' controllers. Imported modules carry their own bindings.
+- **Boot is async, fail-fast, fully torn down on partial failure.** No partial-init state.
+- **No `forwardRef`.** Cycles error at boot.
+- **Headless context is the primitive; HTTP is a layer.** `createContext` returns a `Context` with `resolve` + `Symbol.asyncDispose`. `createApp` extends with router/middleware/`fetch`. `await using` is the canonical short-lived pattern.
+- **WS reservations.** Four micro-extensions ship in v1 even though WS itself does not: (a) middleware/handler return type is `Response | Upgrade`; (b) router method is a free-form string; (c) token store is an interface that `Event` and future `Session` both implement; (d) compile-time validator codegen is framing-agnostic, ready to emit message validators alongside body validators.
+
+### API contracts (key shapes, prose where possible)
+
+- `Token<T>` is a phantom-typed class; `defineToken<T>(name): Token<T>`.
+- `defineModule({ imports?, providers?, exports?, controllers?, middleware? })` — plain object pass-through; no class form.
+- `Provider = ClassConstructor | { provide: Token, useValue } | { provide: Token, useFactory, inject }`.
+- `Lifecycle: OnInit | AsyncDisposable | both` — structural interfaces, duck-typed at runtime.
+- `Middleware = (event: Event, next: () => Promise<Response | Upgrade>) => Promise<Response | Upgrade>`.
+- `Event = { request, body, response, set, get, require, waitUntil, resolve }`.
+- `createContext({ imports }): Promise<Context>`; `Context = { resolve, [Symbol.asyncDispose] }`.
+- `createApp({ imports }): Promise<App>`; `App extends Context` with additional `fetch(request): Promise<Response>`, `use(mw)` / `use(prefix, mw)`, `onError(predicate, handler)`, internal `router` and `createEvent` for adapters.
+- HTTP error classes carry `status: number` and `body: unknown`.
+
+### Build / packaging decisions
+
+- The framework's core lives at `packages/mint` (npm name `@mintkit/core`) within the existing pnpm workspace; `packages/core` is already in use by the `tsgonest` npm package. The Bun adapter lives at `packages/mint-bun` (npm name `@mintkit/bun`). Tsgonest analyzer + codegen changes happen in the existing Go module (`internal/analyzer`, `internal/codegen`).
+- TypeScript 5.2+ required at the consumer side (for `using` keyword).
+- Bun is the only v1 runtime target.
+
+## Testing Decisions
+
+A good test exercises external behavior, not implementation details. Tests should be written against each module's public interface; internal helpers and intermediate state are off-limits. Tests must remain valid through reasonable refactors of internals.
+
+All 13 modules require tests. Prior art lives in the existing tsgonest test infrastructure:
+
+**Go unit tests** (continuing the `internal/*/*_test.go` pattern with fixtures in `testdata/`):
+- **Decorator analyzer extension** — fixtures with TS source containing the new decorators; assert the metadata model captures controllers, routes, parameter bindings, `@Ctx` token references. Mirrors `internal/analyzer/nestjs_test.go`.
+- **Route registration codegen** — fixtures with annotated controllers; assert the generated `registerXxxController` exports have correct method/path/handler shape. Mirrors `internal/codegen/codegen_test.go`.
+
+**TypeScript unit tests** (Vitest, located in the new framework package's `__tests__` or alongside source per existing `packages/runtime/test` pattern):
+- **Container** — register/resolve for singleton, transient, class, useValue, useFactory; topological order on construction; reverse-topo on dispose; cycle detection; missing-token error.
+- **Module resolver** — flat graph, nested imports, dedupe by identity, visibility (private-by-default, explicit `exports`, re-exports through chains), duplicate-token detection, cycle detection across modules.
+- **Router** — radix tree correctness, param extraction (single, multiple, wildcard if supported), method matching (`GET`/`POST`/`WS`/etc.), no-match behavior.
+- **Middleware chain** — onion composition, registration order at each layer, outer-to-inner across layers, short-circuit (no `next()` call), throw propagation, response wrapping (`await next()` then modify).
+- **Event** — body memoization (`bytes`/`text`/`json`/`formData` cache; `stream` single-use), `response.headers` is a Headers instance, `response.status` is mutable, token set/get/require, `waitUntil` delegation (mocked).
+- **Error mapper** — default `HttpError` mapping, default `TsgonestValidationError` → RFC 9457 mapping (assert response shape, status, content-type), user-registered handler precedence, fallthrough 500 for unmatched.
+- **App / Context boot** — six-step order via assertions on hook invocations, fast-fail on init throw (assert partial dispose in reverse-topo), fast-fail on cycle, `Symbol.asyncDispose` drain semantics.
+
+**E2E tests** (continuing the `e2e/compile.test.ts` pattern in this repo — spawn the built tsgonest binary against a controller fixture, then run the emitted JS in a Bun subprocess):
+- Full pipeline: write a TS app using framework decorators, build via `tsgonest build`, boot the resulting JS in Bun, send Web `Request`s via `fetch`, assert response shapes/codes/headers.
+- Coverage: validated body/query/param/header, file upload (buffered and streaming), SSE response, validation error response (RFC 9457), thrown `HttpError` mapping, custom `onError`, middleware ordering across all four attach points, module-level middleware scoping, headless context for a one-shot CLI script (via `await using`).
+
+## Out of Scope
+
+- WebSocket support (deferred; reservations only).
+- Node, Cloudflare Workers, Deno adapters (Bun-only in v1).
+- Request-scoped DI; per-connection scope; child containers.
+- `forwardRef` / circular-dependency resolution mechanisms.
+- String-keyed DI tokens; multi-providers; `useExisting`; function-shaped provider declarations.
+- Glob / auto-discovery of modules and controllers.
+- AsyncAPI generation (will accompany WS when added).
+- Runtime serializer-override APIs (customization stays at type-tag level).
+- A `tsgonest add <module>` CLI (the shadcn-vendored module *shape* is specified; the CLI to scaffold modules into a user's repo is a separate effort).
+- Class-shaped middleware.
+- `defineGuard` / guard primitives. Guards are middleware; ecosystem modules ship them.
+- `onRequest` / `onResponse` lifecycle hooks separate from middleware.
+- Cookies API in core (ships as a vendored module).
+- CSRF, CORS, rate-limit, auth, session, observability, file-storage primitives (all ship as vendored ecosystem modules).
+- Microservice transport adapters (gRPC, NATS, RabbitMQ) — orthogonal effort; design preserves the flexibility for users to roll their own on top of the headless `createContext`.
+
+## Further Notes
+
+- **Naming.** Brand is **Mint**. Core package is `@mintkit/core` (workspace dir `packages/mint`). Vendored Bun adapter is `@mintkit/bun` (workspace dir `packages/mint-bun`). Internal docs may refer to "Mint" interchangeably with "the framework."
+- **Relationship to tsgonest.** This is a new framework that depends on tsgonest as a compile-time tool. tsgonest's analyzer and codegen pipelines are extended (additively) to recognize the framework's decorators and emit the registration calls. No changes to tsgonest's existing NestJS support — this is a parallel decorator vocabulary, identified via import path.
+- **Migration story from NestJS.** Out of scope as a v1 deliverable, but the decorator surface (`@Controller`, `@Get`, `@Body`, `@Param`, `@Query`, `@Headers`, `@Injectable`, `@Module`) is intentionally aligned so a future codemod is straightforward. Differences a migration must address: no pipes/interceptors/guards, no `HttpException` (replaced by `HttpError` hierarchy), no `forwardRef`, no request scope, no `DynamicModule` class (replaced by module functions).
+- **TC39 alignment.** The framework leans on stage-3 / shipped TC39 features: `Symbol.asyncDispose`, `using`/`await using`. TypeScript 5.2+ required at the consumer.
+- **Shadcn philosophy commitment.** Once shipped, core primitives (middleware shape, event API, container, router) change rarely and with care. Every vendored ecosystem module assumes the v1 contract.
+- **Conversation provenance.** This PRD is synthesized from a design conversation that worked through DI style, transport primitive, module shape, lifecycle semantics, middleware shape and the four attach points, error contract, response mutation, after-response work, body parsing edges, file uploads, headless contexts, adapter contract, validation/serialization edges, and WebSocket reservations. The full decision trail and trade-off rationales are captured implicitly in the Implementation Decisions section.

--- a/.scratch/mint/issues/01-hello-world.md
+++ b/.scratch/mint/issues/01-hello-world.md
@@ -1,0 +1,38 @@
+# 01: Hello World — compile-time → runtime → Bun seam
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md) — also see [`../../../plans/mint-spec.md`](../../../plans/mint-spec.md) (technical spec) and [`../../../plans/mint-plan.md`](../../../plans/mint-plan.md) (full plan).
+
+## What to build
+
+A user can write a single TypeScript file with one class decorated `@Controller('/hello')` containing one method decorated `@Get()` that returns a string. Running `tsgonest build` extends the existing pipeline to:
+
+- Recognize Mint's decorators by import path (`@mintkit/core`).
+- Emit a companion file with a `register…Controller(app)` export wiring the route into Mint's router.
+- Include the route in the generated `openapi.json`.
+
+The user writes a `main.ts` that creates a single module with that controller, calls `await createApp({ imports: [...] })`, hands `app.fetch` to `Bun.serve`, and `curl http://localhost:3000/hello` returns the string with a 200.
+
+This phase establishes the entire compile-time → runtime seam end-to-end. Every subsequent phase is incremental thickening.
+
+## Acceptance criteria
+
+- [ ] `@mintkit/core` package exists at `packages/mint` with `createApp`, `defineModule`, and the public decorator surface.
+- [ ] tsgonest analyzer recognizes Mint's decorators (resolved via `@mintkit/core` import path) without breaking existing NestJS support.
+- [ ] tsgonest codegen emits a `register…Controller(app)` export per controller in the existing `*.tsgonest.js` companion files.
+- [ ] Router accepts method + path registration and matches on incoming `Request`.
+- [ ] `Event` exposes at minimum the raw `Request`; handler return value is serialized to a `Response`.
+- [ ] Container constructs the controller (no deps in this phase) and resolves it for each request.
+- [ ] `createApp` returns a `Promise<App>`; `app.fetch(Request): Promise<Response>` works.
+- [ ] Middleware/handler return type is typed `Response | Upgrade` (Upgrade never produced).
+- [ ] Router method slot is `string` (not a constrained verb union).
+- [ ] OpenAPI 3.2 document includes the route.
+- [ ] E2E: build a fixture project, boot in Bun, `curl /hello` returns the expected body.
+- [ ] Unit tests: container resolve, router add/match, decorator analyzer fixture, codegen fixture.
+
+## Blocked by
+
+None — can start immediately.

--- a/.scratch/mint/issues/02-typed-parameters.md
+++ b/.scratch/mint/issues/02-typed-parameters.md
@@ -1,0 +1,27 @@
+# 02: Typed parameters and validated returns
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+The user can declare `@Body() body: SomeDto`, `@Query() q: ListQuery`, `@Param('id') id: string & tags.UUID`, and `@Headers('x-foo') header: string` on handler methods. tsgonest's existing validator/serializer generation is reused: parameter types feed the existing analyzer; the codegen's `register…Controller(app)` wrapper invokes the validators before calling the handler and the serializer on the return value. Validation failures throw `TsgonestValidationError`; the framework's error mapper converts that to RFC 9457 `application/problem+json` with per-field detail.
+
+OpenAPI emits request/response schemas for these parameters from the same type metadata.
+
+## Acceptance criteria
+
+- [ ] `@Body`/`@Query`/`@Param`/`@Headers` parameters are extracted from the request and validated against their TypeScript types before the handler runs.
+- [ ] Validators and serializers are the existing tsgonest-generated ones (no fork).
+- [ ] Return values are serialized via generated fast-JSON serializers; response `Content-Type` is `application/json`.
+- [ ] Validation failure produces a `400 application/problem+json` response with `type`/`title`/`status`/`detail`/`errors` per RFC 9457.
+- [ ] OpenAPI generates request/response schemas matching the declared types.
+- [ ] E2E: round-trip a typed body (valid → 200 with serialized return, invalid → 400 with problem-details).
+- [ ] Unit tests cover analyzer recognition of each parameter decorator and codegen wrapper shape.
+
+## Blocked by
+
+- [01: Hello World](./01-hello-world.md)

--- a/.scratch/mint/issues/03-di-and-dynamic-modules.md
+++ b/.scratch/mint/issues/03-di-and-dynamic-modules.md
@@ -1,0 +1,35 @@
+# 03: Dependency injection and dynamic modules
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+Users can mark classes `@Injectable()` and inject them via constructor. Providers can be declared in three forms within `defineModule({ providers: [...] })`:
+
+- Class shorthand (the class is the token).
+- `{ provide: TOKEN, useValue }`.
+- `{ provide: TOKEN, useFactory, inject?: [...], scope?: 'singleton' | 'transient' }` — the factory's deps come from the same container.
+
+Tokens are typed via `defineToken<T>(name)` and produce `Token<T>` instances with a phantom generic. Class references are themselves valid tokens. `@Inject(TOKEN)` parameter decorator injects non-class tokens into constructors. Container builds the dependency graph in topological order.
+
+Dynamic modules are functions: `StorageModule(opts): Module` and `StorageModuleAsync({ inject, useFactory }): Module`. Both return the same plain-object module shape.
+
+## Acceptance criteria
+
+- [ ] `defineToken<T>(name)` returns a typed `Token<T>`; class refs are valid tokens.
+- [ ] `@Injectable({ scope? })` decorator is recognized; default scope is singleton.
+- [ ] All three provider forms register and resolve correctly.
+- [ ] Constructor injection works for classes; `@Inject(TOKEN)` resolves non-class deps.
+- [ ] Transient providers return a fresh instance on every resolve; singletons are cached.
+- [ ] `useFactory` providers can declare async factories (`Promise<T>` return); await happens during boot.
+- [ ] Dynamic module functions (sync and async-factory shapes) compose with `imports: [Module(opts), ModuleAsync({...})]` at the app level.
+- [ ] E2E: a controller injects a service that depends on a useFactory-provided config token; the full chain resolves and the endpoint returns config-derived data.
+- [ ] Unit tests cover topological construction order, transient vs singleton semantics, and all three provider forms.
+
+## Blocked by
+
+- [01: Hello World](./01-hello-world.md)

--- a/.scratch/mint/issues/04-middleware-and-token-store.md
+++ b/.scratch/mint/issues/04-middleware-and-token-store.md
@@ -1,0 +1,42 @@
+# 04: Middleware and the token store
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+Function-only middleware shaped as `(event, next) => Promise<Response | Upgrade>`. Four attach points, all wiring into the same flat chain:
+
+- `app.use(mw)` and `app.use('/prefix', mw)` — global and prefix-mounted.
+- `defineModule({ middleware: [...] })` — applies to the module's declared controllers; no cascade to imports.
+- `@UseMiddleware(mw)` on a controller class — every method in the controller.
+- `@UseMiddleware(mw)` on a method — single route.
+
+Execution is outer-to-inner across layers, registration order within each layer.
+
+`Event` gains its full surface: token store (`set`/`get`/`require`), memoized `body` accessor with `bytes`/`text`/`json`/`formData` cached and `stream` single-use, mutable `response.headers` (Web `Headers` instance) and `response.status` (number), `waitUntil`, and `resolve` for DI access.
+
+`@Ctx(TOKEN) name: T` parameter decorator extracts token-stored values into handler signatures with compile-time type checking against the token's `T`.
+
+## Acceptance criteria
+
+- [ ] All four middleware attach points register and execute in the documented order.
+- [ ] `await next()` returns the downstream response; middleware can wrap (modify headers/status, transform body via new Response).
+- [ ] Short-circuit by returning a Response without calling `next()`.
+- [ ] Thrown errors in middleware propagate and hit the error mapper.
+- [ ] `event.set(TOKEN, value)` / `event.get(TOKEN)` / `event.require(TOKEN)` are type-checked against the token's `T`; `require` throws if not set.
+- [ ] `event.body` memoizes `bytes`/`text`/`json`/`formData`; `event.body.stream()` errors if the body has already been consumed.
+- [ ] `event.response.headers` is a `Headers` instance; `event.response.status` is a settable number.
+- [ ] `event.waitUntil(promise)` is callable; on Bun it is a fire-and-forget that runs to completion after response.
+- [ ] `@Ctx(TOKEN) user: User` produces a compile-time diagnostic if the parameter type does not match the token's `T`.
+- [ ] Module-level middleware does **not** cascade to imported modules' controllers.
+- [ ] E2E: a request flows through global + module + controller + method middleware in the correct order; an auth middleware sets a token and a handler reads it via `@Ctx`.
+- [ ] Unit tests cover chain composition order, short-circuit, throw propagation, body memoization semantics, and type-store behavior.
+
+## Blocked by
+
+- [01: Hello World](./01-hello-world.md)
+- [03: DI and dynamic modules](./03-di-and-dynamic-modules.md)

--- a/.scratch/mint/issues/05-errors.md
+++ b/.scratch/mint/issues/05-errors.md
@@ -1,0 +1,26 @@
+# 05: HttpError hierarchy and pluggable error mapper
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+The `HttpError` hierarchy is shipped: `BadRequestError`, `UnauthorizedError`, `ForbiddenError`, `NotFoundError`, `ConflictError`, `UnprocessableEntityError`, `TooManyRequestsError`, `InternalServerError` — each carries a status and a JSON body. Default error mapper maps `HttpError` subclasses to JSON responses with the carried status, maps `TsgonestValidationError` to RFC 9457 problem-details (already in #02), and falls through to status 500 for unknown errors (with the full error logged, not leaked to the response).
+
+`app.onError(predicate, handler)` registers user-defined mappings. User handlers take precedence over defaults; first match wins.
+
+## Acceptance criteria
+
+- [ ] `HttpError` base class and all listed subclasses exist with correct status codes.
+- [ ] Throwing an `HttpError` subclass from a handler produces a Response with the carried status and body.
+- [ ] `app.onError` registered handlers run before defaults; first match wins.
+- [ ] Unmatched throws produce a 500 problem-details JSON; the underlying error is logged.
+- [ ] E2E: a controller throws a custom domain error; an `app.onError` registration maps it to a `409 Conflict`.
+- [ ] Unit tests cover precedence between user handlers and defaults, and the 500 fallthrough.
+
+## Blocked by
+
+- [02: Typed parameters and validated returns](./02-typed-parameters.md)

--- a/.scratch/mint/issues/06-lifecycle-and-shutdown.md
+++ b/.scratch/mint/issues/06-lifecycle-and-shutdown.md
@@ -1,0 +1,29 @@
+# 06: Provider lifecycle and graceful shutdown
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+Providers can implement `OnInit` (`init(): void | Promise<void>`) and/or `AsyncDisposable` (`[Symbol.asyncDispose](): PromiseLike<void>`). Container duck-types both at runtime. Boot runs `init()` after all construction, in topological order. If any `init()` throws, the framework disposes already-initialized providers in reverse topological order and rejects `createApp`. Cycles between providers throw at boot with the cycle path printed.
+
+`app[Symbol.asyncDispose]()` stops accepting new requests, drains in-flight requests, then runs each provider's `Symbol.asyncDispose` in reverse topological order.
+
+This issue nails the runtime lifecycle. The Bun-side SIGTERM trigger is wired in #12.
+
+## Acceptance criteria
+
+- [ ] `OnInit` interface is exported; providers implementing `init()` have it called after construction.
+- [ ] `Symbol.asyncDispose` on providers is called on app shutdown.
+- [ ] Construction order is topological; init order is topological; dispose order is reverse-topological.
+- [ ] Failed `init()` triggers reverse-topo dispose of already-initialized providers and rejects `createApp`.
+- [ ] Boot detects provider cycles and throws with the cycle path before any provider construction.
+- [ ] `app[Symbol.asyncDispose]()` drains in-flight requests (long handlers complete) before disposing providers.
+- [ ] Unit tests cover topological vs reverse-topological order, partial-dispose on init failure, and cycle detection.
+
+## Blocked by
+
+- [03: DI and dynamic modules](./03-di-and-dynamic-modules.md)

--- a/.scratch/mint/issues/07-module-visibility-and-validation.md
+++ b/.scratch/mint/issues/07-module-visibility-and-validation.md
@@ -1,0 +1,33 @@
+# 07: Module visibility and boot validation
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+Module resolver enforces visibility rules: providers are private to their declaring module unless listed in `exports`. Importing module A from module B does not auto-leak A's providers; if B wants to re-export A's provider, it must list it in B's `exports`. Controllers are always globally registered.
+
+Boot-time validation:
+
+- Detect duplicate provider tokens across the flattened graph; error with both declaring modules named.
+- Detect cycles between modules and between providers.
+- Verify every `@Inject(TOKEN)` resolves to a visible provider; error with the consumer and unresolved token.
+
+No glob / auto-discovery. All imports are explicit.
+
+## Acceptance criteria
+
+- [ ] Private-by-default providers: importing module A in module B does not let B's providers inject A's non-exported services.
+- [ ] `exports` lists make providers visible to importers.
+- [ ] Re-exports through chains (A imports B, A exports B's token) are explicit and required for transitive visibility.
+- [ ] Duplicate tokens across the flattened module graph throw at boot with both source modules in the message.
+- [ ] Unresolved `@Inject(TOKEN)` references throw at boot with consumer + token info.
+- [ ] No file-system / glob-based module loading anywhere in the boot path.
+- [ ] Unit tests cover all visibility scenarios (private, exported, re-exported, leak attempt) and each validation error class.
+
+## Blocked by
+
+- [03: DI and dynamic modules](./03-di-and-dynamic-modules.md)

--- a/.scratch/mint/issues/08-headless-context.md
+++ b/.scratch/mint/issues/08-headless-context.md
@@ -1,0 +1,26 @@
+# 08: Headless context (`createContext`, `await using`)
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+`createContext({ imports }): Promise<Context>` returns a `Context` with `resolve` and `Symbol.asyncDispose` — no router, no fetch, no middleware. Useful for CLIs, queue consumers, cron, migrations, tests. `App extends Context` so helpers written against `Context` work in `App` too. Controllers in modules used by `createContext` are silently ignored (no warnings).
+
+`await using` is the canonical pattern for short-lived contexts; auto-dispose on scope exit, even on throw.
+
+## Acceptance criteria
+
+- [ ] `createContext({ imports })` exists and resolves to a `Context` with `resolve` and `Symbol.asyncDispose`.
+- [ ] `Context` shares the same module/provider/lifecycle plumbing as `createApp` (no duplication).
+- [ ] `App extends Context` structurally; helpers typed against `Context` work inside `createApp` returns.
+- [ ] Controllers in imported modules are accepted but unused when boot is via `createContext`.
+- [ ] E2E: a CLI fixture using `await using ctx = await createContext(...)` runs a service method and exits with provider dispose having fired.
+- [ ] Unit tests cover `createContext` boot, `App extends Context` structural compatibility, and `await using` integration.
+
+## Blocked by
+
+- [06: Provider lifecycle and graceful shutdown](./06-lifecycle-and-shutdown.md)

--- a/.scratch/mint/issues/09-file-uploads-buffered.md
+++ b/.scratch/mint/issues/09-file-uploads-buffered.md
@@ -1,0 +1,28 @@
+# 09: File uploads — buffered (`File`, `MaxSize`, `MimeTypes`)
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+Users declare `@Body() data: { title: string; image: File & MaxSize<5_000_000> & MimeTypes<'image/png' | 'image/jpeg'> }` on a handler. tsgonest analyzer recognizes the `File` type and the new tag constraints. Codegen generates a multipart parser that reads `event.body.formData()`, extracts each named entry, validates `File` entries against `MaxSize`/`MinSize`/`MimeTypes`, and throws `TsgonestValidationError` on violation. Handler receives Web standard `File` instances.
+
+New tag types in `@tsgonest/types`: `MaxSize<N>`, `MinSize<N>`, `MimeTypes<U>` (with wildcard support like `'image/*'`).
+
+## Acceptance criteria
+
+- [ ] `File`, `MaxSize<N>`, `MinSize<N>`, `MimeTypes<U>` types are added to `@tsgonest/types` (or runtime types) and recognized by the analyzer.
+- [ ] Wildcard MIME patterns (`'image/*'`) match correctly.
+- [ ] `@Body()` with file fields parses multipart via `event.body.formData()`, validates per-file constraints, and passes `File` instances to the handler.
+- [ ] Validation failure produces an RFC 9457 problem-details response with per-field detail.
+- [ ] Array fields (`photos: Array<File & ...>`) parse and validate as a list.
+- [ ] OpenAPI emits `multipart/form-data` request body schemas for these routes.
+- [ ] E2E: round-trip a buffered file upload (valid → 200, oversize → 400, wrong MIME → 400).
+- [ ] Analyzer/codegen unit tests cover the new types and the generated parser shape.
+
+## Blocked by
+
+- [02: Typed parameters and validated returns](./02-typed-parameters.md)

--- a/.scratch/mint/issues/10-file-uploads-streaming.md
+++ b/.scratch/mint/issues/10-file-uploads-streaming.md
@@ -1,0 +1,25 @@
+# 10: File uploads — streaming (`FileStream`, byte-level abort)
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+Users declare `@Body() data: { filename: string; file: FileStream & MaxSize<5_000_000_000> }`. `FileStream` is distinct from `File` and signals streaming parse. Codegen emits a streaming multipart parser (a runtime-shipped utility) that reads `event.body.stream()`, yields each field as it arrives, and aborts the connection when a `FileStream`'s incremental byte count exceeds `MaxSize`. The handler receives `FileStream { name, type, stream }` where `stream` is a `ReadableStream<Uint8Array>`.
+
+## Acceptance criteria
+
+- [ ] `FileStream` type exists and is recognized by the analyzer as distinct from `File`.
+- [ ] A multipart streaming parser ships in the runtime (or framework package) and reads from a `ReadableStream<Uint8Array>` source.
+- [ ] When any `FileStream` field exceeds its `MaxSize` mid-stream, the connection aborts and a 413 (or comparable problem-details) response is sent.
+- [ ] Memory usage during a multi-GB upload stays bounded (verified via integration test or a documented design constraint).
+- [ ] Mixed multipart (string fields + streaming files) parses correctly without buffering the entire body.
+- [ ] E2E: stream a large file to disk via the handler, then assert the file on disk matches the input; oversize uploads abort early.
+- [ ] Unit tests cover the parser's boundary detection, field dispatch, and abort semantics.
+
+## Blocked by
+
+- [09: File uploads — buffered](./09-file-uploads-buffered.md)

--- a/.scratch/mint/issues/11-sse.md
+++ b/.scratch/mint/issues/11-sse.md
@@ -1,0 +1,26 @@
+# 11: SSE helper and OpenAPI integration
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+A core runtime helper `sse<T>(generator: () => AsyncGenerator<T>): Response` returns a streaming `Response` with `text/event-stream` content type and proper SSE framing (`data: <json>\n\n`). Typed via `SSEStream<T>` so the existing `@Returns<SSEStream<T>>` pattern in tsgonest picks up the event type for OpenAPI/SDK generation.
+
+Handlers return `sse(async function* () { yield ...; })` or are typed as `Promise<SSEStream<EventType>>`.
+
+## Acceptance criteria
+
+- [ ] `sse()` helper exists in the runtime package and produces a correctly framed SSE response.
+- [ ] `SSEStream<T>` type is recognized by the analyzer; OpenAPI emits the event payload schema using the existing `@Returns<T>` machinery.
+- [ ] Generators can yield, await between yields, and close the stream by returning.
+- [ ] Client disconnects propagate to the generator (abort signal in the response stream).
+- [ ] E2E: connect a Bun client to an SSE endpoint, receive at least N events in framed form, disconnect, verify the generator cleanup runs.
+- [ ] Unit tests cover framing correctness and abort propagation.
+
+## Blocked by
+
+- [02: Typed parameters and validated returns](./02-typed-parameters.md)

--- a/.scratch/mint/issues/12-bun-adapter.md
+++ b/.scratch/mint/issues/12-bun-adapter.md
@@ -1,0 +1,30 @@
+# 12: Bun adapter (vendored package)
+
+Status: ready-for-agent
+
+## Parent
+
+[../PRD.md](../PRD.md)
+
+## What to build
+
+A single vendored package (intended to be copy-pasted into user repos under the shadcn philosophy) providing:
+
+- `wrap(app): { fetch }` — for users who need access to Bun's `Server` instance. Injects `BUN_SERVER` token onto each event before `app.fetch` runs.
+- `BUN_SERVER` token — typed reference to Bun's `Server` (e.g., for future WebSocket upgrades or socket inspection).
+- `gracefulShutdown(app, opts?)` helper — wires SIGTERM/SIGINT (configurable) to `app[Symbol.asyncDispose]()` with a configurable drain timeout.
+
+Zero-config users continue to write `Bun.serve({ fetch: app.fetch })`. The adapter is only needed when platform features are wanted.
+
+## Acceptance criteria
+
+- [ ] Vendored package exists with `wrap`, `BUN_SERVER`, and `gracefulShutdown` exports.
+- [ ] `wrap(app)` returns a `{ fetch }` handler that injects `BUN_SERVER` on each event before delegating to `app.fetch`.
+- [ ] `BUN_SERVER` token resolves to Bun's `Server` inside handlers/middleware via `event.require(BUN_SERVER)`.
+- [ ] `gracefulShutdown` registers the configured signal handlers, calls `app[Symbol.asyncDispose]()`, enforces the timeout (hard-exits if drain exceeds).
+- [ ] E2E: SIGTERM during in-flight requests drains them, fires provider dispose in reverse-topo, and exits cleanly within the timeout window.
+- [ ] Documentation in the adapter's README walks through the canonical wiring and the customization points users are expected to edit.
+
+## Blocked by
+
+- [06: Provider lifecycle and graceful shutdown](./06-lifecycle-and-shutdown.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,3 +386,17 @@ pnpm add -D tsgonest@latest
 26. **deriveTypeArgName resolution order**: typeIdToName cache → array element recursion → symbol name → Type_alias recovery → literal union members (≤4). Each step has specific guards for internal names (`__type`, `__object`, `\xfe` prefix).
 27. **Walker warnings are deduplicated**: `warnedGenericNames` map prevents flooding output. Each generic base name warns at most once. Warnings surface through `build.go` alongside controller analyzer warnings.
 28. **OpenAPI is deliberately flat — no generics**: OpenAPI 3.2 has no concept of generics. Do NOT add `x-` extensions to reconstruct generic types in SDK output. Flat schemas (`PaginatedResponse_UserDto`) work with all tooling (Swagger UI, Redocly, third-party generators). This is an intentional design decision.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live as markdown files under `.scratch/<feature-slug>/` in this repo. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical role strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) used as-is. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/cmd/tsgonest/build.go
+++ b/cmd/tsgonest/build.go
@@ -434,7 +434,13 @@ func runBuildWithIncrAndProgram(args []string, oldIncrProgram *shimincremental.P
 		}
 		// Mint register companions are emitted independently of type companions —
 		// hello-world controllers have no DTOs and thus no neededTypes entries.
-		if mintCompanions := generateMintRegisterCompanions(controllers, sourceToOutput, modFmt); len(mintCompanions) > 0 {
+		// We pass the walker's registry so the generator can resolve DTO
+		// companion paths for @Body/@Query/@Param/@Headers and return types.
+		mintRegistry := controllerRegistry
+		if mintRegistry == nil && sharedWalker != nil {
+			mintRegistry = sharedWalker.Registry()
+		}
+		if mintCompanions := generateMintRegisterCompanions(controllers, sourceToOutput, modFmt, mintRegistry, cfg.Transforms.ResponseSerializer); len(mintCompanions) > 0 {
 			allCompanions = append(allCompanions, mintCompanions...)
 		}
 		timing.Companions = time.Since(companionStart)

--- a/cmd/tsgonest/build.go
+++ b/cmd/tsgonest/build.go
@@ -432,6 +432,11 @@ func runBuildWithIncrAndProgram(args []string, oldIncrProgram *shimincremental.P
 				OutputToSource: rewrite.BuildOutputToSourceMap(sourceToOutput),
 			}
 		}
+		// Mint register companions are emitted independently of type companions —
+		// hello-world controllers have no DTOs and thus no neededTypes entries.
+		if mintCompanions := generateMintRegisterCompanions(controllers, sourceToOutput, modFmt); len(mintCompanions) > 0 {
+			allCompanions = append(allCompanions, mintCompanions...)
+		}
 		timing.Companions = time.Since(companionStart)
 
 		// Attach controller data to rewrite context

--- a/cmd/tsgonest/companions.go
+++ b/cmd/tsgonest/companions.go
@@ -371,3 +371,57 @@ func generateCompanionsInMemory(program *shimcompiler.Program, cfg *config.Confi
 
 	return allCompanions, typesByFile, nil
 }
+
+// generateMintRegisterCompanions emits a `register{Controller}(app)` companion
+// file for every controller whose @Controller decorator came from @mintkit/*.
+// The companion sits next to the controller's emitted JS and is generated
+// regardless of whether the controller has any DTO types — Phase 1 hello-world
+// controllers have no @Body/@Query/@Param and thus produce no type companions.
+func generateMintRegisterCompanions(controllers []analyzer.ControllerInfo, sourceToOutput map[string]string, moduleFormat string) []codegen.CompanionFile {
+	var out []codegen.CompanionFile
+	isCJS := moduleFormat == "cjs"
+
+	for _, ctrl := range controllers {
+		if ctrl.Framework != "mint" {
+			continue
+		}
+		outputBase, ok := sourceToOutput[ctrl.SourceFile]
+		if !ok {
+			continue
+		}
+
+		// Strip .ts to get the controller's emitted-JS base path (e.g. dist/hello.controller).
+		controllerBase := strings.TrimSuffix(outputBase, ".ts")
+		importPath := "./" + filepath.Base(controllerBase)
+
+		routes := make([]codegen.MintRouteInfo, 0, len(ctrl.Routes))
+		for _, r := range ctrl.Routes {
+			routes = append(routes, codegen.MintRouteInfo{
+				Method:     r.Method,
+				Path:       r.Path,
+				MethodName: r.MethodName,
+			})
+		}
+
+		input := codegen.MintRegisterInput{
+			ControllerName:       ctrl.Name,
+			ControllerImportPath: importPath,
+			Routes:               routes,
+		}
+
+		jsPath := codegen.MintRegisterPath(outputBase, ctrl.Name)
+		jsContent := codegen.GenerateMintRegister(input)
+		dtsPath := strings.TrimSuffix(jsPath, ".js") + ".d.ts"
+		dtsContent := codegen.GenerateMintRegisterTypes(ctrl.Name)
+
+		if isCJS {
+			jsContent = codegen.ConvertToCommonJS(jsContent)
+			dtsContent = codegen.ConvertDtsToCommonJS(dtsContent)
+		}
+
+		out = append(out, codegen.CompanionFile{Path: jsPath, Content: jsContent})
+		out = append(out, codegen.CompanionFile{Path: dtsPath, Content: dtsContent})
+	}
+
+	return out
+}

--- a/cmd/tsgonest/companions.go
+++ b/cmd/tsgonest/companions.go
@@ -377,7 +377,18 @@ func generateCompanionsInMemory(program *shimcompiler.Program, cfg *config.Confi
 // The companion sits next to the controller's emitted JS and is generated
 // regardless of whether the controller has any DTO types — Phase 1 hello-world
 // controllers have no @Body/@Query/@Param and thus produce no type companions.
-func generateMintRegisterCompanions(controllers []analyzer.ControllerInfo, sourceToOutput map[string]string, moduleFormat string) []codegen.CompanionFile {
+//
+// For Phase 2, each route's parameters and return type are projected into the
+// codegen input so the emitted wrapper parses inputs from the Event, runs the
+// existing tsgonest-generated `assertXxx` validators, and serialises the
+// return value via `stringifyXxx`/`serializeXxx` from the same companions.
+func generateMintRegisterCompanions(
+	controllers []analyzer.ControllerInfo,
+	sourceToOutput map[string]string,
+	moduleFormat string,
+	registry *metadata.TypeRegistry,
+	responseSerializer string,
+) []codegen.CompanionFile {
 	var out []codegen.CompanionFile
 	isCJS := moduleFormat == "cjs"
 
@@ -394,19 +405,37 @@ func generateMintRegisterCompanions(controllers []analyzer.ControllerInfo, sourc
 		controllerBase := strings.TrimSuffix(outputBase, ".ts")
 		importPath := "./" + filepath.Base(controllerBase)
 
+		// The Mint register companion lives at codegen.MintRegisterPath(outputBase, ctrl.Name).
+		registerCompanionPath := codegen.MintRegisterPath(outputBase, ctrl.Name)
+
 		routes := make([]codegen.MintRouteInfo, 0, len(ctrl.Routes))
 		for _, r := range ctrl.Routes {
-			routes = append(routes, codegen.MintRouteInfo{
+			route := codegen.MintRouteInfo{
 				Method:     r.Method,
 				Path:       r.Path,
 				MethodName: r.MethodName,
-			})
+			}
+
+			// Project route parameters into codegen-friendly shape.
+			for _, p := range r.Parameters {
+				mp := buildMintParam(p, registry, registerCompanionPath)
+				if mp == nil {
+					continue
+				}
+				route.Params = append(route.Params, *mp)
+			}
+
+			// Project return type.
+			projectReturn(&route, &r.ReturnType, registry, registerCompanionPath)
+
+			routes = append(routes, route)
 		}
 
 		input := codegen.MintRegisterInput{
 			ControllerName:       ctrl.Name,
 			ControllerImportPath: importPath,
 			Routes:               routes,
+			ResponseSerializer:   responseSerializer,
 		}
 
 		jsPath := codegen.MintRegisterPath(outputBase, ctrl.Name)
@@ -424,4 +453,341 @@ func generateMintRegisterCompanions(controllers []analyzer.ControllerInfo, sourc
 	}
 
 	return out
+}
+
+// buildMintParam projects an analyzer.RouteParameter into the codegen shape.
+// Returns nil when the parameter cannot be represented (e.g. anonymous types
+// without a companion; those are intentionally skipped — the handler will see
+// whatever the user typed, but validation won't run).
+func buildMintParam(p analyzer.RouteParameter, registry *metadata.TypeRegistry, registerCompanionPath string) *codegen.MintParamInfo {
+	local := p.LocalName
+	if local == "" {
+		local = p.Name
+	}
+	if local == "" {
+		// Without a JS-visible name we can't bind the value into the call site.
+		return nil
+	}
+
+	kind, ok := paramCategoryToKind(p.Category)
+	if !ok {
+		return nil
+	}
+
+	mp := codegen.MintParamInfo{
+		Kind:      kind,
+		Name:      p.Name,
+		LocalName: local,
+	}
+
+	// Body with File/FileStream fields → multipart parsing path.
+	if kind == codegen.MintParamBody {
+		if mb := buildMultipartBody(&p, registry); mb != nil {
+			mp.Multipart = mb
+			return &mp
+		}
+	}
+
+	// DTO-shaped param: whole-object @Body / @Query / @Headers with a named type.
+	dtoSlot := (kind == codegen.MintParamBody) ||
+		((kind == codegen.MintParamQuery || kind == codegen.MintParamHeader) && p.Name == "")
+	if dtoSlot && p.TypeName != "" && registry != nil {
+		if companionImport := companionImportForType(p.TypeName, registry, registerCompanionPath); companionImport != "" {
+			mp.TypeName = p.TypeName
+			mp.CompanionImport = companionImport
+			return &mp
+		}
+	}
+
+	// Scalar param (named @Param / @Query / @Headers, or @Body without a type).
+	if p.Type.Kind == metadata.KindAtomic {
+		mp.Atomic = p.Type.Atomic
+		mp.Constraints = p.Type.Constraints
+	}
+	return &mp
+}
+
+// buildMultipartBody inspects a body parameter's type metadata for File or
+// FileStream fields. When at least one is found, returns a multipart description
+// that the codegen uses instead of the JSON-body path. Returns nil for JSON bodies.
+func buildMultipartBody(p *analyzer.RouteParameter, registry *metadata.TypeRegistry) *codegen.MintMultipartBody {
+	if p == nil {
+		return nil
+	}
+	obj := resolveObjectMetadata(&p.Type, registry)
+	if obj == nil {
+		return nil
+	}
+
+	hasFile := false
+	for _, prop := range obj.Properties {
+		k := classifyMultipartFieldKind(&prop.Type)
+		if k == multipartFieldKindFile || k == multipartFieldKindFileArray || k == multipartFieldKindFileStream {
+			hasFile = true
+			break
+		}
+	}
+	if !hasFile {
+		return nil
+	}
+
+	mb := &codegen.MintMultipartBody{}
+	for _, prop := range obj.Properties {
+		k := classifyMultipartFieldKind(&prop.Type)
+		field := codegen.MintMultipartField{
+			Name:     prop.Name,
+			Required: prop.Required,
+		}
+		// File-shaped constraints can live on the leaf type (after branded
+		// extraction) or on the property level — combine both.
+		field.Constraints = mergeFileConstraints(prop.Type.Constraints, prop.Constraints)
+		switch k {
+		case multipartFieldKindFile:
+			field.Kind = codegen.MintFieldFile
+			mb.Fields = append(mb.Fields, field)
+		case multipartFieldKindFileArray:
+			field.Kind = codegen.MintFieldFileArray
+			mb.Fields = append(mb.Fields, field)
+		case multipartFieldKindFileStream:
+			field.Kind = codegen.MintFieldFileStream
+			mb.Streaming = true
+			mb.Fields = append(mb.Fields, field)
+		case multipartFieldKindScalar:
+			field.Kind = codegen.MintFieldScalar
+			leaf := scalarLeaf(&prop.Type)
+			if leaf != nil {
+				field.Atomic = leaf.Atomic
+				field.Constraints = mergeFileConstraints(leaf.Constraints, prop.Constraints)
+			}
+			mb.Fields = append(mb.Fields, field)
+		case multipartFieldKindUnknown:
+			// Skip — emit no validation for unknown leaf types.
+		}
+	}
+
+	return mb
+}
+
+type multipartFieldKind int
+
+const (
+	multipartFieldKindUnknown multipartFieldKind = iota
+	multipartFieldKindScalar
+	multipartFieldKindFile
+	multipartFieldKindFileArray
+	multipartFieldKindFileStream
+)
+
+// classifyMultipartFieldKind reports how a property of a multipart body should
+// be parsed. Unwraps optional/nullable union wrappers.
+func classifyMultipartFieldKind(m *metadata.Metadata) multipartFieldKind {
+	if m == nil {
+		return multipartFieldKindUnknown
+	}
+	leaf := unwrapOptional(m)
+	if leaf == nil {
+		return multipartFieldKindUnknown
+	}
+	switch leaf.Kind {
+	case metadata.KindNative:
+		switch leaf.NativeType {
+		case "File", "Blob":
+			return multipartFieldKindFile
+		case "FileStream":
+			return multipartFieldKindFileStream
+		}
+	case metadata.KindArray:
+		if leaf.ElementType != nil {
+			el := unwrapOptional(leaf.ElementType)
+			if el != nil && el.Kind == metadata.KindNative && (el.NativeType == "File" || el.NativeType == "Blob") {
+				return multipartFieldKindFileArray
+			}
+		}
+	case metadata.KindAtomic, metadata.KindLiteral:
+		return multipartFieldKindScalar
+	}
+	return multipartFieldKindUnknown
+}
+
+func scalarLeaf(m *metadata.Metadata) *metadata.Metadata {
+	if m == nil {
+		return nil
+	}
+	leaf := unwrapOptional(m)
+	if leaf == nil {
+		return nil
+	}
+	if leaf.Kind == metadata.KindAtomic || leaf.Kind == metadata.KindLiteral {
+		return leaf
+	}
+	return nil
+}
+
+// unwrapOptional strips union members of `undefined`/`null` to find the
+// concrete leaf, e.g. `File | undefined` → `File`.
+func unwrapOptional(m *metadata.Metadata) *metadata.Metadata {
+	if m == nil {
+		return nil
+	}
+	if m.Kind != metadata.KindUnion {
+		return m
+	}
+	for i := range m.UnionMembers {
+		um := &m.UnionMembers[i]
+		if um.Kind == metadata.KindAtomic && (um.Atomic == "undefined" || um.Atomic == "null") {
+			continue
+		}
+		if um.Kind == metadata.KindLiteral && um.LiteralValue == nil {
+			continue
+		}
+		return um
+	}
+	return m
+}
+
+// resolveObjectMetadata follows a KindRef to its target in the registry. Returns
+// the dereferenced object's metadata, or nil for non-object types.
+func resolveObjectMetadata(m *metadata.Metadata, registry *metadata.TypeRegistry) *metadata.Metadata {
+	if m == nil {
+		return nil
+	}
+	if m.Kind == metadata.KindObject {
+		return m
+	}
+	if m.Kind == metadata.KindRef && registry != nil {
+		if resolved := registry.Types[m.Ref]; resolved != nil && resolved.Kind == metadata.KindObject {
+			return resolved
+		}
+	}
+	return nil
+}
+
+// mergeFileConstraints overlays per-property constraints onto the leaf-type's
+// constraints. The leaf's branded constraints take precedence, but the property
+// may add JSDoc constraints; we union them.
+func mergeFileConstraints(leaf, prop *metadata.Constraints) *metadata.Constraints {
+	if leaf == nil && prop == nil {
+		return nil
+	}
+	out := &metadata.Constraints{}
+	if prop != nil {
+		*out = *prop
+	}
+	if leaf != nil {
+		if leaf.MaxSize != nil {
+			out.MaxSize = leaf.MaxSize
+		}
+		if leaf.MinSize != nil {
+			out.MinSize = leaf.MinSize
+		}
+		if len(leaf.MimeTypes) > 0 {
+			out.MimeTypes = leaf.MimeTypes
+		}
+		if leaf.MinLength != nil {
+			out.MinLength = leaf.MinLength
+		}
+		if leaf.MaxLength != nil {
+			out.MaxLength = leaf.MaxLength
+		}
+		if leaf.Pattern != nil {
+			out.Pattern = leaf.Pattern
+		}
+		if leaf.Minimum != nil {
+			out.Minimum = leaf.Minimum
+		}
+		if leaf.Maximum != nil {
+			out.Maximum = leaf.Maximum
+		}
+	}
+	return out
+}
+
+func paramCategoryToKind(category string) (codegen.MintParamKind, bool) {
+	switch category {
+	case string(analyzer.CategoryBody):
+		return codegen.MintParamBody, true
+	case string(analyzer.CategoryQuery):
+		return codegen.MintParamQuery, true
+	case string(analyzer.CategoryParam):
+		return codegen.MintParamPathParam, true
+	case string(analyzer.CategoryHeaders):
+		return codegen.MintParamHeader, true
+	}
+	return 0, false
+}
+
+// companionImportForType returns the relative module specifier to the named
+// type's companion file (.tsgonest.js), as seen from the Mint register
+// companion file. Empty if the type has no recorded source file (and thus no
+// companion will be emitted for it).
+func companionImportForType(typeName string, registry *metadata.TypeRegistry, registerCompanionPath string) string {
+	outputBase := registry.SourceFile(typeName)
+	if outputBase == "" {
+		return ""
+	}
+	dtoCompanion := codegen.CompanionPathForOutput(outputBase, typeName)
+	return codegen.RelativeCompanionImport(registerCompanionPath, dtoCompanion)
+}
+
+// projectReturn fills the ReturnX fields on a MintRouteInfo from the analyzer's
+// return-type metadata.
+func projectReturn(route *codegen.MintRouteInfo, ret *metadata.Metadata, registry *metadata.TypeRegistry, registerCompanionPath string) {
+	if ret == nil {
+		return
+	}
+	switch ret.Kind {
+	case metadata.KindVoid:
+		route.ReturnVoid = true
+	case metadata.KindAtomic:
+		route.ReturnAtomic = ret.Atomic
+	case metadata.KindArray:
+		if ret.ElementType == nil {
+			return
+		}
+		// Pull the element's named type.
+		elemName := elementNamedType(ret.ElementType)
+		if elemName == "" {
+			return
+		}
+		if companionImport := companionImportForType(elemName, registry, registerCompanionPath); companionImport != "" {
+			route.ReturnTypeName = elemName
+			route.ReturnCompanionImport = companionImport
+			route.ReturnIsArray = true
+		}
+	case metadata.KindObject, metadata.KindRef, metadata.KindUnion, metadata.KindIntersection:
+		name := namedReturnType(ret)
+		if name == "" {
+			return
+		}
+		if companionImport := companionImportForType(name, registry, registerCompanionPath); companionImport != "" {
+			route.ReturnTypeName = name
+			route.ReturnCompanionImport = companionImport
+		}
+	}
+}
+
+func namedReturnType(m *metadata.Metadata) string {
+	if m == nil {
+		return ""
+	}
+	if m.Name != "" {
+		return m.Name
+	}
+	if m.Ref != "" {
+		return m.Ref
+	}
+	return ""
+}
+
+func elementNamedType(m *metadata.Metadata) string {
+	if m == nil {
+		return ""
+	}
+	if m.Name != "" {
+		return m.Name
+	}
+	if m.Ref != "" {
+		return m.Ref
+	}
+	return ""
 }

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,19 @@
+# Issue tracker: Local Markdown
+
+Issues and PRDs for this repo live as markdown files in `.scratch/`.
+
+## Conventions
+
+- One feature per directory: `.scratch/<feature-slug>/`
+- The PRD is `.scratch/<feature-slug>/PRD.md`
+- Implementation issues are `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01`
+- Triage state is recorded as a `Status:` line near the top of each issue file (see `triage-labels.md` for the role strings)
+- Comments and conversation history append to the bottom of the file under a `## Comments` heading
+
+## When a skill says "publish to the issue tracker"
+
+Create a new file under `.scratch/<feature-slug>/` (creating the directory if needed).
+
+## When a skill says "fetch the relevant ticket"
+
+Read the file at the referenced path. The user will normally pass the path or the issue number directly.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/e2e/mint-hello.test.ts
+++ b/e2e/mint-hello.test.ts
@@ -123,12 +123,16 @@ describe("Mint Phase 1: Hello World seam", () => {
     expect(openapi.paths["/hello"].get.operationId).toBe("Hello_hello");
   });
 
-  it("serves /hello via Bun.serve(app.fetch) with 200 + body", async () => {
+  it("serves /hello via Bun.serve(app.fetch) with 200 + JSON body", async () => {
     const server = await startBunServer();
     try {
       const res = await fetch(`${server.url}/hello`);
       expect(res.status).toBe(200);
-      expect(await res.text()).toBe("Hello from Mint!");
+      // Phase 2: all return values are JSON-serialized so SDKs can consume
+      // responses without sniffing the handler signature. Strings become a
+      // quoted JSON literal.
+      expect(res.headers.get("content-type")).toMatch(/application\/json/);
+      expect(await res.text()).toBe('"Hello from Mint!"');
     } finally {
       await server.stop();
     }

--- a/e2e/mint-hello.test.ts
+++ b/e2e/mint-hello.test.ts
@@ -1,0 +1,150 @@
+import { spawn, type ChildProcess } from "child_process";
+import { existsSync, readFileSync, rmSync } from "fs";
+import { resolve } from "path";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { FIXTURES_DIR, runTsgonest } from "./helpers";
+
+const FIXTURE_DIR = resolve(FIXTURES_DIR, "mint-hello");
+const FIXTURE_DIST = resolve(FIXTURE_DIR, "dist");
+
+async function startBunServer(): Promise<{
+  url: string;
+  process: ChildProcess;
+  stop: () => Promise<void>;
+}> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn("bun", [resolve(FIXTURE_DIST, "main.js")], {
+      cwd: FIXTURE_DIR,
+      env: { ...process.env, PORT: "0" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(
+        new Error(
+          `bun did not listen within 10s.\nstdout: ${stdout}\nstderr: ${stderr}`,
+        ),
+      );
+    }, 10000);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+      const match = stdout.match(/LISTENING:(https?:\/\/[^\s\n/]+)\/?/);
+      if (!match) return;
+      clearTimeout(timeout);
+      resolvePromise({
+        url: match[1].replace("[::1]", "127.0.0.1"),
+        process: child,
+        stop: () =>
+          new Promise<void>((res) => {
+            child.on("exit", () => res());
+            child.kill("SIGTERM");
+            setTimeout(() => {
+              child.kill("SIGKILL");
+              res();
+            }, 3000);
+          }),
+      });
+    });
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      if (!stdout.includes("LISTENING:")) {
+        reject(
+          new Error(
+            `bun exited with ${code} before listening.\nstdout: ${stdout}\nstderr: ${stderr}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+describe("Mint Phase 1: Hello World seam", () => {
+  beforeAll(() => {
+    if (existsSync(FIXTURE_DIST)) {
+      rmSync(FIXTURE_DIST, { recursive: true });
+    }
+    const { exitCode, stderr } = runTsgonest([
+      "--project",
+      "testdata/mint-hello/tsconfig.json",
+      "--config",
+      "testdata/mint-hello/tsgonest.config.json",
+    ]);
+    if (exitCode !== 0) {
+      throw new Error(`tsgonest build failed: ${stderr}`);
+    }
+  });
+
+  it("emits the registerHelloController companion", () => {
+    const companionJs = resolve(
+      FIXTURE_DIST,
+      "hello.controller.HelloController.tsgonest.js",
+    );
+    expect(existsSync(companionJs)).toBe(true);
+    const content = readFileSync(companionJs, "utf-8");
+    expect(content).toContain(
+      'import { HelloController } from "./hello.controller"',
+    );
+    expect(content).toContain("export function registerHelloController(app)");
+    expect(content).toContain('app.router.add("GET", "/hello"');
+  });
+
+  it("emits a clean controller JS without NestJS interceptor injections", () => {
+    const ctrlJs = readFileSync(
+      resolve(FIXTURE_DIST, "hello.controller.js"),
+      "utf-8",
+    );
+    expect(ctrlJs).not.toContain("TsgonestSerializeInterceptor");
+    expect(ctrlJs).not.toContain("UseInterceptors");
+    expect(ctrlJs).toContain('from "@mintkit/core"');
+    expect(ctrlJs).toContain('return "Hello from Mint!"');
+  });
+
+  it("includes the route in the OpenAPI 3.2 document", () => {
+    const openapi = JSON.parse(
+      readFileSync(resolve(FIXTURE_DIST, "openapi.json"), "utf-8"),
+    );
+    expect(openapi.openapi).toMatch(/^3\.[12](\.\d+)?$/);
+    expect(openapi.paths["/hello"]).toBeDefined();
+    expect(openapi.paths["/hello"].get).toBeDefined();
+    expect(openapi.paths["/hello"].get.operationId).toBe("Hello_hello");
+  });
+
+  it("serves /hello via Bun.serve(app.fetch) with 200 + body", async () => {
+    const server = await startBunServer();
+    try {
+      const res = await fetch(`${server.url}/hello`);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("Hello from Mint!");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("returns 404 for unknown routes", async () => {
+    const server = await startBunServer();
+    try {
+      const res = await fetch(`${server.url}/nope`);
+      expect(res.status).toBe(404);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  afterAll(() => {
+    // dist is left in place so it can be inspected; the next run cleans it.
+  });
+});

--- a/e2e/mint-typed.test.ts
+++ b/e2e/mint-typed.test.ts
@@ -1,0 +1,244 @@
+import { spawn, type ChildProcess } from "child_process";
+import { existsSync, readFileSync, rmSync } from "fs";
+import { resolve } from "path";
+import { describe, it, expect, beforeAll } from "vitest";
+import { FIXTURES_DIR, runTsgonest } from "./helpers";
+
+const FIXTURE_DIR = resolve(FIXTURES_DIR, "mint-typed");
+const FIXTURE_DIST = resolve(FIXTURE_DIR, "dist");
+
+async function startBunServer(): Promise<{
+  url: string;
+  process: ChildProcess;
+  stop: () => Promise<void>;
+}> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn("bun", [resolve(FIXTURE_DIST, "main.js")], {
+      cwd: FIXTURE_DIR,
+      env: { ...process.env, PORT: "0" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(
+        new Error(
+          `bun did not listen within 10s.\nstdout: ${stdout}\nstderr: ${stderr}`,
+        ),
+      );
+    }, 10000);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+      const match = stdout.match(/LISTENING:(https?:\/\/[^\s\n/]+)\/?/);
+      if (!match) return;
+      clearTimeout(timeout);
+      resolvePromise({
+        url: match[1].replace("[::1]", "127.0.0.1"),
+        process: child,
+        stop: () =>
+          new Promise<void>((res) => {
+            child.on("exit", () => res());
+            child.kill("SIGTERM");
+            setTimeout(() => {
+              child.kill("SIGKILL");
+              res();
+            }, 3000);
+          }),
+      });
+    });
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      if (!stdout.includes("LISTENING:")) {
+        reject(
+          new Error(
+            `bun exited with ${code} before listening.\nstdout: ${stdout}\nstderr: ${stderr}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+describe("Mint Phase 2: typed parameters and validated returns", () => {
+  beforeAll(() => {
+    if (existsSync(FIXTURE_DIST)) {
+      rmSync(FIXTURE_DIST, { recursive: true });
+    }
+    const { exitCode, stderr } = runTsgonest([
+      "--project",
+      "testdata/mint-typed/tsconfig.json",
+      "--config",
+      "testdata/mint-typed/tsgonest.config.json",
+    ]);
+    if (exitCode !== 0) {
+      throw new Error(`tsgonest build failed: ${stderr}`);
+    }
+  });
+
+  it("emits DTO companions and the register wrapper", () => {
+    expect(
+      existsSync(
+        resolve(FIXTURE_DIST, "users.controller.UsersController.tsgonest.js"),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(resolve(FIXTURE_DIST, "users.dto.CreateUserDto.tsgonest.js")),
+    ).toBe(true);
+    expect(
+      existsSync(resolve(FIXTURE_DIST, "users.dto.UserResponse.tsgonest.js")),
+    ).toBe(true);
+    expect(
+      existsSync(resolve(FIXTURE_DIST, "users.dto.ListQuery.tsgonest.js")),
+    ).toBe(true);
+
+    const register = readFileSync(
+      resolve(FIXTURE_DIST, "users.controller.UsersController.tsgonest.js"),
+      "utf-8",
+    );
+    expect(register).toContain("assertCreateUserDto");
+    expect(register).toContain("assertListQuery");
+    expect(register).toContain("stringifyUserResponse");
+    expect(register).toContain("serializeUserResponse");
+  });
+
+  it("POST /users with a valid body → 200 + JSON response", async () => {
+    const server = await startBunServer();
+    try {
+      const res = await fetch(`${server.url}/users`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "ada",
+          email: "ada@example.com",
+          age: 36,
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toMatch(/application\/json/);
+      const json = (await res.json()) as {
+        id: string;
+        name: string;
+        email: string;
+      };
+      expect(json.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(json.name).toBe("ada");
+      expect(json.email).toBe("ada@example.com");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("POST /users with an invalid body → 400 problem+json with errors", async () => {
+    const server = await startBunServer();
+    try {
+      const res = await fetch(`${server.url}/users`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "", email: "not-an-email", age: -1 }),
+      });
+      expect(res.status).toBe(400);
+      expect(res.headers.get("content-type")).toMatch(
+        /application\/problem\+json/,
+      );
+      const body = (await res.json()) as {
+        type: string;
+        title: string;
+        status: number;
+        detail: string;
+        errors: unknown[];
+      };
+      expect(body.status).toBe(400);
+      expect(body.title).toBe("Validation Failed");
+      expect(Array.isArray(body.errors)).toBe(true);
+      expect(body.errors.length).toBeGreaterThan(0);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("GET /users?limit=2 → 200 with array body coerced through ListQuery", async () => {
+    const server = await startBunServer();
+    try {
+      const res = await fetch(`${server.url}/users?limit=2`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toMatch(/application\/json/);
+      const arr = (await res.json()) as Array<{ id: string }>;
+      expect(Array.isArray(arr)).toBe(true);
+      expect(arr.length).toBe(2);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("GET /users?limit=999 → 400 problem+json (Maximum<100>)", async () => {
+    const server = await startBunServer();
+    try {
+      const res = await fetch(`${server.url}/users?limit=999`);
+      expect(res.status).toBe(400);
+      expect(res.headers.get("content-type")).toMatch(
+        /application\/problem\+json/,
+      );
+      const body = (await res.json()) as {
+        errors: Array<{ path: string; expected: string }>;
+      };
+      expect(body.errors.some((e) => e.path.includes("limit"))).toBe(true);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("GET /users/:id extracts the path param", async () => {
+    const server = await startBunServer();
+    try {
+      const res = await fetch(
+        `${server.url}/users/11111111-1111-1111-1111-111111111111`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toMatch(/application\/json/);
+      const json = (await res.json()) as { id: string };
+      // The handler echoes the path id when it's the right length; otherwise
+      // falls back to a stable UUID. Either way, the param round-trips through
+      // the router → event.params.id → assertion.
+      expect(json.id).toBe("11111111-1111-1111-1111-111111111111");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("OpenAPI document includes request/response schemas", () => {
+    const openapi = JSON.parse(
+      readFileSync(resolve(FIXTURE_DIST, "openapi.json"), "utf-8"),
+    );
+    expect(openapi.openapi).toMatch(/^3\.[12](\.\d+)?$/);
+    expect(openapi.paths["/users"]).toBeDefined();
+    expect(openapi.paths["/users"].post).toBeDefined();
+    expect(openapi.paths["/users"].get).toBeDefined();
+    expect(openapi.paths["/users/{id}"]).toBeDefined();
+    expect(openapi.components.schemas.CreateUserDto).toBeDefined();
+    expect(openapi.components.schemas.UserResponse).toBeDefined();
+    // ListQuery is flattened into the `parameters` array (one per property)
+    // — OpenAPI doesn't model query DTOs as schemas, so it doesn't end up
+    // under components.schemas.
+    const listOp = openapi.paths["/users"].get;
+    expect(Array.isArray(listOp.parameters)).toBe(true);
+    expect(
+      listOp.parameters.some(
+        (p: { name: string; in: string }) =>
+          p.name === "limit" && p.in === "query",
+      ),
+    ).toBe(true);
+  });
+});

--- a/e2e/mint-upload.test.ts
+++ b/e2e/mint-upload.test.ts
@@ -1,0 +1,344 @@
+import { spawn, type ChildProcess } from "child_process";
+import { existsSync, readFileSync, rmSync } from "fs";
+import { resolve } from "path";
+import { describe, it, expect, beforeAll } from "vitest";
+import { FIXTURES_DIR, runTsgonest } from "./helpers";
+
+const FIXTURE_DIR = resolve(FIXTURES_DIR, "mint-upload");
+const FIXTURE_DIST = resolve(FIXTURE_DIR, "dist");
+
+async function startBunServer(): Promise<{
+  url: string;
+  process: ChildProcess;
+  stop: () => Promise<void>;
+}> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn("bun", [resolve(FIXTURE_DIST, "main.js")], {
+      cwd: FIXTURE_DIR,
+      env: { ...process.env, PORT: "0" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(
+        new Error(
+          `bun did not listen within 10s.\nstdout: ${stdout}\nstderr: ${stderr}`,
+        ),
+      );
+    }, 10000);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+      const match = stdout.match(/LISTENING:(https?:\/\/[^\s\n/]+)\/?/);
+      if (!match) return;
+      clearTimeout(timeout);
+      resolvePromise({
+        url: match[1].replace("[::1]", "127.0.0.1"),
+        process: child,
+        stop: () =>
+          new Promise<void>((res) => {
+            child.on("exit", () => res());
+            child.kill("SIGTERM");
+            setTimeout(() => {
+              child.kill("SIGKILL");
+              res();
+            }, 3000);
+          }),
+      });
+    });
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      if (!stdout.includes("LISTENING:")) {
+        reject(
+          new Error(
+            `bun exited with ${code} before listening.\nstdout: ${stdout}\nstderr: ${stderr}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+// Build a minimal PNG (8 bytes signature + IHDR). Enough to satisfy
+// content-type sniffing in this test — we never decode it.
+function tinyPng(size: number): Uint8Array {
+  const out = new Uint8Array(size);
+  out.set([137, 80, 78, 71, 13, 10, 26, 10], 0);
+  // Fill remainder with deterministic bytes.
+  for (let i = 8; i < size; i++) out[i] = i & 0xff;
+  return out;
+}
+
+describe("Mint Phase 9: buffered file uploads", () => {
+  beforeAll(() => {
+    if (existsSync(FIXTURE_DIST)) {
+      rmSync(FIXTURE_DIST, { recursive: true });
+    }
+    const { exitCode, stderr } = runTsgonest([
+      "--project",
+      "testdata/mint-upload/tsconfig.json",
+      "--config",
+      "testdata/mint-upload/tsgonest.config.json",
+    ]);
+    if (exitCode !== 0) {
+      throw new Error(`tsgonest build failed: ${stderr}`);
+    }
+  });
+
+  it("emits the multipart-aware register wrapper", () => {
+    const register = readFileSync(
+      resolve(FIXTURE_DIST, "upload.controller.UploadController.tsgonest.js"),
+      "utf-8",
+    );
+    expect(register).toContain("event.body.formData()");
+    expect(register).toContain("matchMimeType");
+    expect(register).toContain("parseMultipartStream");
+    expect(register).toContain("__iter.setLimit");
+  });
+
+  it("OpenAPI emits multipart/form-data for the avatar route", () => {
+    const openapi = JSON.parse(
+      readFileSync(resolve(FIXTURE_DIST, "openapi.json"), "utf-8"),
+    );
+    const avatarOp = openapi.paths["/uploads/avatar"].post;
+    expect(avatarOp.requestBody).toBeDefined();
+    expect(avatarOp.requestBody.content["multipart/form-data"]).toBeDefined();
+    expect(
+      avatarOp.requestBody.content["multipart/form-data"].schema,
+    ).toBeDefined();
+  });
+
+  it("POST /uploads/avatar with a valid PNG → 200 + JSON response", async () => {
+    const server = await startBunServer();
+    try {
+      const form = new FormData();
+      form.append("title", "my avatar");
+      form.append(
+        "image",
+        new Blob([tinyPng(512)], { type: "image/png" }),
+        "avatar.png",
+      );
+      const res = await fetch(`${server.url}/uploads/avatar`, {
+        method: "POST",
+        body: form,
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        ok: boolean;
+        name: string;
+        size: number;
+        type: string;
+      };
+      expect(body.ok).toBe(true);
+      expect(body.name).toBe("my avatar");
+      expect(body.type).toBe("image/png");
+      expect(body.size).toBe(512);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("POST /uploads/avatar with oversize file → 400 problem+json", async () => {
+    const server = await startBunServer();
+    try {
+      const form = new FormData();
+      form.append("title", "big");
+      form.append(
+        "image",
+        new Blob([tinyPng(20_000)], { type: "image/png" }),
+        "big.png",
+      );
+      const res = await fetch(`${server.url}/uploads/avatar`, {
+        method: "POST",
+        body: form,
+      });
+      expect(res.status).toBe(400);
+      expect(res.headers.get("content-type")).toMatch(
+        /application\/problem\+json/,
+      );
+      const body = (await res.json()) as {
+        errors: Array<{ path: string; expected: string }>;
+      };
+      expect(
+        body.errors.some((e) => e.path === "body.image" && /maxSize/.test(e.expected)),
+      ).toBe(true);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("POST /uploads/avatar with wrong MIME → 400 problem+json", async () => {
+    const server = await startBunServer();
+    try {
+      const form = new FormData();
+      form.append("title", "txt");
+      form.append(
+        "image",
+        new Blob(["hello"], { type: "text/plain" }),
+        "note.txt",
+      );
+      const res = await fetch(`${server.url}/uploads/avatar`, {
+        method: "POST",
+        body: form,
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as {
+        errors: Array<{ path: string; expected: string }>;
+      };
+      expect(
+        body.errors.some((e) => e.path === "body.image" && /mimeTypes/.test(e.expected)),
+      ).toBe(true);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("POST /uploads/avatar with empty title → 400 problem+json", async () => {
+    const server = await startBunServer();
+    try {
+      const form = new FormData();
+      form.append("title", "");
+      form.append(
+        "image",
+        new Blob([tinyPng(256)], { type: "image/png" }),
+        "a.png",
+      );
+      const res = await fetch(`${server.url}/uploads/avatar`, {
+        method: "POST",
+        body: form,
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as {
+        errors: Array<{ path: string }>;
+      };
+      expect(body.errors.some((e) => e.path === "body.title")).toBe(true);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+describe("Mint Phase 10: streaming file uploads", () => {
+  it("POST /uploads/large with a streaming file → 200 with byte count", async () => {
+    const server = await startBunServer();
+    try {
+      // Build a multipart body manually so we exercise the streaming path.
+      const boundary = "X-STREAM-TEST-BOUNDARY";
+      const enc = new TextEncoder();
+      const payload = new Uint8Array(1024 * 256); // 256KB
+      for (let i = 0; i < payload.length; i++) payload[i] = i & 0xff;
+
+      const parts: Uint8Array[] = [];
+      parts.push(enc.encode(`--${boundary}\r\n`));
+      parts.push(
+        enc.encode(
+          'Content-Disposition: form-data; name="filename"\r\n\r\n',
+        ),
+      );
+      parts.push(enc.encode("my-upload.bin"));
+      parts.push(enc.encode(`\r\n--${boundary}\r\n`));
+      parts.push(
+        enc.encode(
+          'Content-Disposition: form-data; name="file"; filename="payload.bin"\r\nContent-Type: application/octet-stream\r\n\r\n',
+        ),
+      );
+      parts.push(payload);
+      parts.push(enc.encode(`\r\n--${boundary}--\r\n`));
+
+      let total = 0;
+      for (const p of parts) total += p.length;
+      const body = new Uint8Array(total);
+      let off = 0;
+      for (const p of parts) {
+        body.set(p, off);
+        off += p.length;
+      }
+
+      const res = await fetch(`${server.url}/uploads/large`, {
+        method: "POST",
+        headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+        body,
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as {
+        ok: boolean;
+        filename: string;
+        bytes: number;
+      };
+      expect(json.ok).toBe(true);
+      expect(json.filename).toBe("my-upload.bin");
+      expect(json.bytes).toBe(payload.length);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("POST /uploads/large with oversize stream → 400/413 problem+json", async () => {
+    const server = await startBunServer();
+    try {
+      const boundary = "X-STREAM-LIMIT";
+      const enc = new TextEncoder();
+      // 6MB — exceeds the 5MB MaxSize set in the DTO.
+      const payload = new Uint8Array(6 * 1024 * 1024);
+      for (let i = 0; i < payload.length; i++) payload[i] = i & 0xff;
+
+      const parts: Uint8Array[] = [];
+      parts.push(enc.encode(`--${boundary}\r\n`));
+      parts.push(
+        enc.encode(
+          'Content-Disposition: form-data; name="filename"\r\n\r\n',
+        ),
+      );
+      parts.push(enc.encode("too-big.bin"));
+      parts.push(enc.encode(`\r\n--${boundary}\r\n`));
+      parts.push(
+        enc.encode(
+          'Content-Disposition: form-data; name="file"; filename="big.bin"\r\nContent-Type: application/octet-stream\r\n\r\n',
+        ),
+      );
+      parts.push(payload);
+      parts.push(enc.encode(`\r\n--${boundary}--\r\n`));
+
+      let total = 0;
+      for (const p of parts) total += p.length;
+      const body = new Uint8Array(total);
+      let off = 0;
+      for (const p of parts) {
+        body.set(p, off);
+        off += p.length;
+      }
+
+      const res = await fetch(`${server.url}/uploads/large`, {
+        method: "POST",
+        headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+        body,
+      });
+      // The byte-limit error surfaces as a 400 problem+json via the validation
+      // error mapper. (Mint can be configured to map this to 413 if desired.)
+      expect([400, 413]).toContain(res.status);
+      const json = (await res.json()) as {
+        errors: Array<{ path: string; expected: string }>;
+      };
+      expect(
+        json.errors.some(
+          (e) => e.path === "body.file" && /maxSize/.test(e.expected),
+        ),
+      ).toBe(true);
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/internal/analyzer/branded.go
+++ b/internal/analyzer/branded.go
@@ -23,18 +23,26 @@ func (w *TypeWalker) tryDetectBranded(rawTypes []*shimchecker.Type, members []me
 
 	for i := range members {
 		m := &members[i]
-		if m.Kind == metadata.KindAtomic || m.Kind == metadata.KindLiteral {
+		switch {
+		case m.Kind == metadata.KindAtomic || m.Kind == metadata.KindLiteral:
 			if atomicMember != nil {
 				return nil // Multiple atomics/literals — not a branded type
 			}
 			atomicMember = m
-		} else if m.Kind == metadata.KindObject && isPhantomObject(m) {
+		case m.Kind == metadata.KindNative && isFileLikeNative(m.NativeType):
+			// `File & MaxSize<N>` and friends — treat File/Blob/FileStream as
+			// the "atomic" carrier for file-upload constraint extraction.
+			if atomicMember != nil {
+				return nil
+			}
+			atomicMember = m
+		case m.Kind == metadata.KindObject && isPhantomObject(m):
 			phantomMembers = append(phantomMembers, m)
 			if i < len(rawTypes) {
 				rawPhantomTypes = append(rawPhantomTypes, rawTypes[i])
 			}
 			phantomCount++
-		} else {
+		default:
 			return nil // Non-atomic, non-phantom member — not a branded type
 		}
 	}
@@ -194,6 +202,28 @@ func extractBrandedTagConstraint(c *metadata.Constraints, tagType *metadata.Meta
 
 	// Map typia kind to our constraint keys
 	return extractConstraintValue(c, kind, valueMeta)
+}
+
+// isFileLikeNative reports whether a NativeType is a file-shaped value that
+// can carry MaxSize/MinSize/MimeTypes constraints.
+func isFileLikeNative(name string) bool {
+	switch name {
+	case "File", "Blob", "FileStream":
+		return true
+	}
+	return false
+}
+
+// hasFileStreamMarker reports whether an interface/type exposes the
+// `__tsgonest_fileStream` phantom property. tsgonest uses this marker to
+// distinguish the streaming `FileStream` interface from a user type that
+// happens to be named `FileStream`.
+func hasFileStreamMarker(checker *shimchecker.Checker, t *shimchecker.Type) bool {
+	if checker == nil || t == nil {
+		return false
+	}
+	sym := checker.GetPropertyOfType(t, "__tsgonest_fileStream")
+	return sym != nil
 }
 
 // isPhantomObject checks if an object type only has "phantom" properties

--- a/internal/analyzer/decorator_origin.go
+++ b/internal/analyzer/decorator_origin.go
@@ -180,3 +180,10 @@ func IsTsgonestModule(moduleSpecifier string) bool {
 		moduleSpecifier == "@tsgonest/runtime" ||
 		len(moduleSpecifier) > 10 && moduleSpecifier[:10] == "@tsgonest/"
 }
+
+// IsMintkitModule checks if a module specifier refers to a Mint framework package.
+// Matches "@mintkit/core" exactly (Phase 1 scope) and any "@mintkit/*" scoped package.
+func IsMintkitModule(moduleSpecifier string) bool {
+	return moduleSpecifier == "@mintkit/core" ||
+		(len(moduleSpecifier) > 9 && moduleSpecifier[:9] == "@mintkit/")
+}

--- a/internal/analyzer/mint_test.go
+++ b/internal/analyzer/mint_test.go
@@ -1,0 +1,108 @@
+package analyzer_test
+
+import (
+	"testing"
+
+	"github.com/tsgonest/tsgonest/internal/analyzer"
+)
+
+func TestIsMintkitModule(t *testing.T) {
+	cases := []struct {
+		spec string
+		want bool
+	}{
+		{"@mintkit/core", true},
+		{"@mintkit/runtime", true},
+		{"@mintkit/x", true},
+		{"@mintkit", false},
+		{"@mintkit/", false},
+		{"mintkit", false},
+		{"@nestjs/common", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := analyzer.IsMintkitModule(c.spec); got != c.want {
+			t.Errorf("IsMintkitModule(%q) = %v, want %v", c.spec, got, c.want)
+		}
+	}
+}
+
+func TestControllerAnalyzer_MintFrameworkDetection(t *testing.T) {
+	env := setupWalkerMultiFile(t, map[string]string{
+		"node_modules/@mintkit/core/index.d.ts": `
+			export function Controller(path: string): ClassDecorator;
+			export function Get(path?: string): MethodDecorator;
+		`,
+		"hello.controller.ts": `
+			import { Controller, Get } from "@mintkit/core";
+
+			@Controller("/hello")
+			export class HelloController {
+				@Get()
+				hello(): string { return "hi"; }
+			}
+		`,
+	}, "hello.controller.ts")
+	defer env.release()
+
+	ca, caRelease := analyzer.NewControllerAnalyzer(env.program)
+	defer caRelease()
+
+	controllers := ca.AnalyzeSourceFile(env.sourceFile)
+	if len(controllers) != 1 {
+		t.Fatalf("expected 1 controller, got %d", len(controllers))
+	}
+	ctrl := controllers[0]
+	if ctrl.Name != "HelloController" {
+		t.Errorf("expected Name=HelloController, got %q", ctrl.Name)
+	}
+	if ctrl.Path != "hello" {
+		t.Errorf("expected Path=hello, got %q", ctrl.Path)
+	}
+	if ctrl.Framework != "mint" {
+		t.Errorf("expected Framework=mint, got %q", ctrl.Framework)
+	}
+	if len(ctrl.Routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(ctrl.Routes))
+	}
+	if ctrl.Routes[0].Method != "GET" {
+		t.Errorf("expected Method=GET, got %q", ctrl.Routes[0].Method)
+	}
+}
+
+func TestControllerAnalyzer_NestJSFrameworkUnset(t *testing.T) {
+	env := setupWalkerMultiFile(t, map[string]string{
+		"node_modules/@nestjs/common/index.d.ts": `
+			export function Controller(path: string): ClassDecorator;
+			export function Get(path?: string): MethodDecorator;
+		`,
+		"hello.controller.ts": `
+			import { Controller, Get } from "@nestjs/common";
+
+			@Controller("/hello")
+			export class HelloController {
+				@Get()
+				hello(): string { return "hi"; }
+			}
+		`,
+	}, "hello.controller.ts")
+	defer env.release()
+
+	ca, caRelease := analyzer.NewControllerAnalyzer(env.program)
+	defer caRelease()
+
+	controllers := ca.AnalyzeSourceFile(env.sourceFile)
+	if len(controllers) != 1 {
+		t.Fatalf("expected 1 controller, got %d", len(controllers))
+	}
+	ctrl := controllers[0]
+	if ctrl.Framework != "" {
+		t.Errorf("expected empty Framework for NestJS, got %q", ctrl.Framework)
+	}
+	if ctrl.Path != "hello" {
+		t.Errorf("expected Path=hello, got %q", ctrl.Path)
+	}
+	if len(ctrl.Routes) != 1 || ctrl.Routes[0].Method != "GET" {
+		t.Fatalf("expected 1 GET route")
+	}
+}

--- a/internal/analyzer/routes.go
+++ b/internal/analyzer/routes.go
@@ -32,6 +32,11 @@ type ControllerInfo struct {
 	// IgnoreOpenAPI is true when the controller should be excluded from OpenAPI generation.
 	// Set by @tsgonest-ignore openapi, @hidden, or @exclude JSDoc on the class.
 	IgnoreOpenAPI bool
+	// Framework identifies which framework's @Controller decorator was used.
+	// Values: "" (default/NestJS), "mint" (@mintkit/core). The analyzer recognizes
+	// @Controller by name; this field is populated by resolving the decorator's
+	// import origin when present.
+	Framework string
 }
 
 // Route represents a single HTTP route extracted from a controller method.
@@ -305,6 +310,7 @@ func (a *ControllerAnalyzer) analyzeClass(classNode *ast.Node, sourceFile string
 	var controllerPaths []string
 	controllerVersion := ""
 	isController := false
+	framework := ""
 	for _, dec := range classNode.Decorators() {
 		info := ParseDecorator(dec)
 		if info == nil {
@@ -327,6 +333,9 @@ func (a *ControllerAnalyzer) analyzeClass(classNode *ast.Node, sourceFile string
 				controllerPaths = pathArgs
 			}
 			controllerVersion = extractControllerVersion(dec)
+			if origin := ResolveDecoratorOrigin(dec, a.checker); origin != nil && IsMintkitModule(origin.ModuleSpecifier) {
+				framework = "mint"
+			}
 			break
 		}
 	}
@@ -430,6 +439,7 @@ func (a *ControllerAnalyzer) analyzeClass(classNode *ast.Node, sourceFile string
 			Routes:        routes,
 			SourceFile:    sourceFile,
 			IgnoreOpenAPI: classInfo.IgnoreOpenAPI,
+			Framework:     framework,
 		})
 	}
 

--- a/internal/analyzer/routes.go
+++ b/internal/analyzer/routes.go
@@ -828,13 +828,16 @@ func (a *ControllerAnalyzer) analyzeMethod(methodNode *ast.Node, controllerPath 
 	// Apply content type to body parameters:
 	// 1. JSDoc @contentType override takes highest priority
 	// 2. Auto-detect: string body → text/plain
-	// 3. Default: application/json (empty string means default)
+	// 3. Auto-detect: body type with a File/FileStream field → multipart/form-data
+	// 4. Default: application/json (empty string means default)
 	for i := range params {
 		if params[i].Category == string(CategoryBody) {
 			if contentType != "" {
 				params[i].ContentType = contentType
 			} else if params[i].Type.Kind == metadata.KindAtomic && params[i].Type.Atomic == "string" {
 				params[i].ContentType = "text/plain"
+			} else if bodyContainsFileField(&params[i].Type, a.registry) {
+				params[i].ContentType = "multipart/form-data"
 			}
 			// else: leave empty, generator will default to application/json
 		}
@@ -1415,6 +1418,52 @@ func (a *ControllerAnalyzer) analyzeParameter(paramNode *ast.Node, className str
 	}
 
 	return rp
+}
+
+// bodyContainsFileField inspects a body type for top-level fields of type
+// `File`, `Blob`, `File[]`, or `FileStream`. Follows KindRef into the registry.
+// Used to auto-set ContentType="multipart/form-data" on routes whose bodies are
+// declared with file fields (no explicit @FormDataBody / @contentType needed).
+func bodyContainsFileField(m *metadata.Metadata, registry *metadata.TypeRegistry) bool {
+	if m == nil {
+		return false
+	}
+	target := m
+	if m.Kind == metadata.KindRef && registry != nil {
+		if resolved := registry.Types[m.Ref]; resolved != nil {
+			target = resolved
+		}
+	}
+	if target.Kind != metadata.KindObject {
+		return false
+	}
+	for _, prop := range target.Properties {
+		pt := &prop.Type
+		// Unwrap optional unions.
+		if pt.Kind == metadata.KindUnion {
+			for i := range pt.UnionMembers {
+				um := &pt.UnionMembers[i]
+				if um.Kind == metadata.KindAtomic && (um.Atomic == "undefined" || um.Atomic == "null") {
+					continue
+				}
+				pt = um
+				break
+			}
+		}
+		if pt.Kind == metadata.KindNative {
+			switch pt.NativeType {
+			case "File", "Blob", "FileStream":
+				return true
+			}
+		}
+		if pt.Kind == metadata.KindArray && pt.ElementType != nil {
+			el := pt.ElementType
+			if el.Kind == metadata.KindNative && (el.NativeType == "File" || el.NativeType == "Blob") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // extractInitializerLiteralValue extracts a Go value from an AST literal expression.

--- a/internal/analyzer/type_walker.go
+++ b/internal/analyzer/type_walker.go
@@ -1160,6 +1160,13 @@ func (w *TypeWalker) walkObjectType(t *shimchecker.Type) metadata.Metadata {
 			return metadata.Metadata{Kind: metadata.KindNative, NativeType: name}
 		case "File", "Blob", "StreamableFile":
 			return metadata.Metadata{Kind: metadata.KindNative, NativeType: name}
+		case "FileStream":
+			// `FileStream` is a tsgonest-shipped interface declared with a
+			// `__tsgonest_fileStream` phantom property. Treat it as a distinct
+			// native type so codegen can emit the streaming multipart parser.
+			if hasFileStreamMarker(w.checker, t) {
+				return metadata.Metadata{Kind: metadata.KindNative, NativeType: "FileStream"}
+			}
 		case "Error":
 			return metadata.Metadata{Kind: metadata.KindNative, NativeType: "Error"}
 		}

--- a/internal/analyzer/type_walker_test.go
+++ b/internal/analyzer/type_walker_test.go
@@ -6105,6 +6105,70 @@ func TestWalkType_BlobNativeType(t *testing.T) {
 	}
 }
 
+// TestWalkType_FileStreamNativeType verifies the tsgonest-shipped FileStream
+// interface is recognized as a distinct native type via its phantom marker.
+func TestWalkType_FileStreamNativeType(t *testing.T) {
+	env := setupWalker(t, `
+		interface FileStream {
+			readonly name: string;
+			readonly type: string;
+			readonly stream: any;
+			readonly __tsgonest_fileStream?: true;
+		}
+		type Upload = { file: FileStream; };
+	`)
+	defer env.release()
+
+	m := env.walkExportedType(t, "Upload")
+	assertKind(t, m, metadata.KindObject)
+
+	fileProp := m.Properties[0]
+	if fileProp.Type.Kind != metadata.KindNative || fileProp.Type.NativeType != "FileStream" {
+		t.Errorf("file: expected KindNative/FileStream, got Kind=%s NativeType=%q", fileProp.Type.Kind, fileProp.Type.NativeType)
+	}
+}
+
+// TestWalkType_FileMaxSizeBranded verifies that `File & {__tsgonest_maxSize?: 5000}`
+// extracts a MaxSize constraint while preserving the underlying File native type.
+func TestWalkType_FileMaxSizeBranded(t *testing.T) {
+	env := setupWalker(t, `
+		interface Blob { readonly size: number; readonly type: string; }
+		interface File extends Blob { readonly name: string; }
+		type Avatar = File & { readonly __tsgonest_maxSize?: 5000 };
+	`)
+	defer env.release()
+
+	m := env.walkExportedType(t, "Avatar")
+	if m.Kind != metadata.KindNative || m.NativeType != "File" {
+		t.Fatalf("expected KindNative/File, got Kind=%s NativeType=%q", m.Kind, m.NativeType)
+	}
+	if m.Constraints == nil || m.Constraints.MaxSize == nil {
+		t.Fatalf("expected MaxSize constraint, got %#v", m.Constraints)
+	}
+	if *m.Constraints.MaxSize != 5000 {
+		t.Errorf("expected MaxSize=5000, got %d", *m.Constraints.MaxSize)
+	}
+}
+
+// TestWalkType_FileMimeTypesUnionBranded verifies that a MimeTypes union
+// extracts a slice of allowed MIME types.
+func TestWalkType_FileMimeTypesUnionBranded(t *testing.T) {
+	env := setupWalker(t, `
+		interface Blob { readonly size: number; readonly type: string; }
+		interface File extends Blob { readonly name: string; }
+		type Pic = File & { readonly __tsgonest_mimeTypes?: "image/png" | "image/jpeg" };
+	`)
+	defer env.release()
+
+	m := env.walkExportedType(t, "Pic")
+	if m.Kind != metadata.KindNative || m.NativeType != "File" {
+		t.Fatalf("expected KindNative/File, got Kind=%s NativeType=%q", m.Kind, m.NativeType)
+	}
+	if m.Constraints == nil || len(m.Constraints.MimeTypes) != 2 {
+		t.Fatalf("expected 2 mime types, got %#v", m.Constraints)
+	}
+}
+
 // TestWalkType_InterfacePropertyTypesRegistered verifies that interfaces used
 // as property types are registered as named schemas (KindRef), not inlined as
 // empty schemas. Regression: nested interfaces with branded type properties

--- a/internal/codegen/companion.go
+++ b/internal/codegen/companion.go
@@ -92,6 +92,21 @@ func GenerateCompanionFiles(sourceFileName string, types map[string]*metadata.Me
 	return files
 }
 
+// CompanionPathForOutput returns the companion file path for a type given its
+// source-file output base (e.g. "dist/user.dto.ts") and the type name.
+// Wrapper around the package-internal companionPath so cross-package callers
+// (cmd/tsgonest) can compute companion locations without duplicating the rule.
+func CompanionPathForOutput(sourceFileName string, typeName string) string {
+	return companionPath(sourceFileName, typeName)
+}
+
+// RelativeCompanionImport returns a forward-slash relative module specifier
+// from `fromCompanionPath` to `toCompanionPath`. Exported wrapper around the
+// internal helper.
+func RelativeCompanionImport(fromCompanionPath, toCompanionPath string) string {
+	return relativeCompanionImport(fromCompanionPath, toCompanionPath)
+}
+
 // companionPath generates the companion file path from the source file path.
 // e.g., "src/user.dto.ts" + "CreateUserDto" → "src/user.dto.CreateUserDto.tsgonest.js"
 func companionPath(sourceFileName string, typeName string) string {

--- a/internal/codegen/mint_register.go
+++ b/internal/codegen/mint_register.go
@@ -1,12 +1,102 @@
 package codegen
 
-import "strings"
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/tsgonest/tsgonest/internal/metadata"
+)
+
+// MintParamKind tags how a route parameter is sourced from the incoming Event.
+type MintParamKind int
+
+const (
+	// MintParamBody — @Body() parsed via event.body.json().
+	MintParamBody MintParamKind = iota
+	// MintParamQuery — @Query() — DTO-shaped whole-object or single named scalar.
+	MintParamQuery
+	// MintParamPathParam — @Param() — single named path segment read from event.params.
+	MintParamPathParam
+	// MintParamHeader — @Headers() — either DTO via headers iteration or single named header.
+	MintParamHeader
+)
+
+// MintParamInfo describes one handler parameter for the Mint register wrapper.
+type MintParamInfo struct {
+	Kind MintParamKind
+	// Name is the decorator argument (e.g. "id" for @Param("id"), header name for @Headers("x-foo")).
+	// Empty when the parameter consumes the entire body/query/headers object.
+	Name string
+	// LocalName is the JS identifier the wrapper assigns to before passing to the handler.
+	LocalName string
+	// TypeName is the DTO type name when this param uses a named DTO (assertXxx companion exists).
+	TypeName string
+	// CompanionImport is the relative module specifier for the DTO companion (when TypeName != "").
+	CompanionImport string
+	// Atomic captures the scalar type ("string", "number", "boolean") for single-named
+	// scalar query/param/header params. Empty for DTO-shaped params.
+	Atomic string
+	// Constraints are inlined as runtime checks for scalar params.
+	Constraints *metadata.Constraints
+	// Multipart describes the body parsing strategy when the body contains File
+	// or FileStream fields. nil for JSON bodies.
+	Multipart *MintMultipartBody
+}
+
+// MintMultipartBody describes a body that must be parsed from multipart/form-data
+// rather than JSON. Built from the body type's metadata when at least one field
+// is a File or FileStream.
+type MintMultipartBody struct {
+	// Streaming is true when any field is a FileStream. The wrapper consumes
+	// `event.body.stream()` via the multipart parser shipped in @mintkit/core.
+	Streaming bool
+	// Fields enumerates the body type's top-level properties.
+	Fields []MintMultipartField
+}
+
+// MintMultipartFieldKind identifies the shape of a single multipart field.
+type MintMultipartFieldKind int
+
+const (
+	// MintFieldScalar is a string/number/boolean form field.
+	MintFieldScalar MintMultipartFieldKind = iota
+	// MintFieldFile is a single buffered File entry.
+	MintFieldFile
+	// MintFieldFileArray is a repeated File entry under the same name.
+	MintFieldFileArray
+	// MintFieldFileStream is a single streaming file entry.
+	MintFieldFileStream
+)
+
+// MintMultipartField describes one property of a multipart body type.
+type MintMultipartField struct {
+	Name        string
+	Kind        MintMultipartFieldKind
+	Required    bool
+	Atomic      string // "string"|"number"|"boolean" for MintFieldScalar
+	Constraints *metadata.Constraints
+}
 
 // MintRouteInfo describes a single route to register with a Mint app router.
 type MintRouteInfo struct {
 	Method     string
 	Path       string
 	MethodName string
+	Params     []MintParamInfo
+
+	// ReturnTypeName is the named return type (DTO). Empty for primitive or void returns.
+	ReturnTypeName string
+	// ReturnCompanionImport is the relative specifier of the return type's companion.
+	// Empty when ReturnTypeName is empty.
+	ReturnCompanionImport string
+	// ReturnIsArray is true when the route returns T[] (use serialize + array stringify).
+	ReturnIsArray bool
+	// ReturnAtomic is the primitive return ("string", "number", "boolean").
+	// Set only when there is no DTO return type.
+	ReturnAtomic string
+	// ReturnVoid is true when the handler returns void / undefined → 204.
+	ReturnVoid bool
 }
 
 // MintRegisterInput describes the data needed to emit a registerXxxController() helper.
@@ -14,26 +104,837 @@ type MintRegisterInput struct {
 	ControllerName       string
 	ControllerImportPath string
 	Routes               []MintRouteInfo
+	// ResponseSerializer mirrors transforms.responseSerializer: "guard" (default),
+	// "safe", or "none". "none" falls back to JSON.stringify for DTO returns.
+	ResponseSerializer string
 }
 
 // GenerateMintRegister returns ESM JS source for a companion file that exports
 // `register{ControllerName}(app)`. The companion imports the controller class
-// and registers each route with app.router.add(...).
+// plus any DTO companions, parses parameters from the Event, invokes the handler,
+// and serialises the result back into a Response.
 func GenerateMintRegister(input MintRegisterInput) string {
+	serializer := input.ResponseSerializer
+	if serializer == "" {
+		serializer = "guard"
+	}
+
+	// Decide which file-level helpers we need.
+	needsQueryObj := false
+	needsHeadersObj := false
+	needsValidationErr := false
+	needsMimeHelper := false
+	needsStreamingParser := false
+	for _, r := range input.Routes {
+		for _, p := range r.Params {
+			switch p.Kind {
+			case MintParamQuery:
+				if p.Name == "" {
+					needsQueryObj = true
+				} else {
+					// Scalar query params may throw validation errors during coercion / constraint checks.
+					needsValidationErr = true
+				}
+			case MintParamHeader:
+				if p.Name == "" {
+					needsHeadersObj = true
+				} else {
+					needsValidationErr = true
+				}
+			case MintParamPathParam:
+				if p.Name != "" {
+					needsValidationErr = true
+				}
+			case MintParamBody:
+				if p.Multipart != nil {
+					needsValidationErr = true
+					if p.Multipart.Streaming {
+						needsStreamingParser = true
+					}
+					for _, f := range p.Multipart.Fields {
+						if f.Constraints != nil && len(f.Constraints.MimeTypes) > 0 {
+							needsMimeHelper = true
+						}
+					}
+				}
+			}
+		}
+	}
+
 	e := NewEmitter()
+	e.Line("// Auto-generated by tsgonest — do not edit")
+
+	// Imports.
 	e.Line("import { %s } from %q;", input.ControllerName, input.ControllerImportPath)
+	companionImports := collectCompanionImports(input, serializer)
+	for _, imp := range companionImports {
+		e.Line("import { %s } from %q;", strings.Join(imp.Names, ", "), imp.Module)
+	}
+	if needsMimeHelper || needsStreamingParser {
+		names := []string{}
+		if needsMimeHelper {
+			names = append(names, "matchMimeType")
+		}
+		if needsStreamingParser {
+			names = append(names, "parseMultipartStream", "MultipartByteLimitError")
+		}
+		e.Line("import { %s } from %q;", strings.Join(names, ", "), "@mintkit/core")
+	}
 	e.Blank()
+
+	// Helpers (emit once per file).
+	if needsValidationErr {
+		emitValidationErrorHelper(e)
+	}
+	if needsQueryObj {
+		emitQueryObjectHelper(e)
+	}
+	if needsHeadersObj {
+		emitHeadersObjectHelper(e)
+	}
+	if needsStreamingParser {
+		emitMultipartBoundaryHelper(e)
+	}
+
+	// Exported register function.
 	e.Block("export function %s(app)", mintRegisterFnName(input.ControllerName))
 	for _, r := range input.Routes {
-		e.Block("app.router.add(%q, %q, async (event) =>", r.Method, r.Path)
-		e.Line("const ctrl = event.resolve(%s);", input.ControllerName)
-		e.Line("const result = await ctrl.%s(event);", r.MethodName)
-		e.Line("if (result instanceof Response) return result;")
-		e.Line("return new Response(result == null ? \"\" : String(result));")
-		e.EndBlockSuffix(");")
+		emitRoute(e, input.ControllerName, r, serializer)
 	}
 	e.EndBlock()
 	return e.String()
+}
+
+type mintCompanionImport struct {
+	Module string
+	Names  []string
+}
+
+// collectCompanionImports gathers the deduped set of companion imports needed
+// across all routes — assertXxx for body/query/header DTO params, plus
+// stringifyXxx/serializeXxx for return types.
+func collectCompanionImports(input MintRegisterInput, serializer string) []mintCompanionImport {
+	type entry struct {
+		names map[string]bool
+	}
+	byModule := make(map[string]*entry)
+
+	add := func(module, name string) {
+		if module == "" || name == "" {
+			return
+		}
+		e := byModule[module]
+		if e == nil {
+			e = &entry{names: make(map[string]bool)}
+			byModule[module] = e
+		}
+		e.names[name] = true
+	}
+
+	for _, r := range input.Routes {
+		for _, p := range r.Params {
+			if p.TypeName != "" && p.CompanionImport != "" {
+				add(p.CompanionImport, "assert"+p.TypeName)
+			}
+		}
+		if r.ReturnTypeName != "" && r.ReturnCompanionImport != "" && serializer != "none" {
+			if r.ReturnIsArray {
+				add(r.ReturnCompanionImport, "serialize"+r.ReturnTypeName)
+			} else {
+				add(r.ReturnCompanionImport, "stringify"+r.ReturnTypeName)
+			}
+		}
+	}
+
+	modules := make([]string, 0, len(byModule))
+	for m := range byModule {
+		modules = append(modules, m)
+	}
+	sort.Strings(modules)
+
+	out := make([]mintCompanionImport, 0, len(modules))
+	for _, m := range modules {
+		names := make([]string, 0, len(byModule[m].names))
+		for n := range byModule[m].names {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		out = append(out, mintCompanionImport{Module: m, Names: names})
+	}
+	return out
+}
+
+func emitValidationErrorHelper(e *Emitter) {
+	// __mint_validation_error builds a TsgonestValidationError-compatible throw
+	// so Mint's error mapper (soft name-check) converts it to RFC 9457
+	// application/problem+json. We don't import @tsgonest/runtime to keep this
+	// file dep-free — the name check is all that matters.
+	e.Block("function __mint_validation_error(path, expected, received)")
+	e.Line(`const err = new Error("Validation failed: " + path + " (expected " + expected + ", received " + received + ")");`)
+	e.Line(`err.name = "TsgonestValidationError";`)
+	e.Line(`err.errors = [{ path, expected, received }];`)
+	e.Line(`err.status = 400;`)
+	e.Line(`return err;`)
+	e.EndBlock()
+	e.Blank()
+}
+
+func emitQueryObjectHelper(e *Emitter) {
+	// __mint_query_object turns URLSearchParams into a plain object, collapsing
+	// repeated keys into arrays so DTOs with `tags: string[]` work without extra
+	// schema annotation.
+	e.Block("function __mint_query_object(searchParams)")
+	e.Line(`const out = {};`)
+	e.Block(`for (const [key, value] of searchParams.entries())`)
+	e.Block(`if (Object.prototype.hasOwnProperty.call(out, key))`)
+	e.Block(`if (Array.isArray(out[key]))`)
+	e.Line(`out[key].push(value);`)
+	e.EndBlockSuffix(" else {")
+	e.indent++
+	e.Line(`out[key] = [out[key], value];`)
+	e.indent--
+	e.Line(`}`)
+	e.EndBlockSuffix(" else {")
+	e.indent++
+	e.Line(`out[key] = value;`)
+	e.indent--
+	e.Line(`}`)
+	e.EndBlock()
+	e.Line(`return out;`)
+	e.EndBlock()
+	e.Blank()
+}
+
+func emitHeadersObjectHelper(e *Emitter) {
+	e.Block("function __mint_headers_object(headers)")
+	e.Line(`const out = {};`)
+	e.Block(`for (const [key, value] of headers.entries())`)
+	e.Line(`out[key] = value;`)
+	e.EndBlock()
+	e.Line(`return out;`)
+	e.EndBlock()
+	e.Blank()
+}
+
+func emitMultipartBoundaryHelper(e *Emitter) {
+	// Extracts the boundary parameter from a Content-Type header value.
+	// Throws a TsgonestValidationError when the boundary is missing or empty.
+	e.Block("function __mint_multipart_boundary(contentType)")
+	e.Line(`const match = /boundary=("?)([^";\s]+)\1/i.exec(contentType ?? "");`)
+	e.Block(`if (!match)`)
+	e.Line(`throw __mint_validation_error("body", "multipart/form-data with boundary", "missing boundary");`)
+	e.EndBlock()
+	e.Line(`return match[2];`)
+	e.EndBlock()
+	e.Blank()
+}
+
+// emitBufferedMultipartBody emits inline code that reads the entire request body
+// via event.body.formData(), validates each declared field, and assembles the
+// final object bound to `local`. Used when at least one field is a `File` (or
+// `File[]`) but none are FileStream.
+func emitBufferedMultipartBody(e *Emitter, local string, body *MintMultipartBody) {
+	e.Line(`const __form = await event.body.formData();`)
+	e.Line(`const %s = {};`, local)
+	for _, f := range body.Fields {
+		emitBufferedMultipartField(e, local, f)
+	}
+}
+
+// emitBufferedMultipartField emits parsing + validation for a single multipart
+// field within a buffered body. Throws a TsgonestValidationError on any
+// constraint violation.
+func emitBufferedMultipartField(e *Emitter, local string, f MintMultipartField) {
+	path := "body." + f.Name
+	switch f.Kind {
+	case MintFieldScalar:
+		e.Line(`{`)
+		e.indent++
+		e.Line(`const __raw = __form.get(%q);`, f.Name)
+		if f.Required {
+			e.Block(`if (__raw === null || __raw === undefined)`)
+			e.Line(`throw __mint_validation_error(%q, %q, "undefined");`, path, fieldExpectedType(f))
+			e.EndBlock()
+		}
+		// Coerce to declared atomic type.
+		switch f.Atomic {
+		case "number":
+			e.Block(`if (__raw !== null && __raw !== undefined && __raw !== "")`)
+			e.Line(`const __n = +__raw;`)
+			e.Block(`if (Number.isNaN(__n))`)
+			e.Line(`throw __mint_validation_error(%q, "number", String(__raw));`, path)
+			e.EndBlock()
+			e.Line(`%s[%q] = __n;`, local, f.Name)
+			e.EndBlock()
+		case "boolean":
+			e.Block(`if (__raw === "true" || __raw === "1")`)
+			e.Line(`%s[%q] = true;`, local, f.Name)
+			e.EndBlockSuffix(` else if (__raw === "false" || __raw === "0") {`)
+			e.indent++
+			e.Line(`%s[%q] = false;`, local, f.Name)
+			e.indent--
+			e.EndBlockSuffix(` else if (__raw !== null && __raw !== undefined) {`)
+			e.indent++
+			e.Line(`throw __mint_validation_error(%q, "boolean", String(__raw));`, path)
+			e.indent--
+			e.Line(`}`)
+		default:
+			// String (or unspecified) — accept any FormDataEntryValue that's a string.
+			e.Block(`if (__raw !== null && __raw !== undefined)`)
+			e.Block(`if (typeof __raw !== "string")`)
+			e.Line(`throw __mint_validation_error(%q, "string", typeof __raw);`, path)
+			e.EndBlock()
+			emitBufferedMultipartScalarStringConstraints(e, "__raw", path, f.Constraints)
+			e.Line(`%s[%q] = __raw;`, local, f.Name)
+			e.EndBlock()
+		}
+		if f.Atomic == "number" || f.Atomic == "boolean" {
+			emitBufferedMultipartScalarNumericConstraints(e, fmt.Sprintf("%s[%q]", local, f.Name), path, f.Atomic, f.Constraints)
+		}
+		e.indent--
+		e.Line(`}`)
+
+	case MintFieldFile:
+		e.Line(`{`)
+		e.indent++
+		e.Line(`const __file = __form.get(%q);`, f.Name)
+		if f.Required {
+			e.Block(`if (__file === null || __file === undefined || typeof __file === "string")`)
+			e.Line(`throw __mint_validation_error(%q, "File", typeof __file === "string" ? "string" : "undefined");`, path)
+			e.EndBlock()
+			emitFileConstraints(e, "__file", path, f.Constraints)
+			e.Line(`%s[%q] = __file;`, local, f.Name)
+		} else {
+			e.Block(`if (__file !== null && __file !== undefined)`)
+			e.Block(`if (typeof __file === "string")`)
+			e.Line(`throw __mint_validation_error(%q, "File", "string");`, path)
+			e.EndBlock()
+			emitFileConstraints(e, "__file", path, f.Constraints)
+			e.Line(`%s[%q] = __file;`, local, f.Name)
+			e.EndBlock()
+		}
+		e.indent--
+		e.Line(`}`)
+
+	case MintFieldFileArray:
+		e.Line(`{`)
+		e.indent++
+		e.Line(`const __files = __form.getAll(%q);`, f.Name)
+		if f.Required {
+			e.Block(`if (__files.length === 0)`)
+			e.Line(`throw __mint_validation_error(%q, "File[]", "empty");`, path)
+			e.EndBlock()
+		}
+		e.Line(`const __out = [];`)
+		e.Block(`for (let __i = 0; __i < __files.length; __i++)`)
+		e.Line(`const __file = __files[__i];`)
+		e.Block(`if (typeof __file === "string")`)
+		e.Line(`throw __mint_validation_error(%q + "[" + __i + "]", "File", "string");`, path)
+		e.EndBlock()
+		emitFileConstraints(e, "__file", path+"[]", f.Constraints)
+		e.Line(`__out.push(__file);`)
+		e.EndBlock()
+		e.Line(`%s[%q] = __out;`, local, f.Name)
+		e.indent--
+		e.Line(`}`)
+	}
+}
+
+func fieldExpectedType(f MintMultipartField) string {
+	switch f.Atomic {
+	case "number":
+		return "number"
+	case "boolean":
+		return "boolean"
+	default:
+		return "string"
+	}
+}
+
+// emitBufferedMultipartScalarStringConstraints emits inline checks for string
+// constraints (pattern, minLength, maxLength). Mirrors emitScalarConstraints but
+// without the path-specific framing.
+func emitBufferedMultipartScalarStringConstraints(e *Emitter, varName, path string, c *metadata.Constraints) {
+	if c == nil {
+		return
+	}
+	if c.Pattern != nil {
+		raw := *c.Pattern
+		e.Block("if (!/%s/.test(%s))", escapeForRegexLiteral(raw), varName)
+		e.Line(`throw __mint_validation_error(%q, "pattern %s", %s);`, path, jsStringEscape(raw), varName)
+		e.EndBlock()
+	}
+	if c.MinLength != nil {
+		n := *c.MinLength
+		e.Block("if (%s.length < %d)", varName, n)
+		e.Line(`throw __mint_validation_error(%q, "minLength %d", "length " + %s.length);`, path, n, varName)
+		e.EndBlock()
+	}
+	if c.MaxLength != nil {
+		n := *c.MaxLength
+		e.Block("if (%s.length > %d)", varName, n)
+		e.Line(`throw __mint_validation_error(%q, "maxLength %d", "length " + %s.length);`, path, n, varName)
+		e.EndBlock()
+	}
+}
+
+func emitBufferedMultipartScalarNumericConstraints(e *Emitter, expr, path, atomic string, c *metadata.Constraints) {
+	if c == nil || atomic != "number" {
+		return
+	}
+	if c.Minimum != nil {
+		v := formatMintNumber(*c.Minimum)
+		e.Block("if (%s !== undefined && %s < %s)", expr, expr, v)
+		e.Line(`throw __mint_validation_error(%q, "minimum %s", String(%s));`, path, v, expr)
+		e.EndBlock()
+	}
+	if c.Maximum != nil {
+		v := formatMintNumber(*c.Maximum)
+		e.Block("if (%s !== undefined && %s > %s)", expr, expr, v)
+		e.Line(`throw __mint_validation_error(%q, "maximum %s", String(%s));`, path, v, expr)
+		e.EndBlock()
+	}
+}
+
+// emitFileConstraints emits MaxSize/MinSize/MimeTypes checks on a `File`-shaped
+// value. `expr` evaluates to a File at the call site; `path` is the JSON-path
+// reported on a validation failure.
+func emitFileConstraints(e *Emitter, expr, path string, c *metadata.Constraints) {
+	if c == nil {
+		return
+	}
+	if c.MaxSize != nil {
+		v := *c.MaxSize
+		e.Block("if (%s.size > %d)", expr, v)
+		e.Line(`throw __mint_validation_error(%q, "maxSize %d", "size " + %s.size);`, path, v, expr)
+		e.EndBlock()
+	}
+	if c.MinSize != nil {
+		v := *c.MinSize
+		e.Block("if (%s.size < %d)", expr, v)
+		e.Line(`throw __mint_validation_error(%q, "minSize %d", "size " + %s.size);`, path, v, expr)
+		e.EndBlock()
+	}
+	if len(c.MimeTypes) > 0 {
+		allowed := mimeTypesLiteral(c.MimeTypes)
+		e.Block("if (!matchMimeType(%s.type, %s))", expr, allowed)
+		e.Line(`throw __mint_validation_error(%q, "mimeTypes " + %s, %s.type);`, path, allowed, expr)
+		e.EndBlock()
+	}
+}
+
+func mimeTypesLiteral(types []string) string {
+	parts := make([]string, len(types))
+	for i, t := range types {
+		parts[i] = fmt.Sprintf("%q", t)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// emitStreamingMultipartBody emits code that reads the request body as a
+// streaming multipart payload via parseMultipartStream from @mintkit/core.
+// For each declared field, scalar values are buffered fully; FileStream fields
+// receive the part's underlying stream wrapped with a per-part size cap.
+//
+// Constraint: clients must send scalar form fields BEFORE FileStream parts.
+// When we hit a FileStream we expose it to the handler immediately; downstream
+// scalars are discarded (the handler has already been called). This is the
+// pragmatic single-pass approach — it streams the file without buffering it,
+// at the cost of strict ordering. Multiple FileStream fields are not supported
+// in v1.
+func emitStreamingMultipartBody(e *Emitter, local string, body *MintMultipartBody) {
+	e.Line(`const __ct = event.request.headers.get("content-type") ?? "";`)
+	e.Line(`const __boundary = __mint_multipart_boundary(__ct);`)
+	e.Line(`const %s = {};`, local)
+	e.Line(`const __seen = {};`)
+	e.Line(`const __iter = parseMultipartStream({ stream: event.body.stream(), boundary: __boundary });`)
+	e.Line(`let __streamReady = false;`)
+	e.Block(`try`)
+	e.Block(`for await (const __part of __iter)`)
+	e.Line(`__seen[__part.name] = true;`)
+	emitStreamingMultipartDispatch(e, local, body.Fields)
+	// If we've handed a stream to the caller already, stop iterating.
+	e.Block(`if (__streamReady)`)
+	e.Line(`break;`)
+	e.EndBlock()
+	e.EndBlock()
+	e.EndBlockSuffix(" catch (err) {")
+	e.indent++
+	e.Block(`if (err && err.name === "MultipartByteLimitError")`)
+	e.Line(`throw __mint_validation_error(err.path ?? "body", "maxSize " + err.limit, "size > " + err.limit);`)
+	e.EndBlock()
+	e.Line(`throw err;`)
+	e.indent--
+	e.Line(`}`)
+	// Post-loop required-field checks.
+	for _, f := range body.Fields {
+		if !f.Required {
+			continue
+		}
+		expected := "FileStream"
+		if f.Kind == MintFieldScalar {
+			expected = fieldExpectedType(f)
+		} else if f.Kind == MintFieldFile {
+			expected = "File"
+		} else if f.Kind == MintFieldFileArray {
+			expected = "File[]"
+		}
+		e.Block(`if (!__seen[%q])`, f.Name)
+		e.Line(`throw __mint_validation_error(%q, %q, "missing");`, "body."+f.Name, expected)
+		e.EndBlock()
+	}
+}
+
+// emitStreamingMultipartDispatch emits the per-part branch logic inside the
+// `for await (const __part of __iter)` loop.
+func emitStreamingMultipartDispatch(e *Emitter, local string, fields []MintMultipartField) {
+	for i, f := range fields {
+		// First branch opens with `if (...)`. Subsequent branches arrive
+		// already inside an `} else if (...) {` block (set up by the previous
+		// iteration's EndBlockSuffix below), so we only restore the indent.
+		if i == 0 {
+			e.Block(`if (__part.name === %q)`, f.Name)
+		}
+		path := "body." + f.Name
+		switch f.Kind {
+		case MintFieldScalar:
+			e.Line(`const __chunks = [];`)
+			e.Block(`for await (const __c of __part.stream)`)
+			e.Line(`__chunks.push(__c);`)
+			e.EndBlock()
+			e.Line(`let __total = 0;`)
+			e.Block(`for (const __c of __chunks)`)
+			e.Line(`__total += __c.length;`)
+			e.EndBlock()
+			e.Line(`const __bytes = new Uint8Array(__total);`)
+			e.Line(`let __off = 0;`)
+			e.Block(`for (const __c of __chunks)`)
+			e.Line(`__bytes.set(__c, __off);`)
+			e.Line(`__off += __c.length;`)
+			e.EndBlock()
+			e.Line(`const __raw = new TextDecoder().decode(__bytes);`)
+			switch f.Atomic {
+			case "number":
+				e.Line(`const __n = +__raw;`)
+				e.Block(`if (Number.isNaN(__n))`)
+				e.Line(`throw __mint_validation_error(%q, "number", __raw);`, path)
+				e.EndBlock()
+				e.Line(`%s[%q] = __n;`, local, f.Name)
+			case "boolean":
+				e.Block(`if (__raw === "true" || __raw === "1")`)
+				e.Line(`%s[%q] = true;`, local, f.Name)
+				e.EndBlockSuffix(` else if (__raw === "false" || __raw === "0") {`)
+				e.indent++
+				e.Line(`%s[%q] = false;`, local, f.Name)
+				e.indent--
+				e.EndBlockSuffix(` else {`)
+				e.indent++
+				e.Line(`throw __mint_validation_error(%q, "boolean", __raw);`, path)
+				e.indent--
+				e.Line(`}`)
+			default:
+				emitBufferedMultipartScalarStringConstraints(e, "__raw", path, f.Constraints)
+				e.Line(`%s[%q] = __raw;`, local, f.Name)
+			}
+		case MintFieldFileStream:
+			if f.Constraints != nil && len(f.Constraints.MimeTypes) > 0 {
+				allowed := mimeTypesLiteral(f.Constraints.MimeTypes)
+				e.Block(`if (!matchMimeType(__part.type ?? "", %s))`, allowed)
+				e.Line(`throw __mint_validation_error(%q, "mimeTypes " + %s, __part.type ?? "");`, path, allowed)
+				e.EndBlock()
+			}
+			// Hook in the maxSize limit on the parser before exposing the stream.
+			if f.Constraints != nil && f.Constraints.MaxSize != nil {
+				e.Line(`__iter.setLimit(%d, %q);`, *f.Constraints.MaxSize, path)
+			}
+			e.Line(`%s[%q] = { name: __part.filename ?? "", type: __part.type ?? "", stream: __part.stream };`, local, f.Name)
+			e.Line(`__streamReady = true;`)
+		case MintFieldFile, MintFieldFileArray:
+			// File / File[] inside a streaming body fall back to buffering.
+			e.Line(`const __chunks = [];`)
+			e.Block(`for await (const __c of __part.stream)`)
+			e.Line(`__chunks.push(__c);`)
+			e.EndBlock()
+			e.Line(`const __blob = new File(__chunks, __part.filename ?? "", { type: __part.type ?? "" });`)
+			emitFileConstraints(e, "__blob", path, f.Constraints)
+			if f.Kind == MintFieldFileArray {
+				e.Block(`if (!Array.isArray(%s[%q]))`, local, f.Name)
+				e.Line(`%s[%q] = [];`, local, f.Name)
+				e.EndBlock()
+				e.Line(`%s[%q].push(__blob);`, local, f.Name)
+			} else {
+				e.Line(`%s[%q] = __blob;`, local, f.Name)
+			}
+		}
+		// Chain to the next field, or close with a default "drain" branch.
+		if i+1 < len(fields) {
+			next := fields[i+1]
+			e.EndBlockSuffix(fmt.Sprintf(" else if (__part.name === %q) {", next.Name))
+			e.indent++ // Re-enter the new else-if body for the next iteration.
+		} else {
+			e.EndBlockSuffix(" else {")
+			e.indent++
+			e.Block(`for await (const __c of __part.stream)`)
+			e.Line(`void __c;`)
+			e.EndBlock()
+			e.indent--
+			e.Line(`}`)
+		}
+	}
+}
+
+func emitRoute(e *Emitter, controllerName string, r MintRouteInfo, serializer string) {
+	e.Block("app.router.add(%q, %q, async (event) =>", r.Method, r.Path)
+	e.Line("const ctrl = event.resolve(%s);", controllerName)
+
+	if routeNeedsURL(r) {
+		e.Line("const url = new URL(event.request.url);")
+		e.Line("const searchParams = url.searchParams;")
+	}
+
+	args := make([]string, 0, len(r.Params))
+	streamingBody := false
+	for _, p := range r.Params {
+		emitParamExtraction(e, p)
+		args = append(args, p.LocalName)
+		if p.Kind == MintParamBody && p.Multipart != nil && p.Multipart.Streaming {
+			streamingBody = true
+		}
+	}
+
+	if streamingBody {
+		// FileStream reads can throw MultipartByteLimitError mid-stream from
+		// inside the handler. Catch it here and translate to a validation
+		// error so the route returns 400 problem+json instead of 500.
+		e.Block("try")
+		e.Line("const result = await ctrl.%s(%s);", r.MethodName, strings.Join(args, ", "))
+		e.Line("if (result instanceof Response) return result;")
+		emitReturnSerialization(e, r, serializer)
+		e.EndBlockSuffix(" catch (err) {")
+		e.indent++
+		e.Block(`if (err && err.name === "MultipartByteLimitError")`)
+		e.Line(`throw __mint_validation_error(err.path ?? "body", "maxSize " + err.limit, "size > " + err.limit);`)
+		e.EndBlock()
+		e.Line(`throw err;`)
+		e.indent--
+		e.Line(`}`)
+	} else {
+		e.Line("const result = await ctrl.%s(%s);", r.MethodName, strings.Join(args, ", "))
+		e.Line("if (result instanceof Response) return result;")
+		emitReturnSerialization(e, r, serializer)
+	}
+	e.EndBlockSuffix(");")
+}
+
+func routeNeedsURL(r MintRouteInfo) bool {
+	for _, p := range r.Params {
+		if p.Kind == MintParamQuery {
+			return true
+		}
+	}
+	return false
+}
+
+func emitParamExtraction(e *Emitter, p MintParamInfo) {
+	local := p.LocalName
+	if local == "" {
+		local = "_p"
+	}
+	switch p.Kind {
+	case MintParamBody:
+		if p.Multipart != nil {
+			if p.Multipart.Streaming {
+				emitStreamingMultipartBody(e, local, p.Multipart)
+			} else {
+				emitBufferedMultipartBody(e, local, p.Multipart)
+			}
+		} else if p.TypeName != "" {
+			e.Line("const %s = assert%s(await event.body.json());", local, p.TypeName)
+		} else {
+			e.Line("const %s = await event.body.json();", local)
+		}
+
+	case MintParamQuery:
+		if p.Name == "" {
+			if p.TypeName != "" {
+				e.Line("const %s = assert%s(__mint_query_object(searchParams));", local, p.TypeName)
+			} else {
+				e.Line("const %s = __mint_query_object(searchParams);", local)
+			}
+		} else {
+			e.Line("let %s = searchParams.get(%q);", local, p.Name)
+			emitScalarCoercion(e, local, p.Name, p.Atomic, "query")
+			emitScalarConstraints(e, local, p.Name, p.Atomic, p.Constraints)
+		}
+
+	case MintParamPathParam:
+		if p.Name == "" {
+			e.Line("const %s = event.params;", local)
+		} else {
+			e.Line("let %s = event.params[%q];", local, p.Name)
+			emitScalarCoercion(e, local, p.Name, p.Atomic, "param")
+			emitScalarConstraints(e, local, p.Name, p.Atomic, p.Constraints)
+		}
+
+	case MintParamHeader:
+		if p.Name == "" {
+			if p.TypeName != "" {
+				e.Line("const %s = assert%s(__mint_headers_object(event.request.headers));", local, p.TypeName)
+			} else {
+				e.Line("const %s = __mint_headers_object(event.request.headers);", local)
+			}
+		} else {
+			e.Line("let %s = event.request.headers.get(%q);", local, p.Name)
+			emitScalarCoercion(e, local, p.Name, p.Atomic, "header")
+			emitScalarConstraints(e, local, p.Name, p.Atomic, p.Constraints)
+		}
+	}
+}
+
+// emitScalarCoercion converts a string-typed value to number/boolean inline.
+// It throws a TsgonestValidationError-shaped object so the app error mapper
+// catches it via the soft name-check.
+func emitScalarCoercion(e *Emitter, paramName, sourceName, atomic, kind string) {
+	pathStr := paramPath(sourceName, kind)
+	switch atomic {
+	case "number":
+		e.Block("if (%s === null || %s === \"\")", paramName, paramName)
+		e.Line("throw __mint_validation_error(%q, \"number\", typeof %s);", pathStr, paramName)
+		e.EndBlock()
+		e.Line("%s = +%s;", paramName, paramName)
+		e.Block("if (Number.isNaN(%s))", paramName)
+		e.Line("throw __mint_validation_error(%q, \"number\", \"NaN\");", pathStr)
+		e.EndBlock()
+	case "boolean":
+		e.Block("if (%s === \"true\" || %s === \"1\")", paramName, paramName)
+		e.Line("%s = true;", paramName)
+		e.EndBlockSuffix(fmt.Sprintf(" else if (%s === \"false\" || %s === \"0\") {", paramName, paramName))
+		e.indent++
+		e.Line("%s = false;", paramName)
+		e.indent--
+		e.EndBlockSuffix(" else {")
+		e.indent++
+		e.Line("throw __mint_validation_error(%q, \"boolean\", typeof %s);", pathStr, paramName)
+		e.indent--
+		e.Line("}")
+	case "string", "":
+		// For required string params, reject null (missing). When kind=="param"
+		// the framework guarantees a value (the router only matches if the
+		// segment is present), so null indicates an internal contradiction.
+		e.Block("if (%s === null)", paramName)
+		e.Line("throw __mint_validation_error(%q, \"string\", \"undefined\");", pathStr)
+		e.EndBlock()
+	}
+}
+
+func paramPath(name, kind string) string {
+	switch kind {
+	case "query":
+		return "query." + name
+	case "param":
+		return "params." + name
+	case "header":
+		return "headers." + name
+	}
+	return name
+}
+
+func emitScalarConstraints(e *Emitter, paramName, sourceName, atomic string, c *metadata.Constraints) {
+	if c == nil {
+		return
+	}
+	pathStr := paramPath(sourceName, "query")
+	if atomic == "string" {
+		if c.Pattern != nil {
+			raw := *c.Pattern
+			e.Block("if (!/%s/.test(%s))", escapeForRegexLiteral(raw), paramName)
+			e.Line("throw __mint_validation_error(%q, \"pattern %s\", %s);", pathStr, jsStringEscape(raw), paramName)
+			e.EndBlock()
+		}
+		if c.MinLength != nil {
+			n := *c.MinLength
+			e.Block("if (%s.length < %d)", paramName, n)
+			e.Line("throw __mint_validation_error(%q, \"minLength %d\", \"length \" + %s.length);", pathStr, n, paramName)
+			e.EndBlock()
+		}
+		if c.MaxLength != nil {
+			n := *c.MaxLength
+			e.Block("if (%s.length > %d)", paramName, n)
+			e.Line("throw __mint_validation_error(%q, \"maxLength %d\", \"length \" + %s.length);", pathStr, n, paramName)
+			e.EndBlock()
+		}
+	}
+	if atomic == "number" {
+		if c.Minimum != nil {
+			v := formatMintNumber(*c.Minimum)
+			e.Block("if (%s < %s)", paramName, v)
+			e.Line("throw __mint_validation_error(%q, \"minimum %s\", String(%s));", pathStr, v, paramName)
+			e.EndBlock()
+		}
+		if c.Maximum != nil {
+			v := formatMintNumber(*c.Maximum)
+			e.Block("if (%s > %s)", paramName, v)
+			e.Line("throw __mint_validation_error(%q, \"maximum %s\", String(%s));", pathStr, v, paramName)
+			e.EndBlock()
+		}
+		if c.MultipleOf != nil {
+			v := *c.MultipleOf
+			if v == float64(int64(v)) {
+				vs := formatMintNumber(v)
+				e.Block("if (%s %% %s !== 0)", paramName, vs)
+				e.Line("throw __mint_validation_error(%q, \"multipleOf %s\", String(%s));", pathStr, vs, paramName)
+				e.EndBlock()
+			}
+		}
+	}
+}
+
+func formatMintNumber(f float64) string {
+	if f == float64(int64(f)) {
+		return fmt.Sprintf("%d", int64(f))
+	}
+	return fmt.Sprintf("%g", f)
+}
+
+// emitReturnSerialization builds the final `new Response(...)` from the
+// handler's result, honoring event.response.status / event.response.headers.
+func emitReturnSerialization(e *Emitter, r MintRouteInfo, serializer string) {
+	if r.ReturnVoid {
+		// Always 204 for void returns, regardless of result content.
+		e.Line(`const headers = new Headers(event.response.headers);`)
+		e.Line(`return new Response(null, { status: event.response.status === 200 ? 204 : event.response.status, headers });`)
+		return
+	}
+
+	e.Line(`const headers = new Headers(event.response.headers);`)
+	e.Line(`if (!headers.has("content-type")) headers.set("content-type", "application/json");`)
+
+	switch {
+	case r.ReturnTypeName != "" && serializer != "none":
+		if r.ReturnIsArray {
+			fn := "serialize" + r.ReturnTypeName
+			e.Line(`let __body;`)
+			e.Block(`if (Array.isArray(result))`)
+			e.Line(`let __parts = "";`)
+			e.Block(`for (let __i = 0; __i < result.length; __i++)`)
+			e.Line(`if (__i > 0) __parts += ",";`)
+			e.Line(`__parts += %s(result[__i]);`, fn)
+			e.EndBlock()
+			e.Line(`__body = "[" + __parts + "]";`)
+			e.EndBlockSuffix(" else {")
+			e.indent++
+			e.Line(`__body = JSON.stringify(result);`)
+			e.indent--
+			e.Line(`}`)
+			e.Line(`return new Response(__body, { status: event.response.status, headers });`)
+		} else {
+			fn := "stringify" + r.ReturnTypeName
+			e.Line(`return new Response(%s(result), { status: event.response.status, headers });`, fn)
+		}
+	default:
+		// Primitive return, unknown return type, or serializer="none" — JSON.stringify everything.
+		e.Line(`return new Response(JSON.stringify(result), { status: event.response.status, headers });`)
+	}
 }
 
 // GenerateMintRegisterTypes returns the corresponding .tsgonest.d.ts content.

--- a/internal/codegen/mint_register.go
+++ b/internal/codegen/mint_register.go
@@ -1,0 +1,57 @@
+package codegen
+
+import "strings"
+
+// MintRouteInfo describes a single route to register with a Mint app router.
+type MintRouteInfo struct {
+	Method     string
+	Path       string
+	MethodName string
+}
+
+// MintRegisterInput describes the data needed to emit a registerXxxController() helper.
+type MintRegisterInput struct {
+	ControllerName       string
+	ControllerImportPath string
+	Routes               []MintRouteInfo
+}
+
+// GenerateMintRegister returns ESM JS source for a companion file that exports
+// `register{ControllerName}(app)`. The companion imports the controller class
+// and registers each route with app.router.add(...).
+func GenerateMintRegister(input MintRegisterInput) string {
+	e := NewEmitter()
+	e.Line("import { %s } from %q;", input.ControllerName, input.ControllerImportPath)
+	e.Blank()
+	e.Block("export function %s(app)", mintRegisterFnName(input.ControllerName))
+	for _, r := range input.Routes {
+		e.Block("app.router.add(%q, %q, async (event) =>", r.Method, r.Path)
+		e.Line("const ctrl = event.resolve(%s);", input.ControllerName)
+		e.Line("const result = await ctrl.%s(event);", r.MethodName)
+		e.Line("if (result instanceof Response) return result;")
+		e.Line("return new Response(result == null ? \"\" : String(result));")
+		e.EndBlockSuffix(");")
+	}
+	e.EndBlock()
+	return e.String()
+}
+
+// GenerateMintRegisterTypes returns the corresponding .tsgonest.d.ts content.
+func GenerateMintRegisterTypes(controllerName string) string {
+	return "export declare function " + mintRegisterFnName(controllerName) + "(app: any): void;\n"
+}
+
+// MintRegisterPath returns the companion file path for a Mint register helper.
+// e.g. "src/hello.controller.ts" + "HelloController" → "src/hello.controller.HelloController.tsgonest.js"
+//
+// The companion sits next to the controller's emitted JS, mirroring the
+// existing companion path convention.
+func MintRegisterPath(sourceFileName string, controllerName string) string {
+	return companionPath(sourceFileName, controllerName)
+}
+
+// mintRegisterFnName returns the exported function name. It does not strip the
+// "Controller" suffix — `HelloController` → `registerHelloController`.
+func mintRegisterFnName(controllerName string) string {
+	return "register" + strings.TrimSpace(controllerName)
+}

--- a/internal/codegen/mint_register_test.go
+++ b/internal/codegen/mint_register_test.go
@@ -1,0 +1,73 @@
+package codegen
+
+import "testing"
+
+func TestGenerateMintRegister_SingleGetRoute(t *testing.T) {
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "HelloController",
+		ControllerImportPath: "./hello.controller",
+		Routes: []MintRouteInfo{
+			{Method: "GET", Path: "/hello", MethodName: "hello"},
+		},
+	})
+
+	wants := []string{
+		`import { HelloController } from "./hello.controller";`,
+		`export function registerHelloController(app) {`,
+		`app.router.add("GET", "/hello", async (event) => {`,
+		`const ctrl = event.resolve(HelloController);`,
+		`const result = await ctrl.hello(event);`,
+		`if (result instanceof Response) return result;`,
+		`return new Response(result == null ? "" : String(result));`,
+	}
+	for _, w := range wants {
+		assertContains(t, out, w)
+	}
+}
+
+func TestGenerateMintRegister_MultipleRoutes(t *testing.T) {
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "UsersController",
+		ControllerImportPath: "./users.controller",
+		Routes: []MintRouteInfo{
+			{Method: "GET", Path: "/users", MethodName: "list"},
+			{Method: "POST", Path: "/users", MethodName: "create"},
+			{Method: "DELETE", Path: "/users/:id", MethodName: "remove"},
+		},
+	})
+
+	assertContains(t, out, `export function registerUsersController(app) {`)
+	assertContains(t, out, `app.router.add("GET", "/users", async (event) => {`)
+	assertContains(t, out, `const result = await ctrl.list(event);`)
+	assertContains(t, out, `app.router.add("POST", "/users", async (event) => {`)
+	assertContains(t, out, `const result = await ctrl.create(event);`)
+	assertContains(t, out, `app.router.add("DELETE", "/users/:id", async (event) => {`)
+	assertContains(t, out, `const result = await ctrl.remove(event);`)
+}
+
+func TestGenerateMintRegister_ResponsePassthrough(t *testing.T) {
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "PingController",
+		ControllerImportPath: "./ping.controller",
+		Routes: []MintRouteInfo{
+			{Method: "GET", Path: "/ping", MethodName: "ping"},
+		},
+	})
+
+	assertContains(t, out, "if (result instanceof Response) return result;")
+}
+
+func TestGenerateMintRegister_KeepsControllerSuffix(t *testing.T) {
+	// Phase 1: do NOT strip "Controller" suffix.
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "HelloController",
+		ControllerImportPath: "./hello.controller",
+		Routes:               []MintRouteInfo{{Method: "GET", Path: "/", MethodName: "hello"}},
+	})
+	assertContains(t, out, "registerHelloController")
+}
+
+func TestGenerateMintRegisterTypes(t *testing.T) {
+	out := GenerateMintRegisterTypes("HelloController")
+	assertContains(t, out, "export declare function registerHelloController(app: any): void;")
+}

--- a/internal/codegen/mint_register_test.go
+++ b/internal/codegen/mint_register_test.go
@@ -1,13 +1,18 @@
 package codegen
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsgonest/tsgonest/internal/metadata"
+)
 
 func TestGenerateMintRegister_SingleGetRoute(t *testing.T) {
 	out := GenerateMintRegister(MintRegisterInput{
 		ControllerName:       "HelloController",
 		ControllerImportPath: "./hello.controller",
 		Routes: []MintRouteInfo{
-			{Method: "GET", Path: "/hello", MethodName: "hello"},
+			{Method: "GET", Path: "/hello", MethodName: "hello", ReturnAtomic: "string"},
 		},
 	})
 
@@ -16,9 +21,8 @@ func TestGenerateMintRegister_SingleGetRoute(t *testing.T) {
 		`export function registerHelloController(app) {`,
 		`app.router.add("GET", "/hello", async (event) => {`,
 		`const ctrl = event.resolve(HelloController);`,
-		`const result = await ctrl.hello(event);`,
+		`const result = await ctrl.hello();`,
 		`if (result instanceof Response) return result;`,
-		`return new Response(result == null ? "" : String(result));`,
 	}
 	for _, w := range wants {
 		assertContains(t, out, w)
@@ -38,11 +42,8 @@ func TestGenerateMintRegister_MultipleRoutes(t *testing.T) {
 
 	assertContains(t, out, `export function registerUsersController(app) {`)
 	assertContains(t, out, `app.router.add("GET", "/users", async (event) => {`)
-	assertContains(t, out, `const result = await ctrl.list(event);`)
 	assertContains(t, out, `app.router.add("POST", "/users", async (event) => {`)
-	assertContains(t, out, `const result = await ctrl.create(event);`)
 	assertContains(t, out, `app.router.add("DELETE", "/users/:id", async (event) => {`)
-	assertContains(t, out, `const result = await ctrl.remove(event);`)
 }
 
 func TestGenerateMintRegister_ResponsePassthrough(t *testing.T) {
@@ -70,4 +71,432 @@ func TestGenerateMintRegister_KeepsControllerSuffix(t *testing.T) {
 func TestGenerateMintRegisterTypes(t *testing.T) {
 	out := GenerateMintRegisterTypes("HelloController")
 	assertContains(t, out, "export declare function registerHelloController(app: any): void;")
+}
+
+func TestGenerateMintRegister_BodyParam_ImportsAndAsserts(t *testing.T) {
+	// @Body() body: CreateUserDto → parse JSON, assertCreateUserDto, pass to handler.
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "UsersController",
+		ControllerImportPath: "./users.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:     "POST",
+				Path:       "/users",
+				MethodName: "create",
+				Params: []MintParamInfo{
+					{
+						Kind:            MintParamBody,
+						LocalName:       "body",
+						TypeName:        "CreateUserDto",
+						CompanionImport: "./users.dto.CreateUserDto.tsgonest.js",
+					},
+				},
+				ReturnTypeName:        "UserResponse",
+				ReturnCompanionImport: "./users.dto.UserResponse.tsgonest.js",
+			},
+		},
+	})
+
+	assertContains(t, out, `import { assertCreateUserDto } from "./users.dto.CreateUserDto.tsgonest.js";`)
+	assertContains(t, out, `import { stringifyUserResponse } from "./users.dto.UserResponse.tsgonest.js";`)
+	assertContains(t, out, `const body = assertCreateUserDto(await event.body.json());`)
+	assertContains(t, out, `await ctrl.create(body)`)
+	assertContains(t, out, `stringifyUserResponse(`)
+	assertContains(t, out, `"content-type"`)
+}
+
+func TestGenerateMintRegister_QueryDtoParam(t *testing.T) {
+	// @Query() q: ListQuery → parse searchParams, assertListQuery.
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "UsersController",
+		ControllerImportPath: "./users.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:     "GET",
+				Path:       "/users",
+				MethodName: "list",
+				Params: []MintParamInfo{
+					{
+						Kind:            MintParamQuery,
+						LocalName:       "q",
+						TypeName:        "ListQuery",
+						CompanionImport: "./users.dto.ListQuery.tsgonest.js",
+					},
+				},
+			},
+		},
+	})
+
+	assertContains(t, out, `import { assertListQuery } from "./users.dto.ListQuery.tsgonest.js";`)
+	// Expect a parse of searchParams into a plain object before assert.
+	assertContains(t, out, `new URL(event.request.url)`)
+	assertContains(t, out, `assertListQuery(`)
+	assertContains(t, out, `await ctrl.list(q)`)
+}
+
+func TestGenerateMintRegister_NamedQueryScalarString_WithConstraints(t *testing.T) {
+	// @Query('name') name: string & tags.MinLength<1> → searchParams.get + minLength check.
+	min := 1
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "ItemsController",
+		ControllerImportPath: "./items.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:     "GET",
+				Path:       "/items",
+				MethodName: "search",
+				Params: []MintParamInfo{
+					{
+						Kind:      MintParamQuery,
+						Name:      "name",
+						LocalName: "name",
+						Atomic:    "string",
+						Constraints: &metadata.Constraints{
+							MinLength: &min,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	assertContains(t, out, `searchParams.get("name")`)
+	// minLength constraint emitted.
+	assertContains(t, out, `name.length < 1`)
+	assertContains(t, out, `await ctrl.search(name)`)
+}
+
+func TestGenerateMintRegister_NamedParamScalarString(t *testing.T) {
+	// @Param('id') id: string → extract from event.params, no coercion.
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "UsersController",
+		ControllerImportPath: "./users.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:     "GET",
+				Path:       "/users/:id",
+				MethodName: "one",
+				Params: []MintParamInfo{
+					{
+						Kind:      MintParamPathParam,
+						Name:      "id",
+						LocalName: "id",
+						Atomic:    "string",
+					},
+				},
+			},
+		},
+	})
+
+	assertContains(t, out, `event.params["id"]`)
+	assertContains(t, out, `await ctrl.one(id)`)
+}
+
+func TestGenerateMintRegister_NamedQueryScalarNumber_Coerces(t *testing.T) {
+	// @Query('limit') limit: number & tags.Maximum<100>
+	max := 100.0
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "ItemsController",
+		ControllerImportPath: "./items.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:     "GET",
+				Path:       "/items",
+				MethodName: "list",
+				Params: []MintParamInfo{
+					{
+						Kind:      MintParamQuery,
+						Name:      "limit",
+						LocalName: "limit",
+						Atomic:    "number",
+						Constraints: &metadata.Constraints{
+							Maximum: &max,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	assertContains(t, out, `searchParams.get("limit")`)
+	// Coerce string → number.
+	assertContains(t, out, `+limit`)
+	// Constraint emitted after coercion.
+	assertContains(t, out, `limit > 100`)
+	assertContains(t, out, `await ctrl.list(limit)`)
+}
+
+func TestGenerateMintRegister_NamedHeader(t *testing.T) {
+	// @Headers('x-foo') h: string → request.headers.get(name).
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "PingController",
+		ControllerImportPath: "./ping.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:     "GET",
+				Path:       "/ping",
+				MethodName: "ping",
+				Params: []MintParamInfo{
+					{
+						Kind:      MintParamHeader,
+						Name:      "x-foo",
+						LocalName: "h",
+						Atomic:    "string",
+					},
+				},
+			},
+		},
+	})
+
+	assertContains(t, out, `event.request.headers.get("x-foo")`)
+	assertContains(t, out, `await ctrl.ping(h)`)
+}
+
+func TestGenerateMintRegister_ArrayReturnUsesSerialize(t *testing.T) {
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "UsersController",
+		ControllerImportPath: "./users.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:                "GET",
+				Path:                  "/users",
+				MethodName:            "list",
+				ReturnTypeName:        "UserResponse",
+				ReturnIsArray:         true,
+				ReturnCompanionImport: "./users.dto.UserResponse.tsgonest.js",
+			},
+		},
+	})
+
+	// Array returns: validate elements with assert + use serialize+__sa per array; we emit serializeUserResponse + array wrap.
+	assertContains(t, out, `serializeUserResponse`)
+}
+
+func TestGenerateMintRegister_PrimitiveStringReturnJsonStringifies(t *testing.T) {
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "HelloController",
+		ControllerImportPath: "./hello.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:       "GET",
+				Path:         "/hello",
+				MethodName:   "hello",
+				ReturnAtomic: "string",
+			},
+		},
+	})
+
+	// No DTO: must JSON.stringify the primitive and set application/json.
+	assertContains(t, out, "JSON.stringify(result)")
+	assertContains(t, out, `"content-type"`)
+	assertContains(t, out, `application/json`)
+}
+
+func TestGenerateMintRegister_VoidReturn204(t *testing.T) {
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "UsersController",
+		ControllerImportPath: "./users.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:     "DELETE",
+				Path:       "/users/:id",
+				MethodName: "remove",
+				ReturnVoid: true,
+			},
+		},
+	})
+
+	// Void return: 204 No Content, no body.
+	if !strings.Contains(out, "204") {
+		t.Errorf("expected 204 status for void return, got:\n%s", out)
+	}
+}
+
+func TestGenerateMintRegister_BufferedFileUpload(t *testing.T) {
+	// @Body() data: { title: string; image: File & MaxSize<5000> & MimeTypes<'image/png'> }
+	// → multipart path: read event.body.formData(), validate per field.
+	min := 1
+	maxSize := uint64(5000)
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "UploadController",
+		ControllerImportPath: "./upload.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:     "POST",
+				Path:       "/avatar",
+				MethodName: "upload",
+				Params: []MintParamInfo{
+					{
+						Kind:      MintParamBody,
+						LocalName: "data",
+						Multipart: &MintMultipartBody{
+							Streaming: false,
+							Fields: []MintMultipartField{
+								{
+									Name:     "title",
+									Kind:     MintFieldScalar,
+									Atomic:   "string",
+									Required: true,
+									Constraints: &metadata.Constraints{
+										MinLength: &min,
+									},
+								},
+								{
+									Name:     "image",
+									Kind:     MintFieldFile,
+									Required: true,
+									Constraints: &metadata.Constraints{
+										MaxSize:   &maxSize,
+										MimeTypes: []string{"image/png"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	wants := []string{
+		// Multipart path.
+		`event.body.formData()`,
+		// Scalar field extraction.
+		`__form.get("title")`,
+		// MinLength constraint.
+		`__raw.length < 1`,
+		// File extraction.
+		`__form.get("image")`,
+		// MaxSize check.
+		`.size > 5000`,
+		// Mime helper import and call.
+		`matchMimeType`,
+		// JSON parse path NOT used.
+	}
+	for _, w := range wants {
+		assertContains(t, out, w)
+	}
+	if strings.Contains(out, "event.body.json()") {
+		t.Errorf("expected NO JSON body parse when multipart; got:\n%s", out)
+	}
+}
+
+func TestGenerateMintRegister_BufferedFileArray(t *testing.T) {
+	// photos: Array<File & MaxSize<10000> & MimeTypes<'image/*'>>
+	maxSize := uint64(10000)
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "GalleryController",
+		ControllerImportPath: "./gallery.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:     "POST",
+				Path:       "/gallery",
+				MethodName: "upload",
+				Params: []MintParamInfo{
+					{
+						Kind:      MintParamBody,
+						LocalName: "data",
+						Multipart: &MintMultipartBody{
+							Fields: []MintMultipartField{
+								{
+									Name:     "photos",
+									Kind:     MintFieldFileArray,
+									Required: true,
+									Constraints: &metadata.Constraints{
+										MaxSize:   &maxSize,
+										MimeTypes: []string{"image/*"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// getAll for arrays + per-element validation.
+	assertContains(t, out, `__form.getAll("photos")`)
+	assertContains(t, out, `for (let __i = 0; __i < __files.length`)
+	assertContains(t, out, `.size > 10000`)
+	assertContains(t, out, `matchMimeType`)
+	assertContains(t, out, `"image/*"`)
+}
+
+func TestGenerateMintRegister_StreamingFileUpload(t *testing.T) {
+	maxSize := uint64(5_000_000_000)
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "LargeUploadController",
+		ControllerImportPath: "./large.controller",
+		Routes: []MintRouteInfo{
+			{
+				Method:     "POST",
+				Path:       "/uploads/large",
+				MethodName: "upload",
+				Params: []MintParamInfo{
+					{
+						Kind:      MintParamBody,
+						LocalName: "data",
+						Multipart: &MintMultipartBody{
+							Streaming: true,
+							Fields: []MintMultipartField{
+								{
+									Name:     "filename",
+									Kind:     MintFieldScalar,
+									Atomic:   "string",
+									Required: true,
+								},
+								{
+									Name:     "file",
+									Kind:     MintFieldFileStream,
+									Required: true,
+									Constraints: &metadata.Constraints{
+										MaxSize: &maxSize,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	wants := []string{
+		`parseMultipartStream`,
+		`event.body.stream()`,
+		`__mint_multipart_boundary`,
+		// FileStream binding.
+		`stream: __part.stream`,
+		// setLimit invocation on the parser.
+		`__iter.setLimit(5000000000`,
+		`MultipartByteLimitError`,
+	}
+	for _, w := range wants {
+		assertContains(t, out, w)
+	}
+}
+
+func TestGenerateMintRegister_NoneResponseSerializer_UsesPlainJsonStringify(t *testing.T) {
+	out := GenerateMintRegister(MintRegisterInput{
+		ControllerName:       "UsersController",
+		ControllerImportPath: "./users.controller",
+		ResponseSerializer:   "none",
+		Routes: []MintRouteInfo{
+			{
+				Method:                "GET",
+				Path:                  "/users",
+				MethodName:            "list",
+				ReturnTypeName:        "UserResponse",
+				ReturnCompanionImport: "./users.dto.UserResponse.tsgonest.js",
+			},
+		},
+	})
+
+	// When responseSerializer="none", emit JSON.stringify(result) — no companion import for return.
+	assertContains(t, out, "JSON.stringify(result)")
+	// Do not import the companion's stringify when serializer is "none".
+	if strings.Contains(out, "stringifyUserResponse") {
+		t.Errorf("expected no stringifyUserResponse when serializer=none, got:\n%s", out)
+	}
 }

--- a/internal/constraints/branded.go
+++ b/internal/constraints/branded.go
@@ -97,6 +97,26 @@ func SetBranded(c *metadata.Constraints, key string, typeMeta *metadata.Metadata
 			return true
 		}
 
+	// File upload constraints
+	case FieldMaxSize:
+		if f, ok := LiteralFloat(typeMeta); ok && f >= 0 {
+			n := uint64(f)
+			c.MaxSize = &n
+			return true
+		}
+	case FieldMinSize:
+		if f, ok := LiteralFloat(typeMeta); ok && f >= 0 {
+			n := uint64(f)
+			c.MinSize = &n
+			return true
+		}
+	case FieldMimeTypes:
+		mimes := collectStringLiterals(typeMeta)
+		if len(mimes) > 0 {
+			c.MimeTypes = mimes
+			return true
+		}
+
 	// String case validation
 	case FieldUppercase:
 		if b, ok := LiteralBool(typeMeta); ok && b {

--- a/internal/constraints/constants.go
+++ b/internal/constraints/constants.go
@@ -30,6 +30,11 @@ const (
 	FieldMaxItems    FieldName = "maxItems"
 	FieldUniqueItems FieldName = "uniqueItems"
 
+	// File upload constraints
+	FieldMaxSize   FieldName = "maxSize"
+	FieldMinSize   FieldName = "minSize"
+	FieldMimeTypes FieldName = "mimeTypes"
+
 	// String case validation
 	FieldUppercase FieldName = "uppercase"
 	FieldLowercase FieldName = "lowercase"

--- a/internal/constraints/literals.go
+++ b/internal/constraints/literals.go
@@ -51,3 +51,35 @@ func LiteralBool(m *metadata.Metadata) (bool, bool) {
 	}
 	return false, false
 }
+
+// collectStringLiterals flattens a metadata that may be a single string literal
+// or a union of string literals into a deduplicated slice. Returns nil when no
+// string literals are present. Used by file-upload constraints like MimeTypes<U>
+// where U may be 'image/png' or 'image/png' | 'image/jpeg'.
+func collectStringLiterals(m *metadata.Metadata) []string {
+	if m == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(s string) {
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	switch m.Kind {
+	case metadata.KindLiteral:
+		if s, ok := LiteralString(m); ok {
+			add(s)
+		}
+	case metadata.KindUnion:
+		for i := range m.UnionMembers {
+			if s, ok := LiteralString(&m.UnionMembers[i]); ok {
+				add(s)
+			}
+		}
+	}
+	return out
+}

--- a/internal/constraints/merge.go
+++ b/internal/constraints/merge.go
@@ -66,6 +66,15 @@ func Merge(dst, src *metadata.Constraints) {
 	if src.UniqueItems != nil {
 		dst.UniqueItems = src.UniqueItems
 	}
+	if src.MaxSize != nil {
+		dst.MaxSize = src.MaxSize
+	}
+	if src.MinSize != nil {
+		dst.MinSize = src.MinSize
+	}
+	if len(src.MimeTypes) > 0 {
+		dst.MimeTypes = src.MimeTypes
+	}
 	if src.Default != nil {
 		dst.Default = src.Default
 	}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -161,6 +161,11 @@ type Constraints struct {
 	MaxItems    *int  `json:"maxItems,omitempty"`
 	UniqueItems *bool `json:"uniqueItems,omitempty"`
 
+	// File upload constraints (Phase 9/10 — applied to File or FileStream values)
+	MaxSize   *uint64  `json:"maxSize,omitempty"`
+	MinSize   *uint64  `json:"minSize,omitempty"`
+	MimeTypes []string `json:"mimeTypes,omitempty"`
+
 	// Schema-only (no runtime validation)
 	Default *string `json:"default,omitempty"`
 

--- a/internal/openapi/schema.go
+++ b/internal/openapi/schema.go
@@ -442,7 +442,7 @@ func (g *SchemaGenerator) convertNative(m *metadata.Metadata) *Schema {
 		return &Schema{Type: "array", Items: &Schema{Type: "number"}}
 	case "ArrayBuffer", "SharedArrayBuffer":
 		return &Schema{Type: "string", Format: "binary"}
-	case "File", "Blob", "StreamableFile":
+	case "File", "Blob", "StreamableFile", "FileStream":
 		return &Schema{Type: "string", Format: "binary"}
 	case "Error":
 		return &Schema{

--- a/internal/rewrite/controllers.go
+++ b/internal/rewrite/controllers.go
@@ -53,6 +53,23 @@ func rewriteController(text string, outputFile string, controllers []analyzer.Co
 			report(d)
 		}
 	}
+
+	// Mint controllers register routes through generated registerXxxController
+	// helpers; validation/serialization runs inside that wrapper, not at method
+	// boundaries. The NestJS-shaped injections below (UseInterceptors imports,
+	// JSON.stringify return wraps, @Body asserts) would corrupt the emit.
+	if filtered := controllers[:0:0]; true {
+		for _, c := range controllers {
+			if c.Framework != "mint" {
+				filtered = append(filtered, c)
+			}
+		}
+		controllers = filtered
+		if len(controllers) == 0 {
+			return text
+		}
+	}
+
 	// ── Phase 1: Collect transform specifications (unchanged metadata logic) ──
 
 	type bodyValidation struct {

--- a/internal/watcher/configpoller.go
+++ b/internal/watcher/configpoller.go
@@ -43,6 +43,14 @@ func WatchFiles(paths []string, pollInterval time.Duration, onChange func(path s
 				return
 			case <-ticker.C:
 				for _, path := range paths {
+					// Re-check stop between paths so a stop() that lands
+					// after the tick is honored before the next onChange.
+					select {
+					case <-stopCh:
+						return
+					default:
+					}
+
 					info, err := stat(path)
 
 					oldTime := snapshot[path]

--- a/packages/mint-bun/package.json
+++ b/packages/mint-bun/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@mintkit/bun",
+  "version": "0.0.1",
+  "description": "Mint adapter for Bun — vendored, shadcn-style. Provides wrap(), BUN_SERVER, and gracefulShutdown.",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest --run"
+  },
+  "keywords": [
+    "mint",
+    "mintkit",
+    "bun",
+    "adapter",
+    "tsgonest"
+  ],
+  "dependencies": {
+    "@mintkit/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@mintkit/core": "workspace:*",
+    "bun-types": "*"
+  },
+  "peerDependenciesMeta": {
+    "bun-types": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.0",
+    "@types/node": "^25.5.0",
+    "bun-types": "^1.3.11",
+    "tsdown": "^0.21.7",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tsgonest/tsgonest"
+  }
+}

--- a/packages/mint-bun/src/graceful-shutdown.ts
+++ b/packages/mint-bun/src/graceful-shutdown.ts
@@ -1,0 +1,55 @@
+import type { App } from '@mintkit/core'
+
+export interface GracefulShutdownOptions {
+  /** Signals to listen on. Default: `['SIGTERM', 'SIGINT']`. */
+  signals?: NodeJS.Signals[]
+  /** How long to wait for `app[Symbol.asyncDispose]()` before hard-exiting. Default: 30000ms. */
+  timeout?: number
+}
+
+/**
+ * Wires SIGTERM/SIGINT (configurable) to `app[Symbol.asyncDispose]()`. If
+ * dispose runs past the timeout, the process hard-exits with code 1 so
+ * orchestrators don't hang on a stuck drain.
+ *
+ * Returns an `unsubscribe` function that detaches the signal listeners. Tests
+ * and long-lived embedders should always call it on teardown — otherwise the
+ * listener leaks across the next reload.
+ */
+export function gracefulShutdown(
+  app: App,
+  opts: GracefulShutdownOptions = {},
+): () => void {
+  const signals: NodeJS.Signals[] = opts.signals ?? ['SIGTERM', 'SIGINT']
+  const timeoutMs = opts.timeout ?? 30_000
+
+  let running = false
+  const handler = (): void => {
+    if (running) return
+    running = true
+
+    const timer = setTimeout(() => {
+      // Drain exceeded the budget — orchestrators (k8s, systemd, …) need a
+      // hard cap so they can move on. Exit 1 to signal abnormal shutdown.
+      process.exit(1)
+    }, timeoutMs)
+    // unref so the timer doesn't keep the loop alive on its own if dispose
+    // somehow resolves with nothing else pending.
+    if (typeof timer.unref === 'function') timer.unref()
+
+    Promise.resolve()
+      .then(() => app[Symbol.asyncDispose]())
+      .catch(() => {
+        // Swallow — we still want to exit cleanly even if dispose threw.
+      })
+      .finally(() => {
+        clearTimeout(timer)
+      })
+  }
+
+  for (const sig of signals) process.on(sig, handler)
+
+  return () => {
+    for (const sig of signals) process.off(sig, handler)
+  }
+}

--- a/packages/mint-bun/src/index.ts
+++ b/packages/mint-bun/src/index.ts
@@ -1,0 +1,5 @@
+export { wrap } from './wrap'
+export type { BunHandler } from './wrap'
+export { BUN_SERVER } from './token'
+export { gracefulShutdown } from './graceful-shutdown'
+export type { GracefulShutdownOptions } from './graceful-shutdown'

--- a/packages/mint-bun/src/token.ts
+++ b/packages/mint-bun/src/token.ts
@@ -1,0 +1,10 @@
+import { defineToken } from '@mintkit/core'
+import type { BunServer } from './types'
+
+/**
+ * Typed reference to Bun's `Server` instance. `wrap(app).fetch(req, server)`
+ * sets this on every event so handlers and middleware can read it via
+ * `event.require(BUN_SERVER)` — useful for socket inspection or (future) WS
+ * upgrades.
+ */
+export const BUN_SERVER = defineToken<BunServer>('BUN_SERVER')

--- a/packages/mint-bun/src/types.ts
+++ b/packages/mint-bun/src/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Adapter-internal type alias for Bun's `Server`. We use the global `Bun`
+ * namespace (registered by `bun-types`/`@types/bun`) rather than
+ * `import('bun').Server` because rolldown's d.ts bundler does not resolve
+ * `declare module "bun"` exports and emits `undefined` for the unresolved
+ * type — which would erase consumer type safety.
+ *
+ * When `bun-types` is not installed, `Bun` falls back to `any`; the token still
+ * works at runtime, just without static checking on the consumer side.
+ */
+type AnyBunServer = Bun.Server<unknown> | Bun.Server<any>
+
+export type BunServer = AnyBunServer

--- a/packages/mint-bun/src/wrap.ts
+++ b/packages/mint-bun/src/wrap.ts
@@ -1,0 +1,46 @@
+import type { App, Upgrade } from '@mintkit/core'
+import { BUN_SERVER } from './token'
+import type { BunServer } from './types'
+
+export interface BunHandler {
+  fetch(request: Request, server: BunServer): Promise<Response>
+}
+
+/**
+ * Wraps a Mint app so Bun's `Server` reference is exposed to every handler via
+ * the `BUN_SERVER` token. Use the returned `{ fetch }` directly with
+ * `Bun.serve` when you need platform features:
+ *
+ * ```ts
+ * Bun.serve({ fetch: wrap(app).fetch, port: 3000 })
+ * ```
+ *
+ * Zero-config users who never need the `Server` reference can keep passing
+ * `app.fetch` to `Bun.serve` — this wrapper is opt-in.
+ */
+export function wrap(app: App): BunHandler {
+  return {
+    async fetch(request: Request, server: BunServer): Promise<Response> {
+      // Mirror app.fetch's dispatch loop, but build the event with a setup
+      // callback that seeds BUN_SERVER. We can't reuse app.fetch directly
+      // because it has no per-call hook for the token store.
+      const url = new URL(request.url)
+      const match = app.router.match(request.method, url.pathname)
+      if (!match) {
+        return new Response('Not Found', {
+          status: 404,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+      const event = app.createEvent(request, (ev) => {
+        ev.set(BUN_SERVER, server)
+      })
+      const result: Response | Upgrade = await match.handler(event)
+      if (!(result instanceof Response)) {
+        // `Upgrade` is reserved for a future WS path and not produced in v1.
+        return new Response('Not Implemented', { status: 501 })
+      }
+      return result
+    },
+  }
+}

--- a/packages/mint-bun/test/graceful-shutdown.test.ts
+++ b/packages/mint-bun/test/graceful-shutdown.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { createApp, defineModule } from '@mintkit/core'
+import { gracefulShutdown } from '../src/graceful-shutdown'
+
+class Noop {}
+
+// Track any unsubscribe functions so even a failed test doesn't leave signal
+// listeners attached.
+const cleanups: Array<() => void> = []
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!()
+})
+
+describe('gracefulShutdown', () => {
+  it('calls app[Symbol.asyncDispose] when the configured signal fires', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [Noop] })],
+    })
+    let disposed = 0
+    const original = app[Symbol.asyncDispose].bind(app)
+    app[Symbol.asyncDispose] = async () => {
+      disposed++
+      await original()
+    }
+
+    const unsub = gracefulShutdown(app, {
+      signals: ['SIGUSR2'],
+      timeout: 1000,
+    })
+    cleanups.push(unsub)
+
+    process.emit('SIGUSR2' as any)
+    // Allow the listener's async dispose to flush.
+    await new Promise<void>((r) => setImmediate(r))
+    expect(disposed).toBe(1)
+  })
+
+  it('unsubscribe removes the registered listener', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [Noop] })],
+    })
+    let disposed = 0
+    app[Symbol.asyncDispose] = async () => {
+      disposed++
+    }
+
+    const before = process.listenerCount('SIGUSR2')
+    const unsub = gracefulShutdown(app, {
+      signals: ['SIGUSR2'],
+      timeout: 1000,
+    })
+    expect(process.listenerCount('SIGUSR2')).toBe(before + 1)
+    unsub()
+    expect(process.listenerCount('SIGUSR2')).toBe(before)
+
+    process.emit('SIGUSR2' as any)
+    await new Promise<void>((r) => setImmediate(r))
+    expect(disposed).toBe(0)
+  })
+
+  it('defaults to SIGTERM and SIGINT when no signals given', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [Noop] })],
+    })
+    const beforeTerm = process.listenerCount('SIGTERM')
+    const beforeInt = process.listenerCount('SIGINT')
+    const unsub = gracefulShutdown(app)
+    cleanups.push(unsub)
+    expect(process.listenerCount('SIGTERM')).toBe(beforeTerm + 1)
+    expect(process.listenerCount('SIGINT')).toBe(beforeInt + 1)
+  })
+
+  it('hard-exits if dispose exceeds the timeout', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [Noop] })],
+    })
+    // A dispose that never resolves: timeout should kick in.
+    app[Symbol.asyncDispose] = () => new Promise<void>(() => {})
+
+    const exits: number[] = []
+    const realExit = process.exit
+    // process.exit is typed `(code: never) => never`; we stub via Object.defineProperty
+    // so TS-strict callers don't complain.
+    Object.defineProperty(process, 'exit', {
+      value: (code?: number) => {
+        exits.push(code ?? 0)
+      },
+      configurable: true,
+    })
+
+    try {
+      const unsub = gracefulShutdown(app, {
+        signals: ['SIGUSR2'],
+        timeout: 25,
+      })
+      cleanups.push(unsub)
+      process.emit('SIGUSR2' as any)
+      await new Promise<void>((r) => setTimeout(r, 75))
+      expect(exits).toEqual([1])
+    } finally {
+      Object.defineProperty(process, 'exit', {
+        value: realExit,
+        configurable: true,
+      })
+    }
+  })
+})

--- a/packages/mint-bun/test/wrap.test.ts
+++ b/packages/mint-bun/test/wrap.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { createApp, defineModule } from '@mintkit/core'
+import { wrap } from '../src/wrap'
+import { BUN_SERVER } from '../src/token'
+
+class HelloController {}
+
+describe('wrap(app)', () => {
+  it('exposes a fetch(req, server) handler', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    const handler = wrap(app)
+    expect(typeof handler.fetch).toBe('function')
+    expect(handler.fetch.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('makes BUN_SERVER resolvable inside a handler', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+
+    let captured: unknown
+    app.router.add('GET', '/server', async (event) => {
+      captured = event.require(BUN_SERVER)
+      return new Response('ok')
+    })
+
+    const handler = wrap(app)
+    const fakeServer = { id: 'fake' } as any
+    const res = await handler.fetch(new Request('http://x/server'), fakeServer)
+    expect(res.status).toBe(200)
+    expect(captured).toBe(fakeServer)
+  })
+
+  it('still returns 404 for unmatched routes', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    const handler = wrap(app)
+    const res = await handler.fetch(
+      new Request('http://x/missing'),
+      {} as any,
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('passes a different server instance per call', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+
+    const seen: unknown[] = []
+    app.router.add('GET', '/r', async (event) => {
+      seen.push(event.require(BUN_SERVER))
+      return new Response('')
+    })
+
+    const handler = wrap(app)
+    const s1 = { id: 1 } as any
+    const s2 = { id: 2 } as any
+    await handler.fetch(new Request('http://x/r'), s1)
+    await handler.fetch(new Request('http://x/r'), s2)
+    expect(seen).toEqual([s1, s2])
+  })
+})

--- a/packages/mint-bun/tsconfig.json
+++ b/packages/mint-bun/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["bun"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mint-bun/tsdown.config.ts
+++ b/packages/mint-bun/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  platform: 'node',
+  target: 'node18',
+})

--- a/packages/mint/package.json
+++ b/packages/mint/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@mintkit/core",
+  "version": "0.0.1",
+  "description": "Mint — a tiny Bun-targeted web framework with compile-time decorators",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest --run"
+  },
+  "keywords": [
+    "mint",
+    "mintkit",
+    "bun",
+    "web",
+    "framework",
+    "tsgonest"
+  ],
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsdown": "^0.21.7",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tsgonest/tsgonest"
+  }
+}

--- a/packages/mint/src/app.ts
+++ b/packages/mint/src/app.ts
@@ -1,0 +1,76 @@
+import { Container, type Constructor } from './container'
+import { Event } from './event'
+import { Router } from './router'
+import type { Module } from './module'
+import type { Token } from './token'
+
+export interface AppOptions {
+  imports: Module[]
+}
+
+export interface Context {
+  container: Container
+  router: Router
+}
+
+export interface App extends AsyncDisposable {
+  router: Router
+  fetch(request: Request): Promise<Response>
+  resolve<T>(provider: Token<T> | Constructor<T>): T
+}
+
+export async function createApp(options: AppOptions): Promise<App> {
+  const container = new Container()
+  const router = new Router()
+
+  const modules = flattenModules(options.imports)
+  for (const mod of modules) {
+    for (const Ctrl of mod.controllers ?? []) {
+      if (!container.has(Ctrl)) {
+        container.register(Ctrl, () => new Ctrl())
+      }
+    }
+  }
+
+  const app: App = {
+    router,
+    async fetch(request: Request): Promise<Response> {
+      const url = new URL(request.url)
+      const match = router.match(request.method, url.pathname)
+      if (!match) {
+        return new Response('Not Found', {
+          status: 404,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+      const event = new Event(request, container)
+      const result = await match.handler(event)
+      if (!(result instanceof Response)) {
+        // Upgrade is reserved and never produced in Phase 1.
+        return new Response('Not Implemented', { status: 501 })
+      }
+      return result
+    },
+    resolve(provider) {
+      return container.resolve(provider)
+    },
+    async [Symbol.asyncDispose]() {
+      // Phase 1: no lifecycle hooks.
+    },
+  }
+
+  return app
+}
+
+function flattenModules(roots: Module[]): Module[] {
+  const seen = new Set<Module>()
+  const out: Module[] = []
+  const visit = (m: Module): void => {
+    if (seen.has(m)) return
+    seen.add(m)
+    for (const child of m.imports ?? []) visit(child)
+    out.push(m)
+  }
+  for (const m of roots) visit(m)
+  return out
+}

--- a/packages/mint/src/app.ts
+++ b/packages/mint/src/app.ts
@@ -1,40 +1,131 @@
-import { Container, type Constructor } from './container'
+import type { Constructor } from './container'
 import { Event } from './event'
-import { Router } from './router'
+import { Router, type RouteMatch, type RawRoute } from './router'
 import type { Module } from './module'
 import type { Token } from './token'
+import type { Middleware, RouteHandler } from './types'
+import { composeChain } from './middleware-chain'
+import { ErrorMapper, type ErrorMapHandler, type ErrorPredicate } from './error-mapper'
+import { bootGraph, disposeProviders, type Context } from './context'
+
+export type { Context, ContextOptions } from './context'
+export { createContext } from './context'
 
 export interface AppOptions {
   imports: Module[]
 }
 
-export interface Context {
-  container: Container
-  router: Router
-}
-
-export interface App extends AsyncDisposable {
+export interface App extends Context {
   router: Router
   fetch(request: Request): Promise<Response>
-  resolve<T>(provider: Token<T> | Constructor<T>): T
+  /** Register global or prefix-mounted middleware. */
+  use(middleware: Middleware): void
+  use(prefix: string, middleware: Middleware): void
+  /**
+   * Register a custom error mapping. User-registered handlers run before the
+   * built-in defaults; first match wins.
+   */
+  onError(predicate: ErrorPredicate, handler: ErrorMapHandler): void
+  /**
+   * Adapter hook: construct the per-request {@link Event} that `fetch` would
+   * otherwise build internally. Adapters that need to seed token-store values
+   * (e.g. `BUN_SERVER`) before the handler runs pass a `setup` callback.
+   */
+  createEvent(request: Request, setup?: (event: Event) => void): Event
+}
+
+interface GlobalMiddleware {
+  prefix?: string
+  middleware: Middleware
 }
 
 export async function createApp(options: AppOptions): Promise<App> {
-  const container = new Container()
+  const boot = await bootGraph(options.imports)
   const router = new Router()
+  const errorMapper = new ErrorMapper()
+  const globalMiddleware: GlobalMiddleware[] = []
 
-  const modules = flattenModules(options.imports)
-  for (const mod of modules) {
+  // Map every controller → the module it was declared in. Module-level
+  // middleware only applies to its own module's controllers, not imports.
+  const moduleByController = new Map<Constructor, Module>()
+  for (const mod of boot.modules) {
     for (const Ctrl of mod.controllers ?? []) {
-      if (!container.has(Ctrl)) {
-        container.register(Ctrl, () => new Ctrl())
+      moduleByController.set(Ctrl, mod)
+    }
+  }
+
+  router.setFinalizer((raw: readonly RawRoute[]) => {
+    const out = new Map<string, RouteMatch>()
+    for (const r of raw) {
+      const chain = buildChainFor(r)
+      out.set(`${r.method} ${r.path}`, {
+        handler: chain,
+        params: {},
+        controller: r.controller,
+      })
+    }
+    return out
+  })
+
+  let closed = false
+  let disposed = false
+  const inflight = new Set<Promise<unknown>>()
+
+  function buildChainFor(route: RawRoute): RouteHandler {
+    const moduleMw: Middleware[] = []
+    if (route.controller) {
+      const owningModule = moduleByController.get(route.controller)
+      if (owningModule?.middleware) moduleMw.push(...owningModule.middleware)
+    }
+
+    // The full pipeline: global (with prefix-filter wrappers) → module → handler.
+    // Prefix middleware are conditionalised inline so a non-matching path falls
+    // through without invoking the user's middleware.
+    const ordered: Middleware[] = []
+    for (const g of globalMiddleware) {
+      if (g.prefix === undefined) {
+        ordered.push(g.middleware)
+      } else {
+        const prefix = g.prefix
+        const mw = g.middleware
+        ordered.push(async (event, next) => {
+          const url = new URL(event.request.url)
+          if (matchesPrefix(url.pathname, prefix)) {
+            return mw(event, next)
+          }
+          return next()
+        })
       }
     }
+    for (const m of moduleMw) ordered.push(m)
+    return composeChain(ordered, route.handler)
   }
 
   const app: App = {
     router,
+    createEvent(request: Request, setup?: (event: Event) => void): Event {
+      const event = new Event(request, boot.container)
+      if (setup) setup(event)
+      return event
+    },
+    use(prefixOrMw: string | Middleware, maybeMw?: Middleware): void {
+      if (typeof prefixOrMw === 'string') {
+        if (!maybeMw) throw new Error('app.use(prefix, middleware) requires a middleware')
+        globalMiddleware.push({ prefix: prefixOrMw, middleware: maybeMw })
+      } else {
+        globalMiddleware.push({ middleware: prefixOrMw })
+      }
+    },
+    onError(predicate: ErrorPredicate, handler: ErrorMapHandler): void {
+      errorMapper.register(predicate, handler)
+    },
     async fetch(request: Request): Promise<Response> {
+      if (closed) {
+        return new Response('Service Unavailable', {
+          status: 503,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
       const url = new URL(request.url)
       const match = router.match(request.method, url.pathname)
       if (!match) {
@@ -43,34 +134,44 @@ export async function createApp(options: AppOptions): Promise<App> {
           headers: { 'content-type': 'text/plain' },
         })
       }
-      const event = new Event(request, container)
-      const result = await match.handler(event)
-      if (!(result instanceof Response)) {
-        // Upgrade is reserved and never produced in Phase 1.
-        return new Response('Not Implemented', { status: 501 })
+      const event = app.createEvent(request)
+      event.params = match.params
+      const work = (async (): Promise<Response> => {
+        try {
+          const result = await match.handler(event)
+          if (!(result instanceof Response)) {
+            return new Response('Not Implemented', { status: 501 })
+          }
+          return result
+        } catch (err) {
+          return errorMapper.map(err, event)
+        }
+      })()
+      inflight.add(work)
+      try {
+        return await work
+      } finally {
+        inflight.delete(work)
       }
-      return result
     },
-    resolve(provider) {
-      return container.resolve(provider)
+    resolve(provider: Token<unknown> | Constructor<unknown>) {
+      return boot.container.resolve(provider) as never
     },
     async [Symbol.asyncDispose]() {
-      // Phase 1: no lifecycle hooks.
+      if (disposed) return
+      disposed = true
+      closed = true
+      if (inflight.size > 0) await Promise.allSettled([...inflight])
+      await disposeProviders(boot)
     },
   }
 
   return app
 }
 
-function flattenModules(roots: Module[]): Module[] {
-  const seen = new Set<Module>()
-  const out: Module[] = []
-  const visit = (m: Module): void => {
-    if (seen.has(m)) return
-    seen.add(m)
-    for (const child of m.imports ?? []) visit(child)
-    out.push(m)
-  }
-  for (const m of roots) visit(m)
-  return out
+function matchesPrefix(pathname: string, prefix: string): boolean {
+  if (!prefix.startsWith('/')) prefix = '/' + prefix
+  if (pathname === prefix) return true
+  // Treat `/api` as matching `/api/...` but not `/apiary`.
+  return pathname.startsWith(prefix.endsWith('/') ? prefix : prefix + '/')
 }

--- a/packages/mint/src/container.ts
+++ b/packages/mint/src/container.ts
@@ -1,0 +1,39 @@
+import { Token } from './token'
+
+export type Constructor<T = unknown> = new (...args: any[]) => T
+export type Provider<T> = Token<T> | Constructor<T>
+export type Factory<T> = (container: Container) => T
+
+/**
+ * Singleton-per-token DI container. Tokens can be either {@link Token}
+ * instances or class constructors — lookup is by reference identity.
+ */
+export class Container {
+  private readonly factories = new Map<unknown, Factory<unknown>>()
+  private readonly instances = new Map<unknown, unknown>()
+
+  register<T>(provider: Provider<T>, factory: Factory<T>): void {
+    this.factories.set(provider, factory as Factory<unknown>)
+  }
+
+  resolve<T>(provider: Provider<T>): T {
+    if (this.instances.has(provider)) {
+      return this.instances.get(provider) as T
+    }
+    const factory = this.factories.get(provider)
+    if (!factory) {
+      const name =
+        provider instanceof Token
+          ? `Token(${provider.name})`
+          : (provider as Constructor).name || 'anonymous'
+      throw new Error(`No provider registered for ${name}`)
+    }
+    const instance = factory(this) as T
+    this.instances.set(provider, instance)
+    return instance
+  }
+
+  has(provider: Provider<unknown>): boolean {
+    return this.factories.has(provider)
+  }
+}

--- a/packages/mint/src/container.ts
+++ b/packages/mint/src/container.ts
@@ -1,39 +1,204 @@
 import { Token } from './token'
+import {
+  type Provider,
+  type Scope,
+  isClassProvider,
+  isValueProvider,
+  isFactoryProvider,
+  providerToken,
+} from './module'
+import { topoSort } from './topological'
 
 export type Constructor<T = unknown> = new (...args: any[]) => T
-export type Provider<T> = Token<T> | Constructor<T>
 export type Factory<T> = (container: Container) => T
 
+type TokenKey = Token<any> | Constructor<any>
+
+interface Registration {
+  token: TokenKey
+  provider: Provider
+  declaringModule?: object
+  scope: Scope
+  deps: TokenKey[]
+}
+
 /**
- * Singleton-per-token DI container. Tokens can be either {@link Token}
- * instances or class constructors — lookup is by reference identity.
+ * DI container. Phase 1 exposed `register(token, factory)` for direct singleton
+ * binding; Phases 3+ add `registerProvider(provider, declaringModule?)` plus a
+ * `boot()` phase that resolves dependencies in topological order and supports
+ * `useValue` / `useFactory` (sync or async) providers.
+ *
+ * Class-constructor deps are read from `static inject = [TokenA, TokenB] as const`.
+ * Reflect-metadata is intentionally not consulted — runtime stays zero-dep.
  */
 export class Container {
-  private readonly factories = new Map<unknown, Factory<unknown>>()
-  private readonly instances = new Map<unknown, unknown>()
+  private readonly registrations = new Map<TokenKey, Registration>()
+  private readonly instances = new Map<TokenKey, unknown>()
+  private readonly legacyFactories = new Map<TokenKey, Factory<unknown>>()
+  private booted = false
+  private constructionOrder: unknown[] = []
 
-  register<T>(provider: Provider<T>, factory: Factory<T>): void {
-    this.factories.set(provider, factory as Factory<unknown>)
+  register<T>(provider: Token<T> | Constructor<T>, factory: Factory<T>): void {
+    this.legacyFactories.set(provider, factory as Factory<unknown>)
   }
 
-  resolve<T>(provider: Provider<T>): T {
-    if (this.instances.has(provider)) {
-      return this.instances.get(provider) as T
+  /**
+   * High-level provider registration. Throws on duplicate registration for the
+   * same token. `declaringModule` is opaque metadata used by the boot pipeline
+   * for visibility validation; the container itself does not interpret it.
+   */
+  registerProvider(provider: Provider, declaringModule?: object): void {
+    const token = providerToken(provider)
+    if (this.registrations.has(token) || this.legacyFactories.has(token)) {
+      throw new Error(`duplicate provider registration for ${describeToken(token)}`)
     }
-    const factory = this.factories.get(provider)
-    if (!factory) {
-      const name =
-        provider instanceof Token
-          ? `Token(${provider.name})`
-          : (provider as Constructor).name || 'anonymous'
-      throw new Error(`No provider registered for ${name}`)
-    }
-    const instance = factory(this) as T
-    this.instances.set(provider, instance)
-    return instance
+    const scope: Scope = isFactoryProvider(provider)
+      ? (provider.scope ?? 'singleton')
+      : 'singleton'
+    this.registrations.set(token, {
+      token,
+      provider,
+      declaringModule,
+      scope,
+      deps: providerDeps(provider),
+    })
   }
 
-  has(provider: Provider<unknown>): boolean {
-    return this.factories.has(provider)
+  /**
+   * Resolves dependencies in topological order, constructing singletons and
+   * awaiting async factories. Idempotent — second call is a no-op.
+   */
+  async boot(): Promise<void> {
+    if (this.booted) return
+
+    for (const reg of this.registrations.values()) {
+      for (const dep of reg.deps) {
+        if (!this.registrations.has(dep) && !this.legacyFactories.has(dep)) {
+          throw new Error(
+            `missing provider for ${describeToken(dep)} (required by ${describeToken(reg.token)})`,
+          )
+        }
+      }
+    }
+
+    const order = topoSort(
+      [...this.registrations.values()],
+      (reg) =>
+        reg.deps
+          .map((d) => this.registrations.get(d))
+          .filter((d): d is Registration => d !== undefined),
+      {
+        id: (reg) => reg.token,
+        label: (reg) => describeToken(reg.token),
+      },
+    )
+
+    for (const reg of order) {
+      if (reg.scope === 'transient' && isFactoryProvider(reg.provider)) continue
+      const value = await this.construct(reg)
+      this.instances.set(reg.token, value)
+      this.constructionOrder.push(value)
+    }
+
+    this.booted = true
   }
+
+  /** Reverse construction order — what dispose walks in. */
+  disposalOrder(): unknown[] {
+    return [...this.constructionOrder].reverse()
+  }
+
+  /** The list of constructed instances, in topological order. */
+  initOrder(): unknown[] {
+    return [...this.constructionOrder]
+  }
+
+  /**
+   * Resolve a token. Post-boot:
+   *   singleton → cache hit.
+   *   transient factory → re-runs the factory each call (sync only post-boot).
+   * Legacy `register(token, factory)` bindings are cached on first hit.
+   */
+  resolve<T>(provider: Token<T> | Constructor<T>): T {
+    if (this.instances.has(provider)) return this.instances.get(provider) as T
+
+    const reg = this.registrations.get(provider)
+    if (reg && reg.scope === 'transient' && isFactoryProvider(reg.provider)) {
+      const args = reg.deps.map((d) => this.resolve(d))
+      const v = reg.provider.useFactory(...args)
+      if (v instanceof Promise) {
+        throw new Error(
+          `transient factory for ${describeToken(provider)} returned a Promise; transient resolution is synchronous`,
+        )
+      }
+      return v as T
+    }
+
+    const legacy = this.legacyFactories.get(provider)
+    if (legacy) {
+      const v = legacy(this) as T
+      this.instances.set(provider, v)
+      return v
+    }
+
+    throw new Error(`No provider registered for ${describeToken(provider)}`)
+  }
+
+  has(provider: Token<any> | Constructor<any>): boolean {
+    return (
+      this.registrations.has(provider) ||
+      this.legacyFactories.has(provider) ||
+      this.instances.has(provider)
+    )
+  }
+
+  registeredTokens(): TokenKey[] {
+    return [...this.registrations.keys()]
+  }
+
+  getRegistration(token: TokenKey): Registration | undefined {
+    return this.registrations.get(token)
+  }
+
+  private async construct(reg: Registration): Promise<unknown> {
+    const { provider } = reg
+    if (isValueProvider(provider)) return provider.useValue
+    if (isFactoryProvider(provider)) {
+      const args = reg.deps.map((d) => this.resolveBoot(d))
+      const v = await provider.useFactory(...args)
+      return v
+    }
+    if (isClassProvider(provider)) {
+      const args = reg.deps.map((d) => this.resolveBoot(d))
+      return new provider(...args)
+    }
+    throw new Error(`unknown provider shape: ${describeToken(reg.token)}`)
+  }
+
+  private resolveBoot(token: TokenKey): unknown {
+    if (this.instances.has(token)) return this.instances.get(token)
+    const legacy = this.legacyFactories.get(token)
+    if (legacy) {
+      const v = legacy(this)
+      this.instances.set(token, v)
+      return v
+    }
+    throw new Error(
+      `provider ${describeToken(token)} requested before construction; topological sort invariant broken`,
+    )
+  }
+}
+
+function providerDeps(p: Provider): TokenKey[] {
+  if (isClassProvider(p)) {
+    const inject = (p as Constructor & { inject?: ReadonlyArray<TokenKey> }).inject
+    return inject ? [...inject] : []
+  }
+  if (isFactoryProvider(p)) return p.inject ? [...p.inject] : []
+  return []
+}
+
+export function describeToken(token: TokenKey): string {
+  if (token instanceof Token) return `Token(${token.name})`
+  return (token as Constructor).name || 'anonymous'
 }

--- a/packages/mint/src/context.ts
+++ b/packages/mint/src/context.ts
@@ -1,0 +1,231 @@
+import { Container, describeToken, type Constructor } from './container'
+import {
+  type Module,
+  type Provider,
+  providerToken,
+  isClassProvider,
+} from './module'
+import { Token } from './token'
+import { disposeAll, hasAsyncDispose, hasInit } from './lifecycle'
+
+export interface Context extends AsyncDisposable {
+  resolve<T>(token: Token<T> | Constructor<T>): T
+}
+
+export interface ContextOptions {
+  imports: Module[]
+}
+
+interface BootResult {
+  container: Container
+  modules: Module[]
+  initOrder: unknown[]
+}
+
+export async function createContext(options: ContextOptions): Promise<Context> {
+  const boot = await bootGraph(options.imports)
+  let disposed = false
+  return {
+    resolve(provider) {
+      return boot.container.resolve(provider)
+    },
+    async [Symbol.asyncDispose]() {
+      if (disposed) return
+      disposed = true
+      await disposeProviders(boot)
+    },
+  }
+}
+
+/**
+ * The shared boot pipeline used by both `createApp` and `createContext`.
+ * Flatten → validate (visibility + duplicates + missing tokens) → construct
+ * (topological) → init (topological). On init failure: dispose the
+ * already-init'd providers in reverse order and rethrow.
+ */
+export async function bootGraph(imports: Module[]): Promise<BootResult> {
+  const modules = flattenModules(imports)
+  const declaringModuleByToken = new Map<unknown, Module>()
+  const visibilityByModule = computeVisibility(modules)
+
+  for (const mod of modules) {
+    for (const provider of mod.providers ?? []) {
+      const token = providerToken(provider)
+      const prior = declaringModuleByToken.get(token)
+      if (prior) {
+        throw new Error(
+          `duplicate provider token ${describeToken(token)} declared in two modules`,
+        )
+      }
+      declaringModuleByToken.set(token, mod)
+    }
+  }
+
+  const container = new Container()
+
+  for (const mod of modules) {
+    for (const provider of mod.providers ?? []) {
+      container.registerProvider(provider, mod)
+    }
+    for (const Ctrl of mod.controllers ?? []) {
+      if (!container.has(Ctrl)) container.registerProvider(Ctrl, mod)
+    }
+  }
+
+  validateVisibility(modules, declaringModuleByToken, visibilityByModule)
+
+  await container.boot()
+
+  const initOrder = container.initOrder()
+  const initialized: AsyncDisposable[] = []
+  try {
+    for (const inst of initOrder) {
+      if (hasInit(inst)) await inst.init()
+      if (hasAsyncDispose(inst)) initialized.push(inst)
+    }
+  } catch (e) {
+    await disposeAll([...initialized].reverse()).catch(() => undefined)
+    throw e
+  }
+
+  return { container, modules, initOrder }
+}
+
+export async function disposeProviders(boot: BootResult): Promise<void> {
+  const disposables: AsyncDisposable[] = []
+  for (const inst of boot.container.disposalOrder()) {
+    if (hasAsyncDispose(inst)) disposables.push(inst)
+  }
+  await disposeAll(disposables)
+}
+
+export function flattenModules(roots: Module[]): Module[] {
+  const seen = new Set<Module>()
+  const out: Module[] = []
+  const visit = (m: Module): void => {
+    if (seen.has(m)) return
+    seen.add(m)
+    for (const child of m.imports ?? []) visit(child)
+    out.push(m)
+  }
+  for (const m of roots) visit(m)
+  return out
+}
+
+/**
+ * Build, for every module M, the set of tokens M can see — its own providers
+ * plus exported tokens from its direct imports (which themselves include
+ * re-exports re-exported from deeper imports). A token re-exports through a
+ * chain only if every hop names it in `exports`.
+ */
+function computeVisibility(modules: readonly Module[]): Map<Module, Set<unknown>> {
+  const exportsByModule = new Map<Module, Set<unknown>>()
+  for (const mod of modules) {
+    exportsByModule.set(mod, new Set((mod.exports ?? []) as unknown[]))
+  }
+
+  const ownTokens = new Map<Module, Set<unknown>>()
+  for (const mod of modules) {
+    const own = new Set<unknown>()
+    for (const p of mod.providers ?? []) own.add(providerToken(p))
+    for (const Ctrl of mod.controllers ?? []) own.add(Ctrl)
+    ownTokens.set(mod, own)
+  }
+
+  const visibleExportsCache = new Map<Module, Set<unknown>>()
+  const visibleExportsOf = (mod: Module): Set<unknown> => {
+    if (visibleExportsCache.has(mod)) return visibleExportsCache.get(mod)!
+    const declared = exportsByModule.get(mod) ?? new Set<unknown>()
+    const own = ownTokens.get(mod) ?? new Set<unknown>()
+    const result = new Set<unknown>()
+    for (const token of declared) {
+      if (own.has(token)) result.add(token)
+    }
+    for (const child of mod.imports ?? []) {
+      const childExports = visibleExportsOf(child)
+      for (const token of declared) {
+        if (childExports.has(token)) result.add(token)
+      }
+    }
+    visibleExportsCache.set(mod, result)
+    return result
+  }
+
+  const visible = new Map<Module, Set<unknown>>()
+  for (const mod of modules) {
+    const set = new Set<unknown>(ownTokens.get(mod))
+    for (const child of mod.imports ?? []) {
+      for (const token of visibleExportsOf(child)) set.add(token)
+    }
+    visible.set(mod, set)
+  }
+  return visible
+}
+
+function validateVisibility(
+  modules: readonly Module[],
+  declaringModuleByToken: Map<unknown, Module>,
+  visibility: Map<Module, Set<unknown>>,
+): void {
+  for (const mod of modules) {
+    const visible = visibility.get(mod) ?? new Set<unknown>()
+    for (const provider of mod.providers ?? []) {
+      checkProviderDeps(provider, visible, declaringModuleByToken)
+    }
+    for (const Ctrl of mod.controllers ?? []) {
+      const deps = (Ctrl as Constructor & {
+        inject?: ReadonlyArray<Token<any> | Constructor<any>>
+      }).inject
+      if (!deps) continue
+      for (const dep of deps) {
+        ensureVisible(dep, Ctrl, visible, declaringModuleByToken)
+      }
+    }
+  }
+}
+
+function checkProviderDeps(
+  provider: Provider,
+  visible: Set<unknown>,
+  declaringModuleByToken: Map<unknown, Module>,
+): void {
+  if (isClassProvider(provider)) {
+    const deps = (provider as Constructor & {
+      inject?: ReadonlyArray<Token<any> | Constructor<any>>
+    }).inject
+    if (!deps) return
+    for (const dep of deps) ensureVisible(dep, provider, visible, declaringModuleByToken)
+    return
+  }
+  if ('useFactory' in provider) {
+    const inject = provider.inject ?? []
+    for (const dep of inject)
+      ensureVisible(dep, provider.provide, visible, declaringModuleByToken)
+  }
+}
+
+function ensureVisible(
+  dep: Token<any> | Constructor<any>,
+  consumer: unknown,
+  visible: Set<unknown>,
+  declaringModuleByToken: Map<unknown, Module>,
+): void {
+  if (visible.has(dep)) return
+  const declaring = declaringModuleByToken.get(dep)
+  if (!declaring) {
+    throw new Error(
+      `missing provider for ${describeToken(dep)} (required by ${describeConsumer(consumer)})`,
+    )
+  }
+  throw new Error(
+    `visibility violation: ${describeConsumer(consumer)} requires ${describeToken(dep)} which is declared in another module but not exported`,
+  )
+}
+
+function describeConsumer(c: unknown): string {
+  if (c instanceof Token) return `Token(${c.name})`
+  if (typeof c === 'function') return (c as { name?: string }).name || 'anonymous'
+  if (c && typeof c === 'object' && 'provide' in c)
+    return describeToken((c as { provide: Token<any> | Constructor<any> }).provide)
+  return String(c)
+}

--- a/packages/mint/src/decorators.ts
+++ b/packages/mint/src/decorators.ts
@@ -1,0 +1,42 @@
+/**
+ * Mint's decorators are compile-time-only sugar. tsgonest analyses them
+ * statically and erases them in the emitted output, so every export here is a
+ * runtime no-op that returns the target untouched. No `reflect-metadata`
+ * needed.
+ *
+ * Each factory accepts any args (TS 5 legacy decorators may receive 1-3
+ * arguments depending on whether they decorate a class, method, property, or
+ * parameter) and just hands the target back.
+ */
+
+type AnyDecorator = (...args: any[]) => any
+
+const noop: AnyDecorator = (..._args: any[]) => {
+  // Legacy decorators are called as `Decorator(target, key?, descriptor?)`.
+  // Returning undefined leaves the original descriptor / target in place.
+  return undefined
+}
+
+/** Class decorators */
+export const Controller = (..._args: any[]): AnyDecorator => noop
+export const Injectable = (..._args: any[]): AnyDecorator => noop
+
+/** Method (route) decorators */
+export const Get = (..._args: any[]): AnyDecorator => noop
+export const Post = (..._args: any[]): AnyDecorator => noop
+export const Put = (..._args: any[]): AnyDecorator => noop
+export const Patch = (..._args: any[]): AnyDecorator => noop
+export const Delete = (..._args: any[]): AnyDecorator => noop
+export const Head = (..._args: any[]): AnyDecorator => noop
+export const Options = (..._args: any[]): AnyDecorator => noop
+
+/** Parameter decorators */
+export const Body = (..._args: any[]): AnyDecorator => noop
+export const Query = (..._args: any[]): AnyDecorator => noop
+export const Param = (..._args: any[]): AnyDecorator => noop
+export const Headers = (..._args: any[]): AnyDecorator => noop
+export const Ctx = (..._args: any[]): AnyDecorator => noop
+export const Inject = (..._args: any[]): AnyDecorator => noop
+
+/** Method-level middleware attachment */
+export const UseMiddleware = (..._args: any[]): AnyDecorator => noop

--- a/packages/mint/src/decorators.ts
+++ b/packages/mint/src/decorators.ts
@@ -1,15 +1,25 @@
 /**
  * Mint's decorators are compile-time-only sugar. tsgonest analyses them
- * statically and erases them in the emitted output, so every export here is a
- * runtime no-op that returns the target untouched. No `reflect-metadata`
+ * statically and erases them in the emitted output, so most exports here are
+ * runtime no-ops that return the target untouched. No `reflect-metadata`
  * needed.
  *
  * Each factory accepts any args (TS 5 legacy decorators may receive 1-3
  * arguments depending on whether they decorate a class, method, property, or
  * parameter) and just hands the target back.
+ *
+ * `@UseMiddleware` is the one decorator that also has a runtime effect: it
+ * records the middleware list against the target class (and optionally method)
+ * in a `WeakMap`, so a future codegen step can walk the binding at registration
+ * time. For Phase 4 the codegen does NOT yet read these maps, but recording is
+ * cheap and makes user code using `@UseMiddleware` work without crashing.
  */
 
+import type { Middleware } from './types'
+
 type AnyDecorator = (...args: any[]) => any
+
+type Constructor = new (...args: any[]) => unknown
 
 const noop: AnyDecorator = (..._args: any[]) => {
   // Legacy decorators are called as `Decorator(target, key?, descriptor?)`.
@@ -38,5 +48,49 @@ export const Headers = (..._args: any[]): AnyDecorator => noop
 export const Ctx = (..._args: any[]): AnyDecorator => noop
 export const Inject = (..._args: any[]): AnyDecorator => noop
 
-/** Method-level middleware attachment */
-export const UseMiddleware = (..._args: any[]): AnyDecorator => noop
+const classMiddleware = new WeakMap<Constructor, Middleware[]>()
+const methodMiddleware = new WeakMap<Constructor, Map<string | symbol, Middleware[]>>()
+
+/**
+ * Attaches middleware to a controller class (when applied to a class) or to a
+ * single method (when applied to a method). Records into module-level
+ * WeakMaps; a future codegen revision will read these at boot to wire the
+ * recorded middleware into the chain. For Phase 4 the recording is the only
+ * effect — controller/method @UseMiddleware is not yet enforced at runtime by
+ * core.
+ */
+export function UseMiddleware(...mws: Middleware[]): AnyDecorator {
+  return (target: unknown, propertyKey?: string | symbol): unknown => {
+    if (typeof target === 'function' && propertyKey === undefined) {
+      const Ctor = target as Constructor
+      const existing = classMiddleware.get(Ctor) ?? []
+      classMiddleware.set(Ctor, [...existing, ...mws])
+      return undefined
+    }
+    if (typeof target === 'object' && target !== null && propertyKey !== undefined) {
+      const Ctor = (target as { constructor: Constructor }).constructor
+      let methodMap = methodMiddleware.get(Ctor)
+      if (!methodMap) {
+        methodMap = new Map()
+        methodMiddleware.set(Ctor, methodMap)
+      }
+      const existing = methodMap.get(propertyKey) ?? []
+      methodMap.set(propertyKey, [...existing, ...mws])
+      return undefined
+    }
+    return undefined
+  }
+}
+
+/** Read the class-level middleware list recorded by `@UseMiddleware`. */
+export function getControllerMiddleware(Ctor: Constructor): readonly Middleware[] {
+  return classMiddleware.get(Ctor) ?? []
+}
+
+/** Read the method-level middleware list recorded by `@UseMiddleware`. */
+export function getMethodMiddleware(
+  Ctor: Constructor,
+  method: string | symbol,
+): readonly Middleware[] {
+  return methodMiddleware.get(Ctor)?.get(method) ?? []
+}

--- a/packages/mint/src/error-mapper.ts
+++ b/packages/mint/src/error-mapper.ts
@@ -1,0 +1,101 @@
+import { HttpError } from './errors'
+import type { Event } from './event'
+
+export type ErrorPredicate = (err: unknown) => boolean
+export type ErrorMapHandler = (err: unknown, event: Event) => Response | Promise<Response>
+
+export interface ErrorHandler {
+  predicate: ErrorPredicate
+  handle: ErrorMapHandler
+}
+
+/**
+ * Pluggable throw → Response mapper. User-registered handlers run BEFORE the
+ * built-in defaults; first match wins.
+ *
+ * Defaults:
+ *  - `HttpError` subclass → JSON Response with the carried status + body (or
+ *    `{ error: message }` if `body` is undefined).
+ *  - Validation errors (soft-detected by `err.name === 'TsgonestValidationError'`)
+ *    → RFC 9457 `application/problem+json` at status 400.
+ *  - Unknown throws → 500 problem-details JSON with no message leak; the full
+ *    error is logged via `console.error`.
+ *
+ * The soft name-check avoids a hard dependency on `@tsgonest/runtime` so
+ * `@mintkit/core` stays dep-free.
+ */
+export class ErrorMapper {
+  private readonly handlers: ErrorHandler[] = []
+
+  register(predicate: ErrorPredicate, handle: ErrorMapHandler): void {
+    this.handlers.push({ predicate, handle })
+  }
+
+  async map(err: unknown, event: Event): Promise<Response> {
+    for (const h of this.handlers) {
+      if (h.predicate(err)) return await h.handle(err, event)
+    }
+    return defaultMap(err, event)
+  }
+}
+
+function defaultMap(err: unknown, _event: Event): Response {
+  if (err instanceof HttpError) {
+    const body = err.body !== undefined ? err.body : { error: err.message }
+    return jsonResponse(body, err.status, 'application/json')
+  }
+  if (isValidationError(err)) {
+    const detail = err instanceof Error ? err.message : String(err)
+    const errors = readValidationErrors(err)
+    return jsonResponse(
+      {
+        type: 'about:blank',
+        title: 'Validation Failed',
+        status: 400,
+        detail,
+        errors,
+      },
+      400,
+      'application/problem+json',
+    )
+  }
+  console.error(err)
+  return jsonResponse(
+    {
+      type: 'about:blank',
+      title: 'Internal Server Error',
+      status: 500,
+    },
+    500,
+    'application/problem+json',
+  )
+}
+
+function isValidationError(err: unknown): err is {
+  name: 'TsgonestValidationError'
+  message?: string
+  errors?: unknown
+  details?: unknown
+} {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { name?: unknown }).name === 'TsgonestValidationError'
+  )
+}
+
+function readValidationErrors(err: {
+  errors?: unknown
+  details?: unknown
+}): unknown[] {
+  if (Array.isArray(err.errors)) return err.errors
+  if (Array.isArray(err.details)) return err.details
+  return []
+}
+
+function jsonResponse(body: unknown, status: number, contentType: string): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': contentType },
+  })
+}

--- a/packages/mint/src/errors.ts
+++ b/packages/mint/src/errors.ts
@@ -1,0 +1,66 @@
+/**
+ * HTTP error hierarchy. Throwing one of these from a handler or middleware is
+ * the supported way to produce non-2xx responses without writing a Response by
+ * hand. The error mapper maps each subclass to JSON with the carried `status`.
+ *
+ * `body` is the JSON payload; if `undefined`, the default mapper falls back to
+ * `{ error: message }`.
+ */
+export class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body?: unknown,
+    message?: string,
+  ) {
+    super(message ?? `HTTP ${status}`)
+    this.name = new.target.name
+  }
+}
+
+export class BadRequestError extends HttpError {
+  constructor(body?: unknown, message?: string) {
+    super(400, body, message)
+  }
+}
+
+export class UnauthorizedError extends HttpError {
+  constructor(body?: unknown, message?: string) {
+    super(401, body, message)
+  }
+}
+
+export class ForbiddenError extends HttpError {
+  constructor(body?: unknown, message?: string) {
+    super(403, body, message)
+  }
+}
+
+export class NotFoundError extends HttpError {
+  constructor(body?: unknown, message?: string) {
+    super(404, body, message)
+  }
+}
+
+export class ConflictError extends HttpError {
+  constructor(body?: unknown, message?: string) {
+    super(409, body, message)
+  }
+}
+
+export class UnprocessableEntityError extends HttpError {
+  constructor(body?: unknown, message?: string) {
+    super(422, body, message)
+  }
+}
+
+export class TooManyRequestsError extends HttpError {
+  constructor(body?: unknown, message?: string) {
+    super(429, body, message)
+  }
+}
+
+export class InternalServerError extends HttpError {
+  constructor(body?: unknown, message?: string) {
+    super(500, body, message)
+  }
+}

--- a/packages/mint/src/event.ts
+++ b/packages/mint/src/event.ts
@@ -1,0 +1,44 @@
+import type { Container, Constructor } from './container'
+import { Token } from './token'
+
+export interface EventResponseDraft {
+  headers: Headers
+  status: number
+}
+
+/**
+ * Per-request execution context. Carries the incoming `Request`, a mutable
+ * response draft for middleware to influence headers/status, and a small
+ * token-store backed by a `Map`.
+ */
+export class Event {
+  readonly request: Request
+  readonly response: EventResponseDraft
+  private readonly container: Container
+  private readonly store = new Map<Token<unknown>, unknown>()
+
+  constructor(request: Request, container: Container) {
+    this.request = request
+    this.container = container
+    this.response = { headers: new Headers(), status: 200 }
+  }
+
+  resolve<T>(provider: Token<T> | Constructor<T>): T {
+    return this.container.resolve(provider)
+  }
+
+  set<T>(token: Token<T>, value: T): void {
+    this.store.set(token as Token<unknown>, value)
+  }
+
+  get<T>(token: Token<T>): T | undefined {
+    return this.store.get(token as Token<unknown>) as T | undefined
+  }
+
+  require<T>(token: Token<T>): T {
+    if (!this.store.has(token as Token<unknown>)) {
+      throw new Error(`Event store has no entry for Token(${token.name})`)
+    }
+    return this.store.get(token as Token<unknown>) as T
+  }
+}

--- a/packages/mint/src/event.ts
+++ b/packages/mint/src/event.ts
@@ -6,14 +6,45 @@ export interface EventResponseDraft {
   status: number
 }
 
+export interface Body {
+  /** Reads the raw request body once and caches it for subsequent calls. */
+  bytes(): Promise<Uint8Array>
+  /** Decodes the cached bytes as UTF-8 text. */
+  text(): Promise<string>
+  /** Parses the cached text as JSON. */
+  json<T = unknown>(): Promise<T>
+  /** Returns a `FormData` parsed from the cached body. */
+  formData(): Promise<FormData>
+  /**
+   * Hands back the original `ReadableStream` for streaming use cases. Mutually
+   * exclusive with `bytes`/`text`/`json`/`formData` — calling either side after
+   * the other throws.
+   */
+  stream(): ReadableStream<Uint8Array>
+}
+
 /**
  * Per-request execution context. Carries the incoming `Request`, a mutable
  * response draft for middleware to influence headers/status, and a small
- * token-store backed by a `Map`.
+ * token-store backed by a `Map`. Adapters may seed token-store values via the
+ * `setup` callback on `App.createEvent`.
  */
 export class Event {
   readonly request: Request
   readonly response: EventResponseDraft
+  readonly body: Body
+  /**
+   * Path params extracted from the route template (e.g. `/users/:id` →
+   * `{ id: '42' }`). Empty object for routes without `:name` segments.
+   * Populated by `App.fetch` from the router match result.
+   */
+  params: Record<string, string>
+  /**
+   * Promises passed to `waitUntil`. The adapter (e.g. `@mintkit/bun`) is
+   * responsible for awaiting them after the response is sent; core only
+   * records them.
+   */
+  readonly waitUntilPromises = new Set<Promise<unknown>>()
   private readonly container: Container
   private readonly store = new Map<Token<unknown>, unknown>()
 
@@ -21,6 +52,8 @@ export class Event {
     this.request = request
     this.container = container
     this.response = { headers: new Headers(), status: 200 }
+    this.body = createBody(request)
+    this.params = {}
   }
 
   resolve<T>(provider: Token<T> | Constructor<T>): T {
@@ -40,5 +73,75 @@ export class Event {
       throw new Error(`Event store has no entry for Token(${token.name})`)
     }
     return this.store.get(token as Token<unknown>) as T
+  }
+
+  /**
+   * Records a promise that should outlive the response. The runtime adapter
+   * (Bun in v1) decides what "outlive" means; core just stores the reference.
+   */
+  waitUntil(promise: Promise<unknown>): void {
+    this.waitUntilPromises.add(promise)
+  }
+}
+
+function createBody(request: Request): Body {
+  let bytesPromise: Promise<Uint8Array> | undefined
+  let textPromise: Promise<string> | undefined
+  let streamTaken = false
+
+  const readBytes = (): Promise<Uint8Array> => {
+    if (streamTaken) {
+      return Promise.reject(new Error('body stream already consumed'))
+    }
+    if (!bytesPromise) {
+      bytesPromise = request
+        .arrayBuffer()
+        .then((buf) => new Uint8Array(buf))
+    }
+    return bytesPromise
+  }
+
+  return {
+    bytes: readBytes,
+    async text() {
+      if (!textPromise) {
+        textPromise = readBytes().then((b) => new TextDecoder().decode(b))
+      }
+      return textPromise
+    },
+    async json<T = unknown>(): Promise<T> {
+      const t = await this.text()
+      return JSON.parse(t) as T
+    },
+    async formData(): Promise<FormData> {
+      const bytes = await readBytes()
+      // Build a fake Response carrying the cached bytes + original content-type
+      // and use the platform's FormData parser. Works for both
+      // `application/x-www-form-urlencoded` and `multipart/form-data`.
+      const ct = request.headers.get('content-type') ?? ''
+      return await new Response(bytes, {
+        headers: { 'content-type': ct },
+      }).formData()
+    },
+    stream(): ReadableStream<Uint8Array> {
+      if (bytesPromise !== undefined) {
+        throw new Error('body stream already consumed')
+      }
+      if (streamTaken) {
+        throw new Error('body stream already consumed')
+      }
+      streamTaken = true
+      const body = request.body
+      if (!body) {
+        // Synthesize an empty stream for GETs / no-body requests so callers
+        // can always assume the return type.
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close()
+          },
+        })
+      }
+      return body as ReadableStream<Uint8Array>
+    },
   }
 }

--- a/packages/mint/src/index.ts
+++ b/packages/mint/src/index.ts
@@ -1,15 +1,58 @@
-export { createApp } from './app'
-export type { App, AppOptions, Context } from './app'
-export { defineModule } from './module'
-export type { Module, ProviderEntry } from './module'
+export { createApp, createContext } from './app'
+export type { App, AppOptions } from './app'
+export type { Context, ContextOptions } from './context'
+export { defineModule, defineAsyncModule } from './module'
+export type {
+  Module,
+  Provider,
+  ValueProvider,
+  FactoryProvider,
+  ClassWithInject,
+  Scope,
+} from './module'
 export { defineToken, Token } from './token'
 export { Container } from './container'
-export type { Constructor, Provider, Factory } from './container'
+export type { Constructor, Factory } from './container'
 export { Router } from './router'
 export type { RouteMatch } from './router'
 export { Event } from './event'
-export type { EventResponseDraft } from './event'
+// Re-export the body interface under a non-conflicting name. The `Body`
+// parameter decorator from `./decorators` takes precedence on the public
+// surface; users that need the interface can still import it via the renamed
+// alias `EventBody`.
+export type { EventResponseDraft, Body as EventBody } from './event'
 export type { RouteHandler, Middleware, Upgrade } from './types'
+export type { OnInit } from './lifecycle'
+export { sse } from './sse'
+export type { SSEMessage, SSEStream } from './sse'
+
+export {
+  HttpError,
+  BadRequestError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ConflictError,
+  UnprocessableEntityError,
+  TooManyRequestsError,
+  InternalServerError,
+} from './errors'
+
+export { ErrorMapper } from './error-mapper'
+export type { ErrorHandler, ErrorPredicate, ErrorMapHandler } from './error-mapper'
+
+export { composeChain } from './middleware-chain'
+
+export { matchMimeType } from './mime'
+export {
+  parseMultipartStream,
+  MultipartByteLimitError,
+} from './multipart'
+export type {
+  MultipartPart,
+  MultipartParserOptions,
+  MultipartIterator,
+} from './multipart'
 
 export {
   Controller,
@@ -28,4 +71,6 @@ export {
   Ctx,
   Inject,
   UseMiddleware,
+  getControllerMiddleware,
+  getMethodMiddleware,
 } from './decorators'

--- a/packages/mint/src/index.ts
+++ b/packages/mint/src/index.ts
@@ -1,0 +1,31 @@
+export { createApp } from './app'
+export type { App, AppOptions, Context } from './app'
+export { defineModule } from './module'
+export type { Module, ProviderEntry } from './module'
+export { defineToken, Token } from './token'
+export { Container } from './container'
+export type { Constructor, Provider, Factory } from './container'
+export { Router } from './router'
+export type { RouteMatch } from './router'
+export { Event } from './event'
+export type { EventResponseDraft } from './event'
+export type { RouteHandler, Middleware, Upgrade } from './types'
+
+export {
+  Controller,
+  Injectable,
+  Get,
+  Post,
+  Put,
+  Patch,
+  Delete,
+  Head,
+  Options,
+  Body,
+  Query,
+  Param,
+  Headers,
+  Ctx,
+  Inject,
+  UseMiddleware,
+} from './decorators'

--- a/packages/mint/src/lifecycle.ts
+++ b/packages/mint/src/lifecycle.ts
@@ -1,0 +1,41 @@
+/**
+ * Structural lifecycle interfaces. Providers can implement either or both;
+ * the container duck-types `init` / `Symbol.asyncDispose` at runtime.
+ */
+export interface OnInit {
+  init(): void | Promise<void>
+}
+
+export function hasInit(value: unknown): value is OnInit {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { init?: unknown }).init === 'function'
+  )
+}
+
+export function hasAsyncDispose(value: unknown): value is AsyncDisposable {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { [Symbol.asyncDispose]?: unknown })[Symbol.asyncDispose] ===
+      'function'
+  )
+}
+
+/**
+ * Runs each disposer in order; collects thrown errors. If exactly one disposer
+ * throws, rethrows that error; if more than one, throws AggregateError.
+ */
+export async function disposeAll(disposables: readonly AsyncDisposable[]): Promise<void> {
+  const errors: unknown[] = []
+  for (const d of disposables) {
+    try {
+      await d[Symbol.asyncDispose]()
+    } catch (e) {
+      errors.push(e)
+    }
+  }
+  if (errors.length === 1) throw errors[0]
+  if (errors.length > 1) throw new AggregateError(errors, 'multiple disposers failed')
+}

--- a/packages/mint/src/middleware-chain.ts
+++ b/packages/mint/src/middleware-chain.ts
@@ -1,0 +1,29 @@
+import type { Event } from './event'
+import type { Middleware, RouteHandler, Upgrade } from './types'
+
+/**
+ * Compose an onion of middleware around a route handler. The returned function
+ * runs each middleware outer-to-inner; each middleware decides whether to call
+ * `await next()` (continue) or short-circuit by returning a `Response` without
+ * advancing.
+ */
+export function composeChain(
+  middleware: readonly Middleware[],
+  handler: RouteHandler,
+): RouteHandler {
+  if (middleware.length === 0) return handler
+
+  return async (event: Event): Promise<Response | Upgrade> => {
+    let i = -1
+    const dispatch = async (idx: number): Promise<Response | Upgrade> => {
+      if (idx <= i) {
+        throw new Error('next() called multiple times in the same middleware')
+      }
+      i = idx
+      if (idx === middleware.length) return handler(event)
+      const mw = middleware[idx]
+      return mw(event, () => dispatch(idx + 1))
+    }
+    return dispatch(0)
+  }
+}

--- a/packages/mint/src/mime.ts
+++ b/packages/mint/src/mime.ts
@@ -1,0 +1,43 @@
+/**
+ * Match a concrete MIME type (e.g. `image/png`) against a list of allowed
+ * patterns. Patterns support a single `'*'` subtype wildcard (`image/*`) or
+ * a fully-qualified wildcard (`'*&#47;*'`). Exact matches are case-insensitive
+ * on the type/subtype but preserve the original value.
+ *
+ * @example
+ *   matchMimeType('image/png', ['image/png']) // true
+ *   matchMimeType('image/jpeg', ['image/*'])   // true
+ *   matchMimeType('text/plain', ['image/*'])   // false
+ */
+export function matchMimeType(actual: string, allowed: readonly string[]): boolean {
+  if (!actual) return false
+  const normalized = normalizeMime(actual)
+  for (const pattern of allowed) {
+    if (matchOne(normalized, normalizeMime(pattern))) {
+      return true
+    }
+  }
+  return false
+}
+
+function normalizeMime(value: string): string {
+  // Strip any parameter (charset, boundary, etc.) and trim/lowercase the
+  // type+subtype part. RFC 6838: parameters follow `;`.
+  const idx = value.indexOf(';')
+  const main = (idx >= 0 ? value.slice(0, idx) : value).trim().toLowerCase()
+  return main
+}
+
+function matchOne(actual: string, pattern: string): boolean {
+  if (pattern === '*/*' || pattern === '*') return true
+  if (pattern === actual) return true
+  const slash = pattern.indexOf('/')
+  if (slash < 0) return false
+  const [type, subtype] = [pattern.slice(0, slash), pattern.slice(slash + 1)]
+  const actualSlash = actual.indexOf('/')
+  if (actualSlash < 0) return false
+  const [aType, aSub] = [actual.slice(0, actualSlash), actual.slice(actualSlash + 1)]
+  if (type === '*' && subtype === aSub) return true
+  if (subtype === '*' && type === aType) return true
+  return false
+}

--- a/packages/mint/src/module.ts
+++ b/packages/mint/src/module.ts
@@ -2,21 +2,78 @@ import type { Constructor } from './container'
 import type { Token } from './token'
 import type { Middleware } from './types'
 
-export interface ProviderEntry<T = unknown> {
-  provide: Token<T> | Constructor<T>
-  useFactory?: (...args: any[]) => T
-  useValue?: T
-  useClass?: Constructor<T>
+export type Scope = 'singleton' | 'transient'
+
+export interface ClassWithInject<T = unknown> {
+  new (...args: any[]): T
+  inject?: ReadonlyArray<Token<any> | Constructor<any>>
 }
+
+export interface ValueProvider<T = unknown> {
+  provide: Token<T>
+  useValue: T
+}
+
+export interface FactoryProvider<T = unknown> {
+  provide: Token<T>
+  useFactory: (...deps: any[]) => T | Promise<T>
+  inject?: ReadonlyArray<Token<any> | Constructor<any>>
+  scope?: Scope
+}
+
+export type Provider<T = unknown> =
+  | Constructor<T>
+  | ValueProvider<T>
+  | FactoryProvider<T>
 
 export interface Module {
   imports?: Module[]
-  providers?: Array<Constructor | ProviderEntry>
-  exports?: Array<Constructor | Token<unknown>>
+  providers?: Provider[]
+  exports?: Array<Token<any> | Constructor<any>>
   controllers?: Constructor[]
   middleware?: Middleware[]
 }
 
 export function defineModule(m: Module): Module {
   return m
+}
+
+/**
+ * Sugar for the `useFactory` + `inject` provider form, packaged as a single-
+ * provider module. Useful for dynamic module patterns like
+ * `StorageModuleAsync({ inject, useFactory })`.
+ */
+export function defineAsyncModule<T>(opts: {
+  provide: Token<T>
+  inject?: ReadonlyArray<Token<any> | Constructor<any>>
+  useFactory: (...deps: any[]) => T | Promise<T>
+  exports?: boolean
+}): Module {
+  return {
+    providers: [
+      {
+        provide: opts.provide,
+        useFactory: opts.useFactory,
+        inject: opts.inject,
+      } satisfies FactoryProvider<T>,
+    ],
+    exports: opts.exports === false ? [] : [opts.provide],
+  }
+}
+
+export function isClassProvider(p: Provider): p is Constructor {
+  return typeof p === 'function'
+}
+
+export function isValueProvider(p: Provider): p is ValueProvider {
+  return typeof p === 'object' && p !== null && 'useValue' in p
+}
+
+export function isFactoryProvider(p: Provider): p is FactoryProvider {
+  return typeof p === 'object' && p !== null && 'useFactory' in p
+}
+
+export function providerToken(p: Provider): Token<any> | Constructor<any> {
+  if (isClassProvider(p)) return p
+  return p.provide
 }

--- a/packages/mint/src/module.ts
+++ b/packages/mint/src/module.ts
@@ -1,0 +1,22 @@
+import type { Constructor } from './container'
+import type { Token } from './token'
+import type { Middleware } from './types'
+
+export interface ProviderEntry<T = unknown> {
+  provide: Token<T> | Constructor<T>
+  useFactory?: (...args: any[]) => T
+  useValue?: T
+  useClass?: Constructor<T>
+}
+
+export interface Module {
+  imports?: Module[]
+  providers?: Array<Constructor | ProviderEntry>
+  exports?: Array<Constructor | Token<unknown>>
+  controllers?: Constructor[]
+  middleware?: Middleware[]
+}
+
+export function defineModule(m: Module): Module {
+  return m
+}

--- a/packages/mint/src/multipart.ts
+++ b/packages/mint/src/multipart.ts
@@ -1,0 +1,376 @@
+/**
+ * Streaming multipart/form-data parser.
+ *
+ * Reads from a `ReadableStream<Uint8Array>` boundary-delimited body and yields
+ * each part as `{ name, filename?, type, stream }`. Each yielded part's
+ * `stream` MUST be fully consumed (or cancelled) before the next part is
+ * requested. The parser pulls bytes from the source lazily, so memory stays
+ * bounded by roughly `boundary + chunk` size.
+ *
+ * Caller can throttle a single part by calling
+ * `iter.setLimit(maxBytes, path)` after yielding it; when the part exceeds
+ * `maxBytes`, the next read on its stream rejects with a
+ * `MultipartByteLimitError`.
+ */
+
+export interface MultipartPart {
+  readonly name: string
+  readonly filename?: string
+  readonly type: string
+  readonly stream: ReadableStream<Uint8Array>
+}
+
+export interface MultipartParserOptions {
+  stream: ReadableStream<Uint8Array>
+  /** boundary without the leading `--`. */
+  boundary: string
+}
+
+export interface MultipartIterator extends AsyncIterableIterator<MultipartPart> {
+  /**
+   * Set a maximum byte count for the currently-yielded part. Reads past the
+   * limit reject with `MultipartByteLimitError`. Must be called after the
+   * part is yielded; resets per part.
+   */
+  setLimit(maxBytes: number, path?: string): void
+}
+
+/** Error thrown when a part exceeds its configured `MaxSize`. */
+export class MultipartByteLimitError extends Error {
+  override readonly name = 'MultipartByteLimitError'
+  constructor(
+    readonly limit: number,
+    readonly path: string,
+  ) {
+    super(`multipart part ${path} exceeded ${limit} bytes`)
+  }
+}
+
+const CR = 13
+const LF = 10
+const DASH = 45
+
+export function parseMultipartStream(opts: MultipartParserOptions): MultipartIterator {
+  const reader = opts.stream.getReader()
+  const boundaryBytes = encodeUtf8(`--${opts.boundary}`)
+
+  // Source buffer holding bytes pulled but not yet routed.
+  let buf = new Uint8Array(0)
+  let sourceDone = false
+
+  // Active part state. `null` when no part is currently being yielded.
+  let active: {
+    controller: ReadableStreamDefaultController<Uint8Array>
+    bytes: number
+    limit: number | null
+    path: string
+    closed: boolean
+  } | null = null
+
+  // Pulls more bytes from the source. Returns false on EOF.
+  const pump = async (): Promise<boolean> => {
+    if (sourceDone) return false
+    const { value, done } = await reader.read()
+    if (done) {
+      sourceDone = true
+      return false
+    }
+    if (value && value.length > 0) {
+      buf = concat(buf, value)
+    }
+    return true
+  }
+
+  const ensure = async (n: number): Promise<boolean> => {
+    while (buf.length < n) {
+      const ok = await pump()
+      if (!ok) return false
+    }
+    return true
+  }
+
+  // Hand `chunk` to the active part. Throws/errors the stream on overflow.
+  const writeToActive = (chunk: Uint8Array): boolean => {
+    if (!active || active.closed) return true
+    if (chunk.length === 0) return true
+    active.bytes += chunk.length
+    if (active.limit !== null && active.bytes > active.limit) {
+      const err = new MultipartByteLimitError(active.limit, active.path)
+      active.controller.error(err)
+      active.closed = true
+      return false
+    }
+    active.controller.enqueue(chunk)
+    return true
+  }
+
+  // Drives ONE pump+forward iteration for the active part. Closes the part
+  // when the next boundary is encountered or the source is exhausted.
+  const advance = async (): Promise<void> => {
+    if (!active || active.closed) return
+    const idx = indexOf(buf, boundaryBytes)
+    if (idx >= 0) {
+      // Content ends at the boundary; strip the trailing CRLF (or LF) that
+      // separates the part body from the boundary line.
+      let end = idx
+      if (end >= 2 && buf[end - 2] === CR && buf[end - 1] === LF) end -= 2
+      else if (end >= 1 && buf[end - 1] === LF) end -= 1
+      if (end > 0) {
+        if (!writeToActive(buf.slice(0, end))) return
+      }
+      buf = buf.slice(idx)
+      active.controller.close()
+      active.closed = true
+      return
+    }
+    // No boundary yet: forward all but the trailing `boundary - 1` bytes,
+    // which might contain a partial match.
+    const safeLen = buf.length - boundaryBytes.length
+    if (safeLen > 0) {
+      if (!writeToActive(buf.slice(0, safeLen))) return
+      buf = buf.slice(safeLen)
+    }
+    const ok = await pump()
+    if (!ok) {
+      // Source done — flush remaining buffer (no more boundaries).
+      if (buf.length > 0) {
+        if (!writeToActive(buf)) return
+        buf = new Uint8Array(0)
+      }
+      active.controller.close()
+      active.closed = true
+    }
+  }
+
+  // Drain the active part to its conclusion. Used when the consumer drops
+  // a part (doesn't await its reader) — we still need to advance past it.
+  const drainActive = async (): Promise<void> => {
+    while (active && !active.closed) {
+      await advance()
+    }
+  }
+
+  // Read headers + content-disposition for the next part. Returns null when
+  // the final boundary (`--boundary--`) is reached.
+  const readNextHeaders = async (): Promise<{
+    name: string
+    filename?: string
+    type: string
+  } | null> => {
+    // Locate the boundary marker (it may be at offset 0 for the first part,
+    // or arrive after one or more pump() calls when chunks are small).
+    while (true) {
+      const idx = indexOf(buf, boundaryBytes)
+      if (idx >= 0) {
+        buf = buf.slice(idx + boundaryBytes.length)
+        break
+      }
+      // Keep the last (boundary - 1) bytes in case the boundary straddles.
+      if (buf.length > boundaryBytes.length) {
+        buf = buf.slice(buf.length - boundaryBytes.length)
+      }
+      const ok = await pump()
+      if (!ok) return null
+    }
+    // After the boundary, expect either `--` (terminator) or CRLF / LF (next part).
+    if (!(await ensure(2))) return null
+    if (buf[0] === DASH && buf[1] === DASH) {
+      return null
+    }
+    // Strip a single line separator (CRLF or LF) after the boundary.
+    if (buf[0] === CR && buf.length > 1 && buf[1] === LF) {
+      buf = buf.slice(2)
+    } else if (buf[0] === LF) {
+      buf = buf.slice(1)
+    }
+    // Read header block terminated by \r\n\r\n (or \n\n).
+    while (true) {
+      const idx = findHeaderEnd(buf)
+      if (idx !== -1) {
+        const headerBytes = buf.slice(0, idx.end)
+        buf = buf.slice(idx.advance)
+        return parseHeaderBlock(headerBytes)
+      }
+      const ok = await pump()
+      if (!ok) return null
+    }
+  }
+
+  let parserDone = false
+
+  const next = async (): Promise<IteratorResult<MultipartPart>> => {
+    if (parserDone) return { done: true, value: undefined }
+    if (active && !active.closed) {
+      // Consumer skipped reading — drain to boundary.
+      await drainActive()
+    }
+    active = null
+    const headers = await readNextHeaders()
+    if (!headers) {
+      parserDone = true
+      try {
+        reader.releaseLock()
+      } catch {
+        /* noop */
+      }
+      return { done: true, value: undefined }
+    }
+
+    let myActive: NonNullable<typeof active>
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        myActive = {
+          controller,
+          bytes: 0,
+          limit: null,
+          path: `body.${headers.name}`,
+          closed: false,
+        }
+        active = myActive
+      },
+      pull: async () => {
+        if (!myActive || myActive.closed) return
+        // One advance call ≈ one chunk forwarded (or end-of-part).
+        try {
+          await advance()
+        } catch {
+          /* errored via controller.error already */
+        }
+      },
+      cancel: async () => {
+        if (myActive) myActive.closed = true
+      },
+    })
+
+    return {
+      done: false,
+      value: {
+        name: headers.name,
+        filename: headers.filename,
+        type: headers.type,
+        stream,
+      },
+    }
+  }
+
+  const iterator: MultipartIterator = {
+    next,
+    setLimit(maxBytes: number, path?: string) {
+      if (active) {
+        active.limit = maxBytes
+        if (path) active.path = path
+      }
+    },
+    return: async () => {
+      // Only release the underlying reader when no active part is consuming
+      // it. Otherwise the active FileStream's pull() would lose access mid-read.
+      parserDone = true
+      if (!active || active.closed) {
+        try {
+          reader.releaseLock()
+        } catch {
+          /* noop */
+        }
+      }
+      return { done: true, value: undefined }
+    },
+    throw: async (err) => {
+      parserDone = true
+      if (!active || active.closed) {
+        try {
+          reader.releaseLock()
+        } catch {
+          /* noop */
+        }
+      }
+      throw err
+    },
+    [Symbol.asyncIterator]() {
+      return this
+    },
+  }
+  return iterator
+}
+
+// ─── byte helpers ─────────────────────────────────────────────────────────
+
+function startsWith(buf: Uint8Array, prefix: Uint8Array): boolean {
+  if (buf.length < prefix.length) return false
+  for (let i = 0; i < prefix.length; i++) {
+    if (buf[i] !== prefix[i]) return false
+  }
+  return true
+}
+
+function indexOf(haystack: Uint8Array, needle: Uint8Array): number {
+  if (needle.length === 0) return 0
+  if (haystack.length < needle.length) return -1
+  const last = haystack.length - needle.length
+  outer: for (let i = 0; i <= last; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer
+    }
+    return i
+  }
+  return -1
+}
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  if (a.length === 0) return b
+  if (b.length === 0) return a
+  const out = new Uint8Array(a.length + b.length)
+  out.set(a, 0)
+  out.set(b, a.length)
+  return out
+}
+
+function encodeUtf8(s: string): Uint8Array {
+  return new TextEncoder().encode(s)
+}
+
+function findHeaderEnd(buf: Uint8Array): { end: number; advance: number } | -1 {
+  // \r\n\r\n
+  const crlfcrlf = indexOf(buf, new Uint8Array([CR, LF, CR, LF]))
+  if (crlfcrlf >= 0) return { end: crlfcrlf, advance: crlfcrlf + 4 }
+  // \n\n (tolerant)
+  const lflf = indexOf(buf, new Uint8Array([LF, LF]))
+  if (lflf >= 0) return { end: lflf, advance: lflf + 2 }
+  return -1
+}
+
+function parseHeaderBlock(bytes: Uint8Array): {
+  name: string
+  filename?: string
+  type: string
+} {
+  const text = new TextDecoder().decode(bytes)
+  let cdisp = ''
+  let ctype = ''
+  for (const line of text.split(/\r?\n/)) {
+    const idx = line.indexOf(':')
+    if (idx < 0) continue
+    const name = line.slice(0, idx).trim().toLowerCase()
+    const value = line.slice(idx + 1).trim()
+    if (name === 'content-disposition') cdisp = value
+    else if (name === 'content-type') ctype = value
+  }
+  const { name, filename } = parseContentDisposition(cdisp)
+  return { name, filename, type: ctype }
+}
+
+function parseContentDisposition(value: string): { name: string; filename?: string } {
+  const out: { name: string; filename?: string } = { name: '' }
+  for (const segment of value.split(';')) {
+    const trimmed = segment.trim()
+    const eq = trimmed.indexOf('=')
+    if (eq < 0) continue
+    const key = trimmed.slice(0, eq).trim().toLowerCase()
+    let v = trimmed.slice(eq + 1).trim()
+    if (v.startsWith('"') && v.endsWith('"')) {
+      v = v.slice(1, -1)
+    }
+    if (key === 'name') out.name = v
+    else if (key === 'filename') out.filename = v
+  }
+  return out
+}

--- a/packages/mint/src/router.ts
+++ b/packages/mint/src/router.ts
@@ -1,28 +1,196 @@
+import type { Constructor } from './container'
 import type { RouteHandler } from './types'
 
 export interface RouteMatch {
   handler: RouteHandler
   params: Record<string, string>
+  /**
+   * The controller class this route belongs to, if `addForController` was used.
+   * The middleware finalizer reads this to pick module-level bindings.
+   */
+  controller?: Constructor
+}
+
+interface RawRoute {
+  method: string
+  path: string
+  handler: RouteHandler
+  controller?: Constructor
+  /** Pre-parsed segments for `:name` extraction. */
+  segments: RouteSegment[]
+  hasParams: boolean
+}
+
+interface RouteSegment {
+  /** Literal text or param name. */
+  value: string
+  /** When true, this segment captures the URL segment under `value`. */
+  isParam: boolean
 }
 
 /**
- * Exact-path router keyed by `${method} ${path}`. Method is free-form so
- * non-HTTP verbs like 'WS' work without a constrained union.
+ * Phase 2 router. Supports static segments and `:name` path params.
+ *
+ * Matching strategy is split-and-compare: each registered route is broken into
+ * segments at boot, and `match()` splits the incoming pathname the same way.
+ * Static segments must match exactly; `:name` segments capture into `params`.
+ *
+ * For static-only routes (no `:name` segments) we keep a direct lookup map for
+ * O(1) match. Param routes go through a linear scan; that's fine for the
+ * route counts a single service produces.
+ *
+ * Routes are buffered as raw entries when added. The first `match()` call
+ * triggers `finalize` (when wired up by `App`), which wraps each raw handler
+ * with the full middleware chain. After finalization the router serves
+ * pre-wrapped handlers.
  */
 export class Router {
-  private readonly routes = new Map<string, RouteHandler>()
+  private readonly raw: RawRoute[] = []
+  /** Finalized static routes, keyed by `${method} ${path}`. */
+  private readonly finalizedStatic = new Map<string, RouteMatch>()
+  /**
+   * Finalized parameterised routes, indexed by method. Linear scan within a
+   * method bucket — fast enough for typical route counts.
+   */
+  private readonly finalizedParam = new Map<string, FinalizedParamRoute[]>()
+  private finalizer?: (raw: readonly RawRoute[]) => Map<string, RouteMatch>
+  private isFinalized = false
 
   add(method: string, path: string, handler: RouteHandler): void {
-    this.routes.set(key(method, path), handler)
+    const { segments, hasParams } = parsePath(path)
+    this.raw.push({ method, path, handler, segments, hasParams })
+  }
+
+  /**
+   * Records a route together with the controller class it belongs to. Used by
+   * tsgonest-generated `registerXxxController(app)` companions so module-level
+   * middleware can be scoped correctly.
+   */
+  addForController(
+    controller: Constructor,
+    method: string,
+    path: string,
+    handler: RouteHandler,
+  ): void {
+    const { segments, hasParams } = parsePath(path)
+    this.raw.push({ method, path, handler, controller, segments, hasParams })
+  }
+
+  /**
+   * Lazy hook used by `App` to install a function that wraps each raw route's
+   * handler with the assembled middleware chain. The finalizer runs once, on
+   * the next `match()` call.
+   */
+  setFinalizer(fn: (raw: readonly RawRoute[]) => Map<string, RouteMatch>): void {
+    this.finalizer = fn
   }
 
   match(method: string, pathname: string): RouteMatch | undefined {
-    const handler = this.routes.get(key(method, pathname))
-    if (!handler) return undefined
-    return { handler, params: {} }
+    if (!this.isFinalized) this.finalize()
+
+    const staticHit = this.finalizedStatic.get(key(method, pathname))
+    if (staticHit) return staticHit
+
+    const bucket = this.finalizedParam.get(method)
+    if (!bucket || bucket.length === 0) return undefined
+
+    const pathSegments = splitPath(pathname)
+    for (const route of bucket) {
+      const params = matchSegments(route.segments, pathSegments)
+      if (!params) continue
+      return {
+        handler: route.match.handler,
+        params,
+        controller: route.match.controller,
+      }
+    }
+    return undefined
   }
+
+  private finalize(): void {
+    if (this.isFinalized) return
+    this.isFinalized = true
+
+    let wrapped: Map<string, RouteMatch>
+    if (this.finalizer) {
+      wrapped = this.finalizer(this.raw)
+    } else {
+      wrapped = new Map()
+      for (const r of this.raw) {
+        wrapped.set(key(r.method, r.path), {
+          handler: r.handler,
+          params: {},
+          controller: r.controller,
+        })
+      }
+    }
+
+    for (const r of this.raw) {
+      const finalized = wrapped.get(key(r.method, r.path))
+      if (!finalized) continue
+      if (!r.hasParams) {
+        this.finalizedStatic.set(key(r.method, r.path), finalized)
+        continue
+      }
+      const bucket = this.finalizedParam.get(r.method) ?? []
+      bucket.push({ segments: r.segments, match: finalized })
+      this.finalizedParam.set(r.method, bucket)
+    }
+  }
+}
+
+interface FinalizedParamRoute {
+  segments: RouteSegment[]
+  match: RouteMatch
 }
 
 function key(method: string, path: string): string {
   return `${method} ${path}`
 }
+
+function parsePath(path: string): { segments: RouteSegment[]; hasParams: boolean } {
+  const raw = splitPath(path)
+  let hasParams = false
+  const segments: RouteSegment[] = raw.map((seg) => {
+    if (seg.startsWith(':')) {
+      hasParams = true
+      return { value: seg.slice(1), isParam: true }
+    }
+    return { value: seg, isParam: false }
+  })
+  return { segments, hasParams }
+}
+
+function splitPath(path: string): string[] {
+  // Treat '/' as a single empty-segment route by returning a sentinel ''.
+  if (path === '/' || path === '') return ['']
+  // Strip leading '/' so '/a/b' and 'a/b' both split into ['a','b'].
+  const trimmed = path.startsWith('/') ? path.slice(1) : path
+  // Strip trailing '/' so '/a/b/' matches '/a/b'.
+  const noTail = trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed
+  if (noTail === '') return ['']
+  return noTail.split('/')
+}
+
+function matchSegments(
+  template: RouteSegment[],
+  pathSegments: string[],
+): Record<string, string> | undefined {
+  if (template.length !== pathSegments.length) return undefined
+  const params: Record<string, string> = {}
+  for (let i = 0; i < template.length; i++) {
+    const t = template[i]
+    const p = pathSegments[i]
+    if (t.isParam) {
+      // Empty path segment must not match a :param — '/users/' shouldn't bind
+      // 'id' to ''. Empty-string params are basically always a bug.
+      if (p === '') return undefined
+      params[t.value] = decodeURIComponent(p)
+      continue
+    }
+    if (t.value !== p) return undefined
+  }
+  return params
+}
+
+export type { RawRoute }

--- a/packages/mint/src/router.ts
+++ b/packages/mint/src/router.ts
@@ -1,0 +1,28 @@
+import type { RouteHandler } from './types'
+
+export interface RouteMatch {
+  handler: RouteHandler
+  params: Record<string, string>
+}
+
+/**
+ * Exact-path router keyed by `${method} ${path}`. Method is free-form so
+ * non-HTTP verbs like 'WS' work without a constrained union.
+ */
+export class Router {
+  private readonly routes = new Map<string, RouteHandler>()
+
+  add(method: string, path: string, handler: RouteHandler): void {
+    this.routes.set(key(method, path), handler)
+  }
+
+  match(method: string, pathname: string): RouteMatch | undefined {
+    const handler = this.routes.get(key(method, pathname))
+    if (!handler) return undefined
+    return { handler, params: {} }
+  }
+}
+
+function key(method: string, path: string): string {
+  return `${method} ${path}`
+}

--- a/packages/mint/src/sse.ts
+++ b/packages/mint/src/sse.ts
@@ -1,0 +1,96 @@
+/**
+ * Server-Sent Events helper.
+ *
+ * `sse(generator)` turns an `AsyncGenerator` into a streaming `Response` framed
+ * per the SSE spec: each event is one or more `field: value\n` lines followed
+ * by a blank line (`\n\n`). Yields are JSON-encoded by default; yielding an
+ * {@link SSEMessage} allows you to set `event`, `id`, and `retry` alongside
+ * the payload.
+ *
+ * Phase 11 supports JSON-shaped payloads — multi-line raw strings are not split
+ * across `data:` lines. Use `SSEMessage<string>` if you need that and pre-split
+ * it yourself.
+ */
+
+export interface SSEMessage<T = unknown> {
+  data: T
+  event?: string
+  id?: string
+  retry?: number
+}
+
+/**
+ * Phantom type used by the analyzer and OpenAPI generator to recognize SSE
+ * handler return types. Never produced at runtime; only meaningful at the type
+ * level via `@Returns<SSEStream<T>>` or a typed handler return.
+ */
+export interface SSEStream<T = unknown> {
+  readonly __mintkit_sse_event: T
+}
+
+const encoder = new TextEncoder()
+
+function formatFrame<T>(value: T | SSEMessage<T>): string {
+  if (isSSEMessage(value)) {
+    let frame = ''
+    if (value.event !== undefined) frame += `event: ${value.event}\n`
+    if (value.id !== undefined) frame += `id: ${value.id}\n`
+    if (value.retry !== undefined) frame += `retry: ${value.retry}\n`
+    frame += `data: ${JSON.stringify(value.data)}\n\n`
+    return frame
+  }
+  return `data: ${JSON.stringify(value)}\n\n`
+}
+
+function isSSEMessage<T>(value: unknown): value is SSEMessage<T> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'data' in (value as Record<string, unknown>)
+  )
+}
+
+export function sse<T>(
+  generator: () => AsyncGenerator<T | SSEMessage<T>, void, unknown>,
+): Response {
+  let iter: AsyncGenerator<T | SSEMessage<T>, void, unknown> | undefined
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      iter = generator()
+      try {
+        for (;;) {
+          const { value, done } = await iter.next()
+          if (done) break
+          controller.enqueue(encoder.encode(formatFrame(value)))
+        }
+        controller.close()
+      } catch (err) {
+        // Don't emit a half-finished frame; just terminate cleanly and surface
+        // the error to the consumer via the stream.
+        controller.error(err)
+      } finally {
+        // No-op; cancel() handles the cleanup path when the consumer aborts.
+      }
+    },
+    async cancel() {
+      // Consumer canceled the stream — let the generator run its finally
+      // block so users can clean up resources held inside `try { ... }`.
+      if (iter?.return) {
+        try {
+          await iter.return()
+        } catch {
+          // Swallow: cancel is best-effort cleanup and shouldn't throw upward.
+        }
+      }
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    },
+  })
+}

--- a/packages/mint/src/token.ts
+++ b/packages/mint/src/token.ts
@@ -1,0 +1,15 @@
+/**
+ * A typed dependency-injection token. The `_type` field is a phantom — it only
+ * exists at the type level and carries `T` so consumers of {@link Container.resolve}
+ * get the correct return type.
+ */
+export class Token<T> {
+  /** Phantom: never read at runtime, only used to carry the type parameter. */
+  declare readonly _type: T
+
+  constructor(public readonly name: string) {}
+}
+
+export function defineToken<T>(name: string): Token<T> {
+  return new Token<T>(name)
+}

--- a/packages/mint/src/topological.ts
+++ b/packages/mint/src/topological.ts
@@ -1,0 +1,51 @@
+/**
+ * Topological sort with cycle detection. Nodes are keyed by reference identity
+ * via the `id` callback (default: the node itself). Returns the topologically
+ * ordered list (deps before dependents).
+ *
+ * On cycle, throws an Error whose message includes the cycle path as
+ * `A -> B -> A`, using the `label` callback to format each node (default:
+ * `String(node)`).
+ */
+export function topoSort<N>(
+  nodes: readonly N[],
+  deps: (node: N) => readonly N[],
+  opts?: {
+    id?: (node: N) => unknown
+    label?: (node: N) => string
+  },
+): N[] {
+  const id = opts?.id ?? ((n: N): unknown => n)
+  const label = opts?.label ?? ((n: N): string => String(n))
+
+  const byId = new Map<unknown, N>()
+  for (const n of nodes) byId.set(id(n), n)
+
+  const result: N[] = []
+  const visited = new Set<unknown>()
+  const onStack = new Set<unknown>()
+  const stack: N[] = []
+
+  const visit = (node: N): void => {
+    const nid = id(node)
+    if (visited.has(nid)) return
+    if (onStack.has(nid)) {
+      const startIdx = stack.findIndex((s) => id(s) === nid)
+      const cycle = [...stack.slice(startIdx), node].map(label).join(' -> ')
+      throw new Error(`Provider cycle detected: ${cycle}`)
+    }
+    onStack.add(nid)
+    stack.push(node)
+    for (const d of deps(node)) {
+      const target = byId.get(id(d)) ?? d
+      visit(target)
+    }
+    stack.pop()
+    onStack.delete(nid)
+    visited.add(nid)
+    result.push(node)
+  }
+
+  for (const n of nodes) visit(n)
+  return result
+}

--- a/packages/mint/src/types.ts
+++ b/packages/mint/src/types.ts
@@ -1,0 +1,16 @@
+import type { Event } from './event'
+
+/**
+ * Reserved marker for a future WebSocket-upgrade response. Never produced in
+ * Phase 1, but part of the handler return type so the surface stays stable.
+ */
+export interface Upgrade {
+  readonly _tag: 'upgrade'
+}
+
+export type RouteHandler = (event: Event) => Promise<Response | Upgrade>
+
+export type Middleware = (
+  event: Event,
+  next: () => Promise<Response | Upgrade>,
+) => Promise<Response | Upgrade>

--- a/packages/mint/test/app.test.ts
+++ b/packages/mint/test/app.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { createApp } from '../src/app'
+import { defineModule } from '../src/module'
+
+class HelloController {
+  hello() {
+    return 'hi'
+  }
+}
+
+describe('createApp', () => {
+  it('resolves controllers from modules', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+
+    const ctrl = app.resolve(HelloController)
+    expect(ctrl).toBeInstanceOf(HelloController)
+    expect(app.resolve(HelloController)).toBe(ctrl)
+  })
+
+  it('returns 404 when no route matches', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+
+    const res = await app.fetch(new Request('http://x/missing'))
+    expect(res.status).toBe(404)
+  })
+
+  it('dispatches a manually registered route', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+
+    app.router.add('GET', '/hello', async () => new Response('hi'))
+    const res = await app.fetch(new Request('http://x/hello'))
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hi')
+  })
+
+  it('flattens nested imports and dedupes by identity', async () => {
+    const inner = defineModule({ controllers: [HelloController] })
+    const outer = defineModule({ imports: [inner, inner] })
+    const app = await createApp({ imports: [outer, inner] })
+
+    const ctrl = app.resolve(HelloController)
+    expect(ctrl).toBeInstanceOf(HelloController)
+  })
+
+  it('event.resolve delegates to the container', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+
+    app.router.add('GET', '/who', async (event) => {
+      const ctrl = event.resolve(HelloController)
+      return new Response(ctrl.hello())
+    })
+
+    const res = await app.fetch(new Request('http://x/who'))
+    expect(await res.text()).toBe('hi')
+  })
+})

--- a/packages/mint/test/container-providers.test.ts
+++ b/packages/mint/test/container-providers.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest'
+import { Container } from '../src/container'
+import { defineToken } from '../src/token'
+
+describe('Container — provider forms', () => {
+  it('registers a class shorthand and resolves an instance', async () => {
+    class Service {
+      readonly tag = 'service'
+    }
+    const c = new Container()
+    c.registerProvider(Service)
+    await c.boot()
+    const s = c.resolve(Service)
+    expect(s).toBeInstanceOf(Service)
+    expect(s.tag).toBe('service')
+  })
+
+  it('useValue provider returns the exact value', async () => {
+    const TOKEN = defineToken<{ port: number }>('CONFIG')
+    const value = { port: 8080 }
+    const c = new Container()
+    c.registerProvider({ provide: TOKEN, useValue: value })
+    await c.boot()
+    expect(c.resolve(TOKEN)).toBe(value)
+  })
+
+  it('useFactory provider runs at boot and caches the result', async () => {
+    const TOKEN = defineToken<{ id: number }>('ID')
+    let calls = 0
+    const c = new Container()
+    c.registerProvider({
+      provide: TOKEN,
+      useFactory: () => {
+        calls++
+        return { id: 42 }
+      },
+    })
+    await c.boot()
+    expect(calls).toBe(1)
+    expect(c.resolve(TOKEN)).toEqual({ id: 42 })
+    expect(c.resolve(TOKEN)).toBe(c.resolve(TOKEN))
+    expect(calls).toBe(1)
+  })
+
+  it('useFactory awaits async factories during boot', async () => {
+    const TOKEN = defineToken<{ name: string }>('CFG')
+    const c = new Container()
+    c.registerProvider({
+      provide: TOKEN,
+      useFactory: async () => {
+        await new Promise<void>((r) => setTimeout(r, 1))
+        return { name: 'resolved' }
+      },
+    })
+    await c.boot()
+    expect(c.resolve(TOKEN)).toEqual({ name: 'resolved' })
+  })
+
+  it('useFactory with inject resolves dependencies first', async () => {
+    const DB_URL = defineToken<string>('DB_URL')
+    const DB = defineToken<{ url: string }>('DB')
+    const c = new Container()
+    c.registerProvider({ provide: DB_URL, useValue: 'postgres://x' })
+    c.registerProvider({
+      provide: DB,
+      useFactory: (url: string) => ({ url }),
+      inject: [DB_URL],
+    })
+    await c.boot()
+    expect(c.resolve(DB)).toEqual({ url: 'postgres://x' })
+  })
+
+  it('transient factory re-runs on each resolve', async () => {
+    const TOKEN = defineToken<{ n: number }>('TR')
+    let calls = 0
+    const c = new Container()
+    c.registerProvider({
+      provide: TOKEN,
+      useFactory: () => ({ n: ++calls }),
+      scope: 'transient',
+    })
+    await c.boot()
+    expect(c.resolve(TOKEN).n).toBe(1)
+    expect(c.resolve(TOKEN).n).toBe(2)
+    expect(c.resolve(TOKEN).n).toBe(3)
+  })
+
+  it('class with static inject array resolves constructor args', async () => {
+    const NAME = defineToken<string>('NAME')
+    class Greeter {
+      static inject = [NAME] as const
+      constructor(public name: string) {}
+      hello() {
+        return `hi ${this.name}`
+      }
+    }
+    const c = new Container()
+    c.registerProvider({ provide: NAME, useValue: 'world' })
+    c.registerProvider(Greeter)
+    await c.boot()
+    expect(c.resolve(Greeter).hello()).toBe('hi world')
+  })
+
+  it('classes get constructed in topological order', async () => {
+    const order: string[] = []
+    class A {
+      constructor() {
+        order.push('A')
+      }
+    }
+    class B {
+      static inject = [A] as const
+      constructor(public a: A) {
+        order.push('B')
+      }
+    }
+    class C {
+      static inject = [B, A] as const
+      constructor(
+        public b: B,
+        public a: A,
+      ) {
+        order.push('C')
+      }
+    }
+    const c = new Container()
+    c.registerProvider(C)
+    c.registerProvider(B)
+    c.registerProvider(A)
+    await c.boot()
+    expect(order).toEqual(['A', 'B', 'C'])
+  })
+
+  it('throws on a provider cycle with the cycle path', async () => {
+    const A = defineToken<number>('A')
+    const B = defineToken<number>('B')
+    const c = new Container()
+    c.registerProvider({ provide: A, useFactory: (b: number) => b + 1, inject: [B] })
+    c.registerProvider({ provide: B, useFactory: (a: number) => a + 1, inject: [A] })
+    await expect(c.boot()).rejects.toThrow(/cycle/i)
+  })
+
+  it('throws on a missing token at boot', async () => {
+    const MISSING = defineToken<string>('MISSING')
+    class Needs {
+      static inject = [MISSING] as const
+      constructor(public x: string) {}
+    }
+    const c = new Container()
+    c.registerProvider(Needs)
+    await expect(c.boot()).rejects.toThrow(/MISSING/)
+  })
+
+  it('throws on duplicate provider registration', async () => {
+    const T = defineToken<number>('DUP')
+    const c = new Container()
+    c.registerProvider({ provide: T, useValue: 1 })
+    expect(() => c.registerProvider({ provide: T, useValue: 2 })).toThrow(/duplicate/i)
+  })
+})

--- a/packages/mint/test/container.test.ts
+++ b/packages/mint/test/container.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { Container } from '../src/container'
+import { defineToken } from '../src/token'
+
+describe('Container', () => {
+  it('returns the same instance on repeated resolve (singleton)', () => {
+    class Service {
+      readonly id = Math.random()
+    }
+    const c = new Container()
+    c.register(Service, () => new Service())
+
+    const a = c.resolve(Service)
+    const b = c.resolve(Service)
+    expect(a).toBe(b)
+  })
+
+  it('resolves a Token by identity', () => {
+    const TOKEN = defineToken<{ value: number }>('value')
+    const c = new Container()
+    c.register(TOKEN, () => ({ value: 42 }))
+
+    expect(c.resolve(TOKEN)).toEqual({ value: 42 })
+    expect(c.resolve(TOKEN)).toBe(c.resolve(TOKEN))
+  })
+
+  it('throws when resolving an unregistered token', () => {
+    class Unknown {}
+    const c = new Container()
+    expect(() => c.resolve(Unknown)).toThrow()
+  })
+})

--- a/packages/mint/test/context.test.ts
+++ b/packages/mint/test/context.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, expectTypeOf } from 'vitest'
+import { createApp, createContext } from '../src/app'
+import type { App, Context } from '../src/app'
+import { defineModule } from '../src/module'
+import { defineToken } from '../src/token'
+
+describe('createContext — headless', () => {
+  it('boots and resolves providers without a router', async () => {
+    const TOKEN = defineToken<{ port: number }>('CFG')
+    class Service {
+      static inject = [TOKEN] as const
+      constructor(public cfg: { port: number }) {}
+    }
+    const ctx = await createContext({
+      imports: [
+        defineModule({
+          providers: [{ provide: TOKEN, useValue: { port: 9000 } }, Service],
+          exports: [TOKEN],
+        }),
+      ],
+    })
+    expect(ctx.resolve(Service).cfg.port).toBe(9000)
+    expect((ctx as unknown as { fetch?: unknown }).fetch).toBeUndefined()
+    expect((ctx as unknown as { router?: unknown }).router).toBeUndefined()
+    await ctx[Symbol.asyncDispose]()
+  })
+
+  it('runs init() and dispose for headless contexts too', async () => {
+    const order: string[] = []
+    class Svc {
+      async init() {
+        order.push('init')
+      }
+      async [Symbol.asyncDispose]() {
+        order.push('dispose')
+      }
+    }
+    const ctx = await createContext({
+      imports: [defineModule({ providers: [Svc] })],
+    })
+    expect(order).toEqual(['init'])
+    await ctx[Symbol.asyncDispose]()
+    expect(order).toEqual(['init', 'dispose'])
+  })
+
+  it('silently ignores controllers in imported modules', async () => {
+    class Ctrl {
+      hello() {
+        return 'hi'
+      }
+    }
+    const ctx = await createContext({
+      imports: [defineModule({ controllers: [Ctrl] })],
+    })
+    expect(ctx.resolve(Ctrl).hello()).toBe('hi')
+    expect((ctx as unknown as { router?: unknown }).router).toBeUndefined()
+    await ctx[Symbol.asyncDispose]()
+  })
+
+  it('App is structurally assignable to Context', async () => {
+    const app = await createApp({ imports: [defineModule({})] })
+    const asCtx: Context = app
+    expect(typeof asCtx.resolve).toBe('function')
+    expect(typeof asCtx[Symbol.asyncDispose]).toBe('function')
+    await app[Symbol.asyncDispose]()
+    expectTypeOf<App>().toExtend<Context>()
+  })
+
+  it('await using auto-disposes the context on scope exit', async () => {
+    const events: string[] = []
+    class Svc {
+      async [Symbol.asyncDispose]() {
+        events.push('disposed')
+      }
+    }
+    {
+      await using _ctx = await createContext({
+        imports: [defineModule({ providers: [Svc] })],
+      })
+      events.push('inside')
+    }
+    expect(events).toEqual(['inside', 'disposed'])
+  })
+
+  it('await using auto-disposes even on throw', async () => {
+    const events: string[] = []
+    class Svc {
+      async [Symbol.asyncDispose]() {
+        events.push('disposed')
+      }
+    }
+    await expect(
+      (async () => {
+        await using _ctx = await createContext({
+          imports: [defineModule({ providers: [Svc] })],
+        })
+        events.push('before-throw')
+        throw new Error('boom')
+      })(),
+    ).rejects.toThrow(/boom/)
+    expect(events).toEqual(['before-throw', 'disposed'])
+  })
+
+  it('module visibility validation runs for createContext too', async () => {
+    const HIDDEN = defineToken<number>('HIDDEN_CTX')
+    class C {
+      static inject = [HIDDEN] as const
+      constructor(public x: number) {}
+    }
+    const inner = defineModule({
+      providers: [{ provide: HIDDEN, useValue: 1 }],
+    })
+    const outer = defineModule({ imports: [inner], providers: [C] })
+    await expect(createContext({ imports: [outer] })).rejects.toThrow(/visibility|HIDDEN/)
+  })
+})

--- a/packages/mint/test/error-handling.test.ts
+++ b/packages/mint/test/error-handling.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createApp } from '../src/app'
+import { defineModule } from '../src/module'
+import {
+  HttpError,
+  ConflictError,
+  BadRequestError,
+  NotFoundError,
+} from '../src/errors'
+
+class HelloController {}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('handler throws + error mapper integration', () => {
+  it('thrown HttpError maps to the carried status', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.router.add('GET', '/r', async () => {
+      throw new ConflictError({ code: 'CONFLICTED' })
+    })
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(409)
+    expect(res.headers.get('content-type')).toContain('application/json')
+    expect(await res.json()).toEqual({ code: 'CONFLICTED' })
+  })
+
+  it('thrown plain HttpError honours the message → body fallback', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.router.add('GET', '/r', async () => {
+      throw new NotFoundError(undefined, 'no such doc')
+    })
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'no such doc' })
+  })
+
+  it('TsgonestValidationError-shaped throw produces RFC 9457 problem-details', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    class FakeValErr extends Error {
+      readonly errors: Array<{ path: string; expected: string; received: string }>
+      constructor() {
+        super('Validation failed: 1 error(s)')
+        this.name = 'TsgonestValidationError'
+        this.errors = [{ path: 'x', expected: 'string', received: 'number' }]
+      }
+    }
+    app.router.add('GET', '/r', async () => {
+      throw new FakeValErr()
+    })
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(400)
+    expect(res.headers.get('content-type')).toContain('application/problem+json')
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.title).toBe('Validation Failed')
+    expect(body.status).toBe(400)
+    expect(body.errors).toEqual([
+      { path: 'x', expected: 'string', received: 'number' },
+    ])
+  })
+
+  it('random throw → 500 problem-details with no leak; full error is logged', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.router.add('GET', '/r', async () => {
+      throw new Error('top-secret stack trace')
+    })
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(500)
+    expect(res.headers.get('content-type')).toContain('application/problem+json')
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.title).toBe('Internal Server Error')
+    expect(JSON.stringify(body)).not.toContain('top-secret')
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('app.onError — user-registered handlers', () => {
+  it('takes precedence over the default HttpError mapping', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.onError(
+      (e) => e instanceof ConflictError,
+      () =>
+        new Response(JSON.stringify({ overridden: true }), {
+          status: 409,
+          headers: { 'content-type': 'application/json' },
+        }),
+    )
+    app.router.add('GET', '/r', async () => {
+      throw new ConflictError({ code: 'x' })
+    })
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ overridden: true })
+  })
+
+  it('first match wins among multiple user handlers', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.onError(
+      (e) => e instanceof HttpError,
+      () => new Response('http-handler', { status: 418 }),
+    )
+    app.onError(
+      (e) => e instanceof BadRequestError,
+      () => new Response('br-handler', { status: 400 }),
+    )
+    app.router.add('GET', '/r', async () => {
+      throw new BadRequestError({ x: 1 })
+    })
+    const res = await app.fetch(new Request('http://x/r'))
+    // The first predicate matches and wins, even though the second is more
+    // specific.
+    expect(res.status).toBe(418)
+    expect(await res.text()).toBe('http-handler')
+  })
+
+  it('passes the event to the handler so middleware-set tokens are visible', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    let seenUrl: string | undefined
+    app.onError(
+      () => true,
+      (_err, event) => {
+        seenUrl = event.request.url
+        return new Response('ok', { status: 200 })
+      },
+    )
+    app.router.add('GET', '/r', async () => {
+      throw new Error('x')
+    })
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(200)
+    expect(seenUrl).toContain('/r')
+  })
+
+  it('falls through to defaults when no predicate matches', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.onError(
+      (e) => e instanceof BadRequestError,
+      () => new Response('never', { status: 200 }),
+    )
+    app.router.add('GET', '/r', async () => {
+      throw new ConflictError({ code: 'c' })
+    })
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ code: 'c' })
+  })
+
+  it('throw inside middleware also goes through onError', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.onError(
+      (e) => e instanceof Error && (e as Error).message === 'auth',
+      () => new Response('unauth', { status: 401 }),
+    )
+    app.use(async () => {
+      throw new Error('auth')
+    })
+    app.router.add('GET', '/r', async () => new Response('ok'))
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('unauth')
+  })
+})

--- a/packages/mint/test/error-mapper.test.ts
+++ b/packages/mint/test/error-mapper.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { ErrorMapper } from '../src/error-mapper'
+import {
+  HttpError,
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+} from '../src/errors'
+import { Event } from '../src/event'
+import { Container } from '../src/container'
+
+function makeEvent(): Event {
+  return new Event(new Request('http://x/'), new Container())
+}
+
+describe('ErrorMapper — default handlers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('maps HttpError to a JSON Response with the carried status and body', async () => {
+    const mapper = new ErrorMapper()
+    const res = await mapper.map(new ConflictError({ code: 'DUPLICATE' }), makeEvent())
+    expect(res.status).toBe(409)
+    expect(res.headers.get('content-type')).toContain('application/json')
+    expect(await res.json()).toEqual({ code: 'DUPLICATE' })
+  })
+
+  it('falls back to { error: message } when HttpError body is undefined', async () => {
+    const mapper = new ErrorMapper()
+    const res = await mapper.map(new NotFoundError(undefined, 'gone'), makeEvent())
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'gone' })
+  })
+
+  it('maps a plain HttpError (any status) correctly', async () => {
+    const mapper = new ErrorMapper()
+    const res = await mapper.map(new HttpError(418, { teapot: true }), makeEvent())
+    expect(res.status).toBe(418)
+    expect(await res.json()).toEqual({ teapot: true })
+  })
+
+  it('maps TsgonestValidationError-named errors to RFC 9457 problem-details', async () => {
+    const mapper = new ErrorMapper()
+    class FakeValErr extends Error {
+      readonly errors: Array<{ path: string; expected: string; received: string }>
+      constructor(errors: Array<{ path: string; expected: string; received: string }>) {
+        super('Validation failed: 1 error(s)')
+        this.name = 'TsgonestValidationError'
+        this.errors = errors
+      }
+    }
+    const err = new FakeValErr([
+      { path: 'input.name', expected: 'string', received: 'undefined' },
+    ])
+    const res = await mapper.map(err, makeEvent())
+    expect(res.status).toBe(400)
+    expect(res.headers.get('content-type')).toContain('application/problem+json')
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.type).toBe('about:blank')
+    expect(body.title).toBe('Validation Failed')
+    expect(body.status).toBe(400)
+    expect(body.detail).toBe('Validation failed: 1 error(s)')
+    expect(body.errors).toEqual([
+      { path: 'input.name', expected: 'string', received: 'undefined' },
+    ])
+  })
+
+  it('also accepts `details` as a fallback field for validation errors', async () => {
+    const mapper = new ErrorMapper()
+    class FakeValErr extends Error {
+      readonly details: Array<unknown>
+      constructor(details: Array<unknown>) {
+        super('bad')
+        this.name = 'TsgonestValidationError'
+        this.details = details
+      }
+    }
+    const res = await mapper.map(new FakeValErr([{ x: 1 }]), makeEvent())
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.errors).toEqual([{ x: 1 }])
+  })
+
+  it('emits a 500 problem-details and logs the error for unknown throws', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const mapper = new ErrorMapper()
+    const res = await mapper.map(new Error('top-secret stack trace'), makeEvent())
+    expect(res.status).toBe(500)
+    expect(res.headers.get('content-type')).toContain('application/problem+json')
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.status).toBe(500)
+    expect(body.title).toBe('Internal Server Error')
+    expect(body.type).toBe('about:blank')
+    // No leak of the original message
+    expect(JSON.stringify(body)).not.toContain('top-secret')
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles non-Error throws (string/object) without leaking content', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const mapper = new ErrorMapper()
+    const res = await mapper.map('plain string boom', makeEvent())
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(JSON.stringify(body)).not.toContain('plain string boom')
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('ErrorMapper — user handlers', () => {
+  it('user handlers run BEFORE defaults; first match wins', async () => {
+    const mapper = new ErrorMapper()
+    let firstCalled = 0
+    let secondCalled = 0
+    mapper.register(
+      (e) => e instanceof Error && e.message === 'snowflake',
+      () => {
+        firstCalled++
+        return new Response('first', { status: 418 })
+      },
+    )
+    mapper.register(
+      (e) => e instanceof Error && e.message === 'snowflake',
+      () => {
+        secondCalled++
+        return new Response('second', { status: 422 })
+      },
+    )
+    const res = await mapper.map(new Error('snowflake'), makeEvent())
+    expect(res.status).toBe(418)
+    expect(await res.text()).toBe('first')
+    expect(firstCalled).toBe(1)
+    expect(secondCalled).toBe(0)
+  })
+
+  it('user handler takes precedence over the default HttpError mapping', async () => {
+    const mapper = new ErrorMapper()
+    mapper.register(
+      (e) => e instanceof ConflictError,
+      () => new Response('custom-conflict', { status: 409, headers: { 'x-overridden': '1' } }),
+    )
+    const res = await mapper.map(new ConflictError({ code: 'x' }), makeEvent())
+    expect(res.status).toBe(409)
+    expect(res.headers.get('x-overridden')).toBe('1')
+    expect(await res.text()).toBe('custom-conflict')
+  })
+
+  it('user handler can return a Promise<Response>', async () => {
+    const mapper = new ErrorMapper()
+    mapper.register(
+      () => true,
+      async () => new Response('async', { status: 202 }),
+    )
+    const res = await mapper.map(new Error('x'), makeEvent())
+    expect(res.status).toBe(202)
+    expect(await res.text()).toBe('async')
+  })
+
+  it('falls through to defaults when no user predicate matches', async () => {
+    const mapper = new ErrorMapper()
+    mapper.register(
+      (e) => e instanceof Error && (e as Error).message === 'other',
+      () => new Response('never', { status: 200 }),
+    )
+    const res = await mapper.map(new BadRequestError({ code: 'bad' }), makeEvent())
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ code: 'bad' })
+  })
+
+  it('passes the event to the handler', async () => {
+    const mapper = new ErrorMapper()
+    const event = makeEvent()
+    let captured: Event | undefined
+    mapper.register(
+      () => true,
+      (_err, ev) => {
+        captured = ev
+        return new Response('ok')
+      },
+    )
+    await mapper.map(new Error('x'), event)
+    expect(captured).toBe(event)
+  })
+})

--- a/packages/mint/test/errors.test.ts
+++ b/packages/mint/test/errors.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import {
+  HttpError,
+  BadRequestError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ConflictError,
+  UnprocessableEntityError,
+  TooManyRequestsError,
+  InternalServerError,
+} from '../src/errors'
+
+describe('HttpError hierarchy', () => {
+  it('HttpError carries status, body, and message', () => {
+    const err = new HttpError(418, { teapot: true }, "I'm a teapot")
+    expect(err.status).toBe(418)
+    expect(err.body).toEqual({ teapot: true })
+    expect(err.message).toBe("I'm a teapot")
+    expect(err.name).toBe('HttpError')
+    expect(err).toBeInstanceOf(Error)
+  })
+
+  it('default message uses the status when none provided', () => {
+    const err = new HttpError(500)
+    expect(err.message).toBe('HTTP 500')
+    expect(err.body).toBeUndefined()
+  })
+
+  it('subclasses carry the right status and name', () => {
+    const cases: Array<[new (b?: unknown, m?: string) => HttpError, number, string]> = [
+      [BadRequestError, 400, 'BadRequestError'],
+      [UnauthorizedError, 401, 'UnauthorizedError'],
+      [ForbiddenError, 403, 'ForbiddenError'],
+      [NotFoundError, 404, 'NotFoundError'],
+      [ConflictError, 409, 'ConflictError'],
+      [UnprocessableEntityError, 422, 'UnprocessableEntityError'],
+      [TooManyRequestsError, 429, 'TooManyRequestsError'],
+      [InternalServerError, 500, 'InternalServerError'],
+    ]
+    for (const [Ctor, expectedStatus, expectedName] of cases) {
+      const e = new Ctor({ msg: 'x' })
+      expect(e.status).toBe(expectedStatus)
+      expect(e.body).toEqual({ msg: 'x' })
+      expect(e.name).toBe(expectedName)
+      expect(e).toBeInstanceOf(HttpError)
+      expect(e).toBeInstanceOf(Error)
+    }
+  })
+
+  it('subclasses preserve a custom message', () => {
+    const e = new NotFoundError({ resource: 'user' }, 'user 42 not found')
+    expect(e.message).toBe('user 42 not found')
+    expect(e.status).toBe(404)
+  })
+})

--- a/packages/mint/test/event-body.test.ts
+++ b/packages/mint/test/event-body.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { Event } from '../src/event'
+import { Container } from '../src/container'
+
+function bodyEvent(body: BodyInit, headers?: Record<string, string>): Event {
+  return new Event(
+    new Request('http://x/', { method: 'POST', body, headers }),
+    new Container(),
+  )
+}
+
+describe('Event.body', () => {
+  it('bytes() returns the raw body and is memoized', async () => {
+    const event = bodyEvent('hello')
+    const a = await event.body.bytes()
+    const b = await event.body.bytes()
+    expect(a).toBeInstanceOf(Uint8Array)
+    expect(new TextDecoder().decode(a)).toBe('hello')
+    // Memoized: same reference on repeated calls.
+    expect(a).toBe(b)
+  })
+
+  it('text() decodes the bytes and is memoized', async () => {
+    const event = bodyEvent('hello')
+    expect(await event.body.text()).toBe('hello')
+    expect(await event.body.text()).toBe('hello')
+  })
+
+  it('json() parses the body', async () => {
+    const event = bodyEvent(JSON.stringify({ a: 1 }), {
+      'content-type': 'application/json',
+    })
+    expect(await event.body.json<{ a: number }>()).toEqual({ a: 1 })
+    expect(await event.body.json()).toEqual({ a: 1 })
+  })
+
+  it('formData() works for application/x-www-form-urlencoded', async () => {
+    const event = bodyEvent('a=1&b=two', {
+      'content-type': 'application/x-www-form-urlencoded',
+    })
+    const fd = await event.body.formData()
+    expect(fd.get('a')).toBe('1')
+    expect(fd.get('b')).toBe('two')
+  })
+
+  it('formData() works for multipart/form-data', async () => {
+    const form = new FormData()
+    form.append('name', 'jane')
+    form.append('file', new Blob(['hello']), 'hello.txt')
+    const event = new Event(
+      new Request('http://x/', { method: 'POST', body: form }),
+      new Container(),
+    )
+    const fd = await event.body.formData()
+    expect(fd.get('name')).toBe('jane')
+    const file = fd.get('file') as File | null
+    expect(file).toBeInstanceOf(Blob)
+    expect(await (file as Blob).text()).toBe('hello')
+  })
+
+  it('formData() can be called after bytes() (re-parsed from cached bytes)', async () => {
+    const event = bodyEvent('a=1&b=2', {
+      'content-type': 'application/x-www-form-urlencoded',
+    })
+    const bytes = await event.body.bytes()
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    const fd = await event.body.formData()
+    expect(fd.get('a')).toBe('1')
+    expect(fd.get('b')).toBe('2')
+  })
+
+  it('stream() throws if bytes() was already called', async () => {
+    const event = bodyEvent('x')
+    await event.body.bytes()
+    expect(() => event.body.stream()).toThrow(/already consumed/)
+  })
+
+  it('bytes() throws if stream() was already taken', async () => {
+    const event = bodyEvent('x')
+    const stream = event.body.stream()
+    expect(stream).toBeInstanceOf(ReadableStream)
+    await expect(event.body.bytes()).rejects.toThrow(/already consumed/)
+  })
+
+  it('stream() can only be taken once', async () => {
+    const event = bodyEvent('x')
+    event.body.stream()
+    expect(() => event.body.stream()).toThrow(/already consumed/)
+  })
+})
+
+describe('Event.waitUntil', () => {
+  it('records promises in the internal set', () => {
+    const event = new Event(new Request('http://x/'), new Container())
+    const p1 = Promise.resolve(1)
+    const p2 = Promise.resolve(2)
+    event.waitUntil(p1)
+    event.waitUntil(p2)
+    expect(event.waitUntilPromises.size).toBe(2)
+    expect(event.waitUntilPromises.has(p1)).toBe(true)
+    expect(event.waitUntilPromises.has(p2)).toBe(true)
+  })
+})

--- a/packages/mint/test/lifecycle.test.ts
+++ b/packages/mint/test/lifecycle.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest'
+import { createApp } from '../src/app'
+import { defineModule } from '../src/module'
+import { defineToken } from '../src/token'
+
+describe('Lifecycle — init and asyncDispose', () => {
+  it('calls init() on every provider with one, in topological order', async () => {
+    const order: string[] = []
+    class A {
+      async init() {
+        order.push('A')
+      }
+    }
+    class B {
+      static inject = [A] as const
+      constructor(public a: A) {}
+      async init() {
+        order.push('B')
+      }
+    }
+    class C {
+      static inject = [B] as const
+      constructor(public b: B) {}
+      async init() {
+        order.push('C')
+      }
+    }
+    await createApp({
+      imports: [defineModule({ providers: [A, B, C] })],
+    })
+    expect(order).toEqual(['A', 'B', 'C'])
+  })
+
+  it('rejects createApp when an init throws and disposes already-init providers in reverse order', async () => {
+    const events: string[] = []
+    class A {
+      async init() {
+        events.push('init:A')
+      }
+      async [Symbol.asyncDispose]() {
+        events.push('dispose:A')
+      }
+    }
+    class B {
+      static inject = [A] as const
+      constructor(public a: A) {}
+      async init() {
+        events.push('init:B')
+      }
+      async [Symbol.asyncDispose]() {
+        events.push('dispose:B')
+      }
+    }
+    class C {
+      static inject = [B] as const
+      constructor(public b: B) {}
+      async init() {
+        events.push('init:C')
+        throw new Error('C failed')
+      }
+      async [Symbol.asyncDispose]() {
+        events.push('dispose:C')
+      }
+    }
+    await expect(
+      createApp({
+        imports: [defineModule({ providers: [A, B, C] })],
+      }),
+    ).rejects.toThrow(/C failed/)
+    expect(events).toEqual(['init:A', 'init:B', 'init:C', 'dispose:B', 'dispose:A'])
+  })
+
+  it('asyncDispose runs provider dispose in reverse topological order', async () => {
+    const order: string[] = []
+    class A {
+      async [Symbol.asyncDispose]() {
+        order.push('A')
+      }
+    }
+    class B {
+      static inject = [A] as const
+      constructor(public a: A) {}
+      async [Symbol.asyncDispose]() {
+        order.push('B')
+      }
+    }
+    const app = await createApp({
+      imports: [defineModule({ providers: [A, B] })],
+    })
+    await app[Symbol.asyncDispose]()
+    expect(order).toEqual(['B', 'A'])
+  })
+
+  it('drains in-flight fetch invocations before disposing', async () => {
+    const events: string[] = []
+    class Svc {
+      async [Symbol.asyncDispose]() {
+        events.push('disposed')
+      }
+    }
+    const app = await createApp({
+      imports: [defineModule({ providers: [Svc] })],
+    })
+
+    let resolveHandler!: () => void
+    app.router.add('GET', '/slow', async () => {
+      await new Promise<void>((r) => {
+        resolveHandler = r
+      })
+      events.push('handler-done')
+      return new Response('ok')
+    })
+
+    const inflight = app.fetch(new Request('http://x/slow'))
+    await new Promise<void>((r) => setTimeout(r, 5))
+
+    const disposed = app[Symbol.asyncDispose]()
+    await new Promise<void>((r) => setTimeout(r, 5))
+
+    expect(events).toEqual([])
+    resolveHandler()
+    const res = await inflight
+    expect(res.status).toBe(200)
+    await disposed
+    expect(events).toEqual(['handler-done', 'disposed'])
+  })
+
+  it('returns 503 from fetch once asyncDispose has started', async () => {
+    const app = await createApp({
+      imports: [defineModule({})],
+    })
+    app.router.add('GET', '/ping', async () => new Response('pong'))
+    await app[Symbol.asyncDispose]()
+    const res = await app.fetch(new Request('http://x/ping'))
+    expect(res.status).toBe(503)
+  })
+
+  it('throws AggregateError when multiple disposers throw', async () => {
+    class A {
+      async [Symbol.asyncDispose]() {
+        throw new Error('A boom')
+      }
+    }
+    class B {
+      static inject = [A] as const
+      constructor(public a: A) {}
+      async [Symbol.asyncDispose]() {
+        throw new Error('B boom')
+      }
+    }
+    const app = await createApp({
+      imports: [defineModule({ providers: [A, B] })],
+    })
+    let err: unknown
+    try {
+      await app[Symbol.asyncDispose]()
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeInstanceOf(AggregateError)
+    expect((err as AggregateError).errors).toHaveLength(2)
+  })
+
+  it('rethrows a single disposer error directly', async () => {
+    class Only {
+      async [Symbol.asyncDispose]() {
+        throw new Error('solo')
+      }
+    }
+    const app = await createApp({ imports: [defineModule({ providers: [Only] })] })
+    await expect(app[Symbol.asyncDispose]()).rejects.toThrow(/solo/)
+  })
+
+  it('detects provider cycles at boot with the cycle path', async () => {
+    const A = defineToken<number>('CYCLE_A')
+    const B = defineToken<number>('CYCLE_B')
+    await expect(
+      createApp({
+        imports: [
+          defineModule({
+            providers: [
+              { provide: A, useFactory: (b: number) => b + 1, inject: [B] },
+              { provide: B, useFactory: (a: number) => a + 1, inject: [A] },
+            ],
+          }),
+        ],
+      }),
+    ).rejects.toThrow(/cycle/i)
+  })
+})

--- a/packages/mint/test/middleware.test.ts
+++ b/packages/mint/test/middleware.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest'
+import { createApp } from '../src/app'
+import { defineModule } from '../src/module'
+import type { Middleware } from '../src/types'
+
+class HelloController {}
+
+const tag = (label: string, log: string[]): Middleware => {
+  return async (_event, next) => {
+    log.push(`>${label}`)
+    const res = await next()
+    log.push(`<${label}`)
+    return res
+  }
+}
+
+describe('app.use — global middleware', () => {
+  it('runs outer-to-inner; handler last', async () => {
+    const log: string[] = []
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.use(tag('A', log))
+    app.use(tag('B', log))
+    app.router.add('GET', '/r', async () => {
+      log.push('handler')
+      return new Response('hi')
+    })
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(200)
+    expect(log).toEqual(['>A', '>B', 'handler', '<B', '<A'])
+  })
+
+  it('preserves registration order across multiple use() calls', async () => {
+    const log: string[] = []
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.use(tag('first', log))
+    app.use(tag('second', log))
+    app.use(tag('third', log))
+    app.router.add('GET', '/r', async () => new Response(''))
+    await app.fetch(new Request('http://x/r'))
+    expect(log).toEqual([
+      '>first',
+      '>second',
+      '>third',
+      '<third',
+      '<second',
+      '<first',
+    ])
+  })
+})
+
+describe('app.use(prefix, mw) — prefix middleware', () => {
+  it('runs only for matching pathname prefixes', async () => {
+    const log: string[] = []
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.use('/api', tag('api', log))
+    app.router.add('GET', '/api/users', async () => new Response('a'))
+    app.router.add('GET', '/public', async () => new Response('b'))
+
+    await app.fetch(new Request('http://x/api/users'))
+    await app.fetch(new Request('http://x/public'))
+
+    // 'api' should have wrapped only the /api/users call.
+    expect(log).toEqual(['>api', '<api'])
+  })
+
+  it('runs in combination with global middleware in registration order', async () => {
+    const log: string[] = []
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.use(tag('global', log))
+    app.use('/api', tag('api', log))
+    app.router.add('GET', '/api/x', async () => new Response(''))
+    await app.fetch(new Request('http://x/api/x'))
+    expect(log).toEqual(['>global', '>api', '<api', '<global'])
+  })
+})
+
+describe('short-circuit + throw semantics', () => {
+  it('middleware that returns without next() prevents handler execution', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    let handlerRan = false
+    app.use(async () => new Response('gate', { status: 401 }))
+    app.router.add('GET', '/r', async () => {
+      handlerRan = true
+      return new Response('hi')
+    })
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('gate')
+    expect(handlerRan).toBe(false)
+  })
+
+  it('thrown error in middleware hits the error mapper', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.use(async () => {
+      throw new Error('boom')
+    })
+    app.router.add('GET', '/r', async () => new Response('hi'))
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.status).toBe(500)
+    expect(body.title).toBe('Internal Server Error')
+  })
+
+  it('middleware can wrap the downstream response', async () => {
+    const app = await createApp({
+      imports: [defineModule({ controllers: [HelloController] })],
+    })
+    app.use(async (_event, next) => {
+      const res = (await next()) as Response
+      const headers = new Headers(res.headers)
+      headers.set('x-wrapped', '1')
+      return new Response(res.body, { status: res.status, headers })
+    })
+    app.router.add('GET', '/r', async () => new Response('body'))
+    const res = await app.fetch(new Request('http://x/r'))
+    expect(res.headers.get('x-wrapped')).toBe('1')
+  })
+})
+
+describe('module middleware', () => {
+  it('applies only to that module\'s controllers, not imports', async () => {
+    const log: string[] = []
+    class CtrlA {}
+    class CtrlB {}
+    const inner = defineModule({
+      controllers: [CtrlA],
+      middleware: [tag('inner', log)],
+    })
+    const outer = defineModule({
+      imports: [inner],
+      controllers: [CtrlB],
+      middleware: [tag('outer', log)],
+    })
+    const app = await createApp({ imports: [outer] })
+    app.router.addForController(CtrlA, 'GET', '/a', async () => new Response('a'))
+    app.router.addForController(CtrlB, 'GET', '/b', async () => new Response('b'))
+
+    await app.fetch(new Request('http://x/a'))
+    expect(log).toEqual(['>inner', '<inner'])
+
+    log.length = 0
+    await app.fetch(new Request('http://x/b'))
+    expect(log).toEqual(['>outer', '<outer'])
+  })
+
+  it('runs after global middleware in execution order', async () => {
+    const log: string[] = []
+    class Ctrl {}
+    const mod = defineModule({
+      controllers: [Ctrl],
+      middleware: [tag('mod', log)],
+    })
+    const app = await createApp({ imports: [mod] })
+    app.use(tag('global', log))
+    app.router.addForController(Ctrl, 'GET', '/r', async () => {
+      log.push('handler')
+      return new Response('hi')
+    })
+
+    await app.fetch(new Request('http://x/r'))
+    expect(log).toEqual(['>global', '>mod', 'handler', '<mod', '<global'])
+  })
+
+  it('falls back to global-only when route has no associated controller', async () => {
+    const log: string[] = []
+    class Ctrl {}
+    const mod = defineModule({
+      controllers: [Ctrl],
+      middleware: [tag('mod', log)],
+    })
+    const app = await createApp({ imports: [mod] })
+    app.use(tag('global', log))
+    app.router.add('GET', '/loose', async () => new Response(''))
+    await app.fetch(new Request('http://x/loose'))
+    expect(log).toEqual(['>global', '<global'])
+  })
+})

--- a/packages/mint/test/mime-match.test.ts
+++ b/packages/mint/test/mime-match.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { matchMimeType } from '../src/mime'
+
+describe('matchMimeType', () => {
+  it('matches exact MIME types', () => {
+    expect(matchMimeType('image/png', ['image/png'])).toBe(true)
+    expect(matchMimeType('image/png', ['image/jpeg', 'image/png'])).toBe(true)
+  })
+
+  it('matches subtype wildcards', () => {
+    expect(matchMimeType('image/jpeg', ['image/*'])).toBe(true)
+    expect(matchMimeType('image/svg+xml', ['image/*'])).toBe(true)
+    expect(matchMimeType('text/html', ['text/*'])).toBe(true)
+  })
+
+  it('matches universal wildcards', () => {
+    expect(matchMimeType('application/pdf', ['*/*'])).toBe(true)
+    expect(matchMimeType('image/png', ['*/*'])).toBe(true)
+  })
+
+  it('rejects mismatched MIME types', () => {
+    expect(matchMimeType('text/plain', ['image/*'])).toBe(false)
+    expect(matchMimeType('image/png', ['image/jpeg'])).toBe(false)
+    expect(matchMimeType('image/png', [])).toBe(false)
+  })
+
+  it('strips parameters from the actual type before matching', () => {
+    expect(matchMimeType('text/plain; charset=utf-8', ['text/plain'])).toBe(true)
+    expect(matchMimeType('image/jpeg;quality=high', ['image/jpeg'])).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(matchMimeType('IMAGE/PNG', ['image/png'])).toBe(true)
+    expect(matchMimeType('Image/JPEG', ['image/*'])).toBe(true)
+  })
+
+  it('rejects empty actual', () => {
+    expect(matchMimeType('', ['image/*'])).toBe(false)
+  })
+
+  it('handles type-side wildcards', () => {
+    expect(matchMimeType('image/png', ['*/png'])).toBe(true)
+    expect(matchMimeType('image/png', ['*/jpeg'])).toBe(false)
+  })
+})

--- a/packages/mint/test/module-visibility.test.ts
+++ b/packages/mint/test/module-visibility.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { createApp } from '../src/app'
+import { defineModule } from '../src/module'
+import { defineToken } from '../src/token'
+
+describe('Module visibility', () => {
+  it('private providers are not visible to importing modules', async () => {
+    const SECRET = defineToken<string>('SECRET')
+    class Consumer {
+      static inject = [SECRET] as const
+      constructor(public secret: string) {}
+    }
+    const inner = defineModule({
+      providers: [{ provide: SECRET, useValue: 'shh' }],
+    })
+    const outer = defineModule({
+      imports: [inner],
+      providers: [Consumer],
+    })
+    await expect(createApp({ imports: [outer] })).rejects.toThrow(/visibility|SECRET/)
+  })
+
+  it('exports list makes the provider visible to importers', async () => {
+    const TOKEN = defineToken<string>('GREET')
+    class Consumer {
+      static inject = [TOKEN] as const
+      constructor(public greeting: string) {}
+    }
+    const inner = defineModule({
+      providers: [{ provide: TOKEN, useValue: 'hi' }],
+      exports: [TOKEN],
+    })
+    const outer = defineModule({
+      imports: [inner],
+      providers: [Consumer],
+    })
+    const app = await createApp({ imports: [outer] })
+    expect(app.resolve(Consumer).greeting).toBe('hi')
+  })
+
+  it('re-exports through chains require explicit export at every hop', async () => {
+    const TOKEN = defineToken<number>('VAL')
+    class Consumer {
+      static inject = [TOKEN] as const
+      constructor(public v: number) {}
+    }
+    const a = defineModule({
+      providers: [{ provide: TOKEN, useValue: 7 }],
+      exports: [TOKEN],
+    })
+    const b = defineModule({
+      imports: [a],
+    })
+    const c = defineModule({
+      imports: [b],
+      providers: [Consumer],
+    })
+    await expect(createApp({ imports: [c] })).rejects.toThrow(/visibility|VAL/)
+  })
+
+  it('re-exports through chains work when every hop exports', async () => {
+    const TOKEN = defineToken<number>('VAL2')
+    class Consumer {
+      static inject = [TOKEN] as const
+      constructor(public v: number) {}
+    }
+    const a = defineModule({
+      providers: [{ provide: TOKEN, useValue: 99 }],
+      exports: [TOKEN],
+    })
+    const b = defineModule({
+      imports: [a],
+      exports: [TOKEN],
+    })
+    const c = defineModule({
+      imports: [b],
+      providers: [Consumer],
+    })
+    const app = await createApp({ imports: [c] })
+    expect(app.resolve(Consumer).v).toBe(99)
+  })
+
+  it('rejects duplicate provider tokens across the flattened graph', async () => {
+    const TOKEN = defineToken<number>('DUP_X')
+    const a = defineModule({ providers: [{ provide: TOKEN, useValue: 1 }] })
+    const b = defineModule({ providers: [{ provide: TOKEN, useValue: 2 }] })
+    await expect(createApp({ imports: [a, b] })).rejects.toThrow(/duplicate/i)
+  })
+
+  it('rejects a missing token referenced by a consumer class', async () => {
+    const MISSING = defineToken<string>('NOT_THERE')
+    class Consumer {
+      static inject = [MISSING] as const
+      constructor(public x: string) {}
+    }
+    const m = defineModule({ providers: [Consumer] })
+    await expect(createApp({ imports: [m] })).rejects.toThrow(/NOT_THERE/)
+  })
+
+  it('a class can inject from its own module without exporting', async () => {
+    const TOKEN = defineToken<string>('INTERNAL')
+    class Consumer {
+      static inject = [TOKEN] as const
+      constructor(public v: string) {}
+    }
+    const m = defineModule({
+      providers: [{ provide: TOKEN, useValue: 'private' }, Consumer],
+    })
+    const app = await createApp({ imports: [m] })
+    expect(app.resolve(Consumer).v).toBe('private')
+  })
+
+  it('controllers are always globally registered (resolvable from app)', async () => {
+    class Ctrl {
+      ping() {
+        return 'pong'
+      }
+    }
+    const inner = defineModule({ controllers: [Ctrl] })
+    const outer = defineModule({ imports: [inner] })
+    const app = await createApp({ imports: [outer] })
+    expect(app.resolve(Ctrl).ping()).toBe('pong')
+  })
+})

--- a/packages/mint/test/multipart.test.ts
+++ b/packages/mint/test/multipart.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseMultipartStream,
+  MultipartByteLimitError,
+} from '../src/multipart'
+
+const BOUNDARY = 'X-TEST-BOUNDARY'
+
+function streamFromBytes(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  // Emit a few small chunks to exercise the boundary lookahead logic.
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const chunkSize = 17 // intentionally awkward
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        controller.enqueue(bytes.slice(i, i + chunkSize))
+      }
+      controller.close()
+    },
+  })
+}
+
+function buildMultipart(parts: Array<{
+  name: string
+  value: Uint8Array | string
+  filename?: string
+  type?: string
+}>): Uint8Array {
+  const enc = new TextEncoder()
+  const chunks: Uint8Array[] = []
+  for (const p of parts) {
+    chunks.push(enc.encode(`--${BOUNDARY}\r\n`))
+    let cd = `Content-Disposition: form-data; name="${p.name}"`
+    if (p.filename) cd += `; filename="${p.filename}"`
+    chunks.push(enc.encode(`${cd}\r\n`))
+    if (p.type) chunks.push(enc.encode(`Content-Type: ${p.type}\r\n`))
+    chunks.push(enc.encode(`\r\n`))
+    chunks.push(typeof p.value === 'string' ? enc.encode(p.value) : p.value)
+    chunks.push(enc.encode(`\r\n`))
+  }
+  chunks.push(enc.encode(`--${BOUNDARY}--\r\n`))
+  return concatBytes(chunks)
+}
+
+function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  let total = 0
+  for (const c of chunks) total += c.length
+  const out = new Uint8Array(total)
+  let off = 0
+  for (const c of chunks) {
+    out.set(c, off)
+    off += c.length
+  }
+  return out
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    if (value) chunks.push(value)
+  }
+  return concatBytes(chunks)
+}
+
+describe('parseMultipartStream', () => {
+  it('yields text and file parts in order', async () => {
+    const bytes = buildMultipart([
+      { name: 'title', value: 'hello world' },
+      {
+        name: 'avatar',
+        value: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+        filename: 'a.bin',
+        type: 'application/octet-stream',
+      },
+    ])
+    const iter = parseMultipartStream({
+      stream: streamFromBytes(bytes),
+      boundary: BOUNDARY,
+    })
+    const parts: Array<{ name: string; body: Uint8Array; type: string; filename?: string }> = []
+    for await (const part of iter) {
+      const body = await readAll(part.stream)
+      parts.push({ name: part.name, body, type: part.type, filename: part.filename })
+    }
+    expect(parts).toHaveLength(2)
+    expect(parts[0].name).toBe('title')
+    expect(new TextDecoder().decode(parts[0].body)).toBe('hello world')
+    expect(parts[1].name).toBe('avatar')
+    expect(parts[1].filename).toBe('a.bin')
+    expect(parts[1].type).toBe('application/octet-stream')
+    expect(Array.from(parts[1].body)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+  })
+
+  it('aborts a part that exceeds setLimit', async () => {
+    const big = new Uint8Array(1024)
+    for (let i = 0; i < big.length; i++) big[i] = i & 0xff
+    const bytes = buildMultipart([{ name: 'file', value: big, filename: 'f.bin' }])
+    const iter = parseMultipartStream({
+      stream: streamFromBytes(bytes),
+      boundary: BOUNDARY,
+    })
+    const { value: part } = await iter.next()
+    expect(part).toBeDefined()
+    iter.setLimit(100, 'body.file')
+
+    let err: unknown
+    try {
+      await readAll(part!.stream)
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeInstanceOf(MultipartByteLimitError)
+    if (err instanceof MultipartByteLimitError) {
+      expect(err.limit).toBe(100)
+      expect(err.path).toBe('body.file')
+    }
+  })
+
+  it('ignores trailing bytes after the final boundary', async () => {
+    const enc = new TextEncoder()
+    const base = buildMultipart([{ name: 'a', value: '1' }])
+    const trailing = enc.encode('garbage data should be ignored')
+    const combined = concatBytes([base, trailing])
+
+    const iter = parseMultipartStream({
+      stream: streamFromBytes(combined),
+      boundary: BOUNDARY,
+    })
+    const collected: Array<{ name: string; value: string }> = []
+    for await (const part of iter) {
+      const body = await readAll(part.stream)
+      collected.push({ name: part.name, value: new TextDecoder().decode(body) })
+    }
+    expect(collected).toEqual([{ name: 'a', value: '1' }])
+  })
+
+  it('handles multiple binary parts without buffering everything', async () => {
+    const a = new Uint8Array(32)
+    const b = new Uint8Array(48)
+    for (let i = 0; i < a.length; i++) a[i] = i
+    for (let i = 0; i < b.length; i++) b[i] = 255 - i
+    const bytes = buildMultipart([
+      { name: 'a', value: a, filename: 'a.bin' },
+      { name: 'b', value: b, filename: 'b.bin' },
+    ])
+    const iter = parseMultipartStream({
+      stream: streamFromBytes(bytes),
+      boundary: BOUNDARY,
+    })
+    const got: Record<string, Uint8Array> = {}
+    for await (const part of iter) {
+      got[part.name] = await readAll(part.stream)
+    }
+    expect(Array.from(got['a'])).toEqual(Array.from(a))
+    expect(Array.from(got['b'])).toEqual(Array.from(b))
+  })
+
+  it('treats parts whose body equals the source byte-by-byte', async () => {
+    // Verify boundary lookahead doesn't accidentally swallow content.
+    const value = new TextEncoder().encode('hi -- ' + 'X-TEST-BO ' + 'no boundary here')
+    const bytes = buildMultipart([{ name: 'a', value, filename: 'a.txt', type: 'text/plain' }])
+    const iter = parseMultipartStream({
+      stream: streamFromBytes(bytes),
+      boundary: BOUNDARY,
+    })
+    const { value: part } = await iter.next()
+    const body = await readAll(part!.stream)
+    expect(new TextDecoder().decode(body)).toBe(new TextDecoder().decode(value))
+  })
+})

--- a/packages/mint/test/router.test.ts
+++ b/packages/mint/test/router.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { Router } from '../src/router'
+import type { RouteHandler } from '../src/types'
+
+const noop: RouteHandler = async () => new Response('')
+
+describe('Router', () => {
+  it('matches a registered route', () => {
+    const r = new Router()
+    const handler: RouteHandler = async () => new Response('hi')
+    r.add('GET', '/hello', handler)
+
+    const m = r.match('GET', '/hello')
+    expect(m).toBeDefined()
+    expect(m!.handler).toBe(handler)
+  })
+
+  it('returns undefined for unknown path', () => {
+    const r = new Router()
+    r.add('GET', '/hello', noop)
+    expect(r.match('GET', '/missing')).toBeUndefined()
+  })
+
+  it('returns undefined for unknown method', () => {
+    const r = new Router()
+    r.add('GET', '/hello', noop)
+    expect(r.match('POST', '/hello')).toBeUndefined()
+  })
+
+  it('accepts arbitrary method strings such as WS', () => {
+    const r = new Router()
+    const handler: RouteHandler = async () => new Response('ws')
+    // Method slot is a free-form string, not a constrained union.
+    r.add('WS', '/socket', handler)
+    expect(r.match('WS', '/socket')!.handler).toBe(handler)
+  })
+})

--- a/packages/mint/test/router.test.ts
+++ b/packages/mint/test/router.test.ts
@@ -34,4 +34,51 @@ describe('Router', () => {
     r.add('WS', '/socket', handler)
     expect(r.match('WS', '/socket')!.handler).toBe(handler)
   })
+
+  it('extracts a single :param', () => {
+    const r = new Router()
+    const handler: RouteHandler = async () => new Response('ok')
+    r.add('GET', '/users/:id', handler)
+    const m = r.match('GET', '/users/42')
+    expect(m).toBeDefined()
+    expect(m!.params).toEqual({ id: '42' })
+  })
+
+  it('extracts multiple :params', () => {
+    const r = new Router()
+    r.add('GET', '/orgs/:org/users/:id', noop)
+    const m = r.match('GET', '/orgs/acme/users/7')
+    expect(m).toBeDefined()
+    expect(m!.params).toEqual({ org: 'acme', id: '7' })
+  })
+
+  it('does not match when segment counts differ', () => {
+    const r = new Router()
+    r.add('GET', '/users/:id', noop)
+    expect(r.match('GET', '/users')).toBeUndefined()
+    expect(r.match('GET', '/users/1/posts')).toBeUndefined()
+  })
+
+  it('does not bind an empty segment to a :param', () => {
+    const r = new Router()
+    r.add('GET', '/users/:id', noop)
+    expect(r.match('GET', '/users/')).toBeUndefined()
+  })
+
+  it('decodes URL-encoded :param values', () => {
+    const r = new Router()
+    r.add('GET', '/items/:name', noop)
+    const m = r.match('GET', '/items/hello%20world')
+    expect(m!.params).toEqual({ name: 'hello world' })
+  })
+
+  it('still serves static routes alongside :param routes', () => {
+    const r = new Router()
+    const staticH: RouteHandler = async () => new Response('s')
+    const paramH: RouteHandler = async () => new Response('p')
+    r.add('GET', '/users', staticH)
+    r.add('GET', '/users/:id', paramH)
+    expect(r.match('GET', '/users')!.handler).toBe(staticH)
+    expect(r.match('GET', '/users/42')!.handler).toBe(paramH)
+  })
 })

--- a/packages/mint/test/sse.test.ts
+++ b/packages/mint/test/sse.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { sse, type SSEMessage, type SSEStream } from '../src/sse'
+
+async function readAll(res: Response): Promise<string> {
+  // Use the body reader to avoid runtime-dependent helpers.
+  const reader = res.body!.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  out += decoder.decode()
+  return out
+}
+
+describe('sse()', () => {
+  it('sets text/event-stream headers and streams a Uint8Array body', async () => {
+    const res = sse<number>(async function* () {
+      yield 1
+    })
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
+    expect(res.headers.get('cache-control')).toBe('no-cache')
+    expect(res.headers.get('connection')).toBe('keep-alive')
+    expect(res.body).toBeInstanceOf(ReadableStream)
+  })
+
+  it('frames plain values as JSON data lines terminated by a blank line', async () => {
+    const res = sse<{ n: number }>(async function* () {
+      yield { n: 1 }
+      yield { n: 2 }
+      yield { n: 3 }
+    })
+    const text = await readAll(res)
+    expect(text).toBe(
+      'data: {"n":1}\n\n' + 'data: {"n":2}\n\n' + 'data: {"n":3}\n\n',
+    )
+  })
+
+  it('emits event/id/retry/data lines for SSEMessage objects', async () => {
+    const res = sse<{ tick: number }>(async function* () {
+      const msg: SSEMessage<{ tick: number }> = {
+        data: { tick: 7 },
+        event: 'tick',
+        id: '1',
+        retry: 2500,
+      }
+      yield msg
+    })
+    const text = await readAll(res)
+    expect(text).toContain('event: tick\n')
+    expect(text).toContain('id: 1\n')
+    expect(text).toContain('retry: 2500\n')
+    expect(text).toContain('data: {"tick":7}\n')
+    expect(text.endsWith('\n\n')).toBe(true)
+  })
+
+  it('closes cleanly when the generator returns', async () => {
+    const res = sse<number>(async function* () {
+      yield 1
+      return
+    })
+    const text = await readAll(res)
+    expect(text).toBe('data: 1\n\n')
+  })
+
+  it("calls generator.return() so finally blocks run when the consumer cancels", async () => {
+    let cleaned = 0
+    let yielded = 0
+    const res = sse<number>(async function* () {
+      try {
+        while (true) {
+          yielded++
+          yield yielded
+          // Cooperative pause so the consumer can cancel before we loop again.
+          await new Promise<void>((r) => setTimeout(r, 0))
+        }
+      } finally {
+        cleaned++
+      }
+    })
+    const reader = res.body!.getReader()
+    const first = await reader.read()
+    expect(first.done).toBe(false)
+    await reader.cancel()
+    // Give the generator one tick to run its finally block.
+    await new Promise<void>((r) => setTimeout(r, 10))
+    expect(cleaned).toBe(1)
+  })
+
+  it('terminates without a half-finished frame when the generator throws', async () => {
+    const res = sse<number>(async function* () {
+      yield 1
+      throw new Error('boom')
+    })
+    const reader = res.body!.getReader()
+    const decoder = new TextDecoder()
+    const first = await reader.read()
+    expect(first.done).toBe(false)
+    expect(decoder.decode(first.value!)).toBe('data: 1\n\n')
+    // The second read surfaces the throw — there is no partial frame in the
+    // buffer because the error was raised at a frame boundary.
+    await expect(reader.read()).rejects.toThrow('boom')
+  })
+
+  it('compiles with a typed event payload via SSEStream<T>', () => {
+    // Compile-time check only: the call expression must type-check and the
+    // phantom SSEStream<T> alias must exist as an exported type.
+    type Tick = { type: 'tick'; ts: number }
+    const _typed: () => Response = () =>
+      sse<Tick>(async function* () {
+        yield { type: 'tick', ts: 0 }
+      })
+    const _phantom: SSEStream<Tick> | undefined = undefined
+    expect(typeof _typed).toBe('function')
+    expect(_phantom).toBeUndefined()
+  })
+})

--- a/packages/mint/tsconfig.json
+++ b/packages/mint/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mint/tsdown.config.ts
+++ b/packages/mint/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  platform: 'node',
+  target: 'node18',
+})

--- a/packages/types/src/tags.ts
+++ b/packages/types/src/tags.ts
@@ -427,3 +427,52 @@ export type Uint = Type<"uint32">;
 
 /** number & Type<"double"> */
 export type Double = Type<"double">;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// File upload constraints
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Maximum byte size for a `File` or `FileStream`.
+ * @example MaxSize<5_000_000>  // 5MB
+ * @example MaxSize<{value: 5_000_000, error: "File too large"}>
+ */
+export type MaxSize<N extends number | { value: number; error?: string }> =
+  N extends { value: infer V extends number; error: infer E extends string }
+    ? { readonly __tsgonest_maxSize?: V; readonly __tsgonest_maxSize_error?: E }
+    : { readonly __tsgonest_maxSize?: N extends { value: infer V } ? V : N };
+
+/**
+ * Minimum byte size for a `File` or `FileStream`.
+ * @example MinSize<1>
+ */
+export type MinSize<N extends number | { value: number; error?: string }> =
+  N extends { value: infer V extends number; error: infer E extends string }
+    ? { readonly __tsgonest_minSize?: V; readonly __tsgonest_minSize_error?: E }
+    : { readonly __tsgonest_minSize?: N extends { value: infer V } ? V : N };
+
+/**
+ * Allowed MIME types for a `File` or `FileStream`. Accepts a union of string
+ * literals; values like `'image/*'` match any image subtype.
+ * @example MimeTypes<'image/png' | 'image/jpeg'>
+ * @example MimeTypes<'image/*'>
+ */
+export type MimeTypes<U extends string> = {
+  readonly __tsgonest_mimeTypes?: U;
+};
+
+/**
+ * A streaming file upload from `multipart/form-data`. Distinct from `File`
+ * (which is buffered) — tsgonest emits a streaming parser when a body field
+ * is typed as `FileStream`. `MaxSize` is enforced incrementally as bytes flow.
+ *
+ * The `stream` property is consumed by the handler; reading past `MaxSize`
+ * causes the read to reject with a typed error.
+ */
+export interface FileStream {
+  readonly name: string;
+  readonly type: string;
+  readonly stream: ReadableStream<Uint8Array>;
+  /** Phantom marker the analyzer reads to distinguish from `File`. */
+  readonly __tsgonest_fileStream?: true;
+}

--- a/plans/mint-plan.md
+++ b/plans/mint-plan.md
@@ -1,0 +1,332 @@
+# Plan: Mint — tiny web framework for Bun
+
+> Brand: **Mint**. Core package: `@mintkit/core`. Bun adapter: `@mintkit/bun`.
+> Source PRD: [`../.scratch/mint/PRD.md`](../.scratch/mint/PRD.md)
+> Companion technical spec: [`mint-spec.md`](./mint-spec.md)
+> Implementation issues: [`../.scratch/mint/issues/`](../.scratch/mint/issues/)
+
+12 phases. Each phase is a vertical tracer bullet through compile-time (tsgonest analyzer + codegen extensions) and runtime (Mint package) and Bun execution. Each phase is independently demoable.
+
+## Architectural decisions
+
+Durable decisions that apply across every phase:
+
+- **Package layout**: Mint's core lives at `packages/mint` with npm name `@mintkit/core`. The Bun adapter (vendored/shadcn-style) lives at `packages/mint-bun` with npm name `@mintkit/bun`. Compile-time extensions live in the existing Go module (`internal/analyzer`, `internal/codegen`) alongside the current NestJS support — additive, not a fork.
+- **Runtime target**: Bun. `app.fetch(Request): Promise<Response>` is the universal entry point. v1 also ships a single vendored adapter package providing `wrap(app)`, `BUN_SERVER` token, and `gracefulShutdown` helper.
+- **Decorator vocabulary**: `@Controller(path)`, HTTP verb decorators (`@Get`/`@Post`/`@Put`/`@Patch`/`@Delete`/`@Head`/`@Options`), parameter decorators (`@Body`, `@Query`, `@Param`, `@Headers`, `@Ctx`), middleware attach (`@UseMiddleware`), DI (`@Injectable`, `@Inject`). Recognized via import path. Factory-wrapped decorators are unsupported (existing tsgonest constraint).
+- **WS reservations baked in from Phase 1**:
+  - Middleware/handler return type is `Response | Upgrade` (`Upgrade` is reserved; never produced in v1).
+  - Router method slot is a free-form string (`'WS'` registers without code changes when added).
+  - `TokenStore` is a shared interface that `Event` implements; future `Session` will implement the same surface.
+  - Validator codegen consumes "source bytes" rather than "HTTP request body" — framing-agnostic from day one.
+- **Web standards as primitive**: `Request`, `Response`, `Headers`, `File`, `Blob`, `FormData`, `ReadableStream`. The framework wraps Web primitives only where wrapping solves a real problem (`event.body` memoization).
+- **Error contract**: throw-only. Default mapper produces RFC 9457 `application/problem+json` for `TsgonestValidationError`, status-keyed JSON for `HttpError` subclasses, generic 500 for everything else. Users register custom mappings via `app.onError`.
+- **DI scope**: singleton (default) and transient only. No request scope, no child containers, no `forwardRef`.
+- **Boot semantics**: async, fail-fast, partial-dispose on init failure. Boot follows a fixed six-step sequence (flatten → validate → construct → init → register routes → ready).
+- **Lifecycle interfaces**: `OnInit` (framework-defined) and `AsyncDisposable` (TC39 standard `Symbol.asyncDispose`). Duck-typed at runtime.
+- **TypeScript**: 5.2+ at the consumer (for `using` / `await using`).
+- **Test stack**: Vitest for TS modules (continuing the `packages/runtime/test` pattern), Go unit tests for analyzer/codegen (continuing the `internal/*/_test.go` pattern with `testdata/` fixtures), e2e tests that build the binary and run controllers in a Bun subprocess (continuing the `e2e/compile.test.ts` pattern).
+
+---
+
+## Phase 1: Hello World
+
+**User stories**: 2, 30, 31, 35, 36, 50.
+
+### What to build
+
+A user can write a single TypeScript file with one class decorated `@Controller('/hello')` containing one method decorated `@Get()` that returns a string. Running `tsgonest build` extends the existing pipeline to:
+
+- Recognize Mint's decorators by import path (`@mintkit/core`).
+- Emit a companion file with a `register…Controller(app)` export wiring the route into Mint's router.
+- Include the route in the generated `openapi.json`.
+
+The user writes a `main.ts` that creates a single module with that controller, calls `await createApp({ imports: [...] })`, hands `app.fetch` to `Bun.serve`, and `curl http://localhost:3000/hello` returns the string with a 200.
+
+This phase establishes the entire compile-time → runtime seam end-to-end. Every subsequent phase is incremental thickening.
+
+### Acceptance criteria
+
+- [ ] `@mintkit/core` package exists at `packages/mint` with `createApp`, `defineModule`, and the public decorator surface.
+- [ ] tsgonest analyzer recognizes Mint's decorators (resolved via `@mintkit/core` import path) without breaking existing NestJS support.
+- [ ] tsgonest codegen emits a `register…Controller(app)` export per controller in the existing `*.tsgonest.js` companion files.
+- [ ] Router accepts method + path registration and matches on incoming `Request`.
+- [ ] `Event` exposes at minimum the raw `Request`; handler return value is serialized to a `Response`.
+- [ ] Container constructs the controller (no deps in this phase) and resolves it for each request.
+- [ ] `createApp` returns a `Promise<App>`; `app.fetch(Request): Promise<Response>` works.
+- [ ] Middleware/handler return type is typed `Response | Upgrade` (Upgrade never produced).
+- [ ] Router method slot is `string` (not a constrained verb union).
+- [ ] OpenAPI 3.2 document includes the route.
+- [ ] E2E: build a fixture project, boot in Bun, `curl /hello` returns the expected body.
+- [ ] Unit tests: container resolve, router add/match, decorator analyzer fixture, codegen fixture.
+
+---
+
+## Phase 2: Typed parameters and validated returns
+
+**User stories**: 3, 4, 53, 55, 56.
+
+### What to build
+
+The user can declare `@Body() body: SomeDto`, `@Query() q: ListQuery`, `@Param('id') id: string & tags.UUID`, and `@Headers('x-foo') header: string` on handler methods. tsgonest's existing validator/serializer generation is reused: parameter types feed the existing analyzer; the codegen's `register…Controller(app)` wrapper invokes the validators before calling the handler and the serializer on the return value. Validation failures throw `TsgonestValidationError`; the framework's error mapper converts that to RFC 9457 `application/problem+json` with per-field detail.
+
+OpenAPI emits request/response schemas for these parameters from the same type metadata.
+
+### Acceptance criteria
+
+- [ ] `@Body`/`@Query`/`@Param`/`@Headers` parameters are extracted from the request and validated against their TypeScript types before the handler runs.
+- [ ] Validators and serializers are the existing tsgonest-generated ones (no fork).
+- [ ] Return values are serialized via generated fast-JSON serializers; response `Content-Type` is `application/json`.
+- [ ] Validation failure produces a `400 application/problem+json` response with `type`/`title`/`status`/`detail`/`errors` per RFC 9457.
+- [ ] OpenAPI generates request/response schemas matching the declared types.
+- [ ] E2E: round-trip a typed body (valid → 200 with serialized return, invalid → 400 with problem-details).
+- [ ] Unit tests cover analyzer recognition of each parameter decorator and codegen wrapper shape.
+
+---
+
+## Phase 3: Dependency injection and dynamic modules
+
+**User stories**: 1, 6, 7, 40, 41.
+
+### What to build
+
+Users can mark classes `@Injectable()` and inject them via constructor. Providers can be declared in three forms within `defineModule({ providers: [...] })`:
+
+- Class shorthand (the class is the token).
+- `{ provide: TOKEN, useValue }`.
+- `{ provide: TOKEN, useFactory, inject?: [...], scope?: 'singleton' | 'transient' }` — the factory's deps come from the same container.
+
+Tokens are typed via `defineToken<T>(name)` and produce `Token<T>` instances with a phantom generic. Class references are themselves valid tokens. `@Inject(TOKEN)` parameter decorator injects non-class tokens into constructors. Container builds the dependency graph in topological order.
+
+Dynamic modules are functions: `StorageModule(opts): Module` and `StorageModuleAsync({ inject, useFactory }): Module`. Both return the same plain-object module shape.
+
+### Acceptance criteria
+
+- [ ] `defineToken<T>(name)` returns a typed `Token<T>`; class refs are valid tokens.
+- [ ] `@Injectable({ scope? })` decorator is recognized; default scope is singleton.
+- [ ] All three provider forms register and resolve correctly.
+- [ ] Constructor injection works for classes; `@Inject(TOKEN)` resolves non-class deps.
+- [ ] Transient providers return a fresh instance on every resolve; singletons are cached.
+- [ ] `useFactory` providers can declare async factories (`Promise<T>` return); await happens during boot.
+- [ ] Dynamic module functions (sync and async-factory shapes) compose with `imports: [Module(opts), ModuleAsync({...})]` at the app level.
+- [ ] E2E: a controller injects a service that depends on a useFactory-provided config token; the full chain resolves and the endpoint returns config-derived data.
+- [ ] Unit tests cover topological construction order, transient vs singleton semantics, and all three provider forms.
+
+---
+
+## Phase 4: Middleware and the token store
+
+**User stories**: 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 30, 32, 57, 58, 59, 62, 63.
+
+### What to build
+
+Function-only middleware shaped as `(event, next) => Promise<Response | Upgrade>`. Four attach points, all wiring into the same flat chain:
+
+- `app.use(mw)` and `app.use('/prefix', mw)` — global and prefix-mounted.
+- `defineModule({ middleware: [...] })` — applies to the module's declared controllers; no cascade to imports.
+- `@UseMiddleware(mw)` on a controller class — every method in the controller.
+- `@UseMiddleware(mw)` on a method — single route.
+
+Execution is outer-to-inner across layers, registration order within each layer.
+
+`Event` gains its full surface: token store (`set`/`get`/`require`), memoized `body` accessor with `bytes`/`text`/`json`/`formData` cached and `stream` single-use, mutable `response.headers` (Web `Headers` instance) and `response.status` (number), `waitUntil`, and `resolve` for DI access.
+
+`@Ctx(TOKEN) name: T` parameter decorator extracts token-stored values into handler signatures with compile-time type checking against the token's `T`.
+
+### Acceptance criteria
+
+- [ ] All four middleware attach points register and execute in the documented order.
+- [ ] `await next()` returns the downstream response; middleware can wrap (modify headers/status, transform body via new Response).
+- [ ] Short-circuit by returning a Response without calling `next()`.
+- [ ] Thrown errors in middleware propagate and hit the error mapper.
+- [ ] `event.set(TOKEN, value)` / `event.get(TOKEN)` / `event.require(TOKEN)` are type-checked against the token's `T`; `require` throws if not set.
+- [ ] `event.body` memoizes `bytes`/`text`/`json`/`formData`; `event.body.stream()` errors if the body has already been consumed.
+- [ ] `event.response.headers` is a `Headers` instance; `event.response.status` is a settable number.
+- [ ] `event.waitUntil(promise)` is callable; on Bun it is a fire-and-forget that runs to completion after response.
+- [ ] `@Ctx(TOKEN) user: User` produces a compile-time diagnostic if the parameter type does not match the token's `T`.
+- [ ] Module-level middleware does **not** cascade to imported modules' controllers.
+- [ ] E2E: a request flows through global + module + controller + method middleware in the correct order; an auth middleware sets a token and a handler reads it via `@Ctx`.
+- [ ] Unit tests cover chain composition order, short-circuit, throw propagation, body memoization semantics, and type-store behavior.
+
+---
+
+## Phase 5: Errors
+
+**User stories**: 4, 27, 28, 29.
+
+### What to build
+
+The `HttpError` hierarchy is shipped: `BadRequestError`, `UnauthorizedError`, `ForbiddenError`, `NotFoundError`, `ConflictError`, `UnprocessableEntityError`, `TooManyRequestsError`, `InternalServerError` — each carries a status and a JSON body. Default error mapper maps `HttpError` subclasses to JSON responses with the carried status, maps `TsgonestValidationError` to RFC 9457 problem-details (already in Phase 2), and falls through to status 500 for unknown errors (with the full error logged, not leaked to the response).
+
+`app.onError(predicate, handler)` registers user-defined mappings. User handlers take precedence over defaults; first match wins.
+
+### Acceptance criteria
+
+- [ ] `HttpError` base class and all listed subclasses exist with correct status codes.
+- [ ] Throwing an `HttpError` subclass from a handler produces a Response with the carried status and body.
+- [ ] `app.onError` registered handlers run before defaults; first match wins.
+- [ ] Unmatched throws produce a 500 problem-details JSON; the underlying error is logged.
+- [ ] E2E: a controller throws a custom domain error; an `app.onError` registration maps it to a `409 Conflict`.
+- [ ] Unit tests cover precedence between user handlers and defaults, and the 500 fallthrough.
+
+---
+
+## Phase 6: Lifecycle and graceful shutdown
+
+**User stories**: 8, 9, 10, 11, 47, 48, 50.
+
+### What to build
+
+Providers can implement `OnInit` (`init(): void | Promise<void>`) and/or `AsyncDisposable` (`[Symbol.asyncDispose](): PromiseLike<void>`). Container duck-types both at runtime. Boot runs `init()` after all construction, in topological order. If any `init()` throws, the framework disposes already-initialized providers in reverse topological order and rejects `createApp`. Cycles between providers throw at boot with the cycle path printed.
+
+`app[Symbol.asyncDispose]()` stops accepting new requests, drains in-flight requests, then runs each provider's `Symbol.asyncDispose` in reverse topological order.
+
+This phase nails the runtime lifecycle. The Bun-side SIGTERM trigger is wired in Phase 12.
+
+### Acceptance criteria
+
+- [ ] `OnInit` interface is exported; providers implementing `init()` have it called after construction.
+- [ ] `Symbol.asyncDispose` on providers is called on app shutdown.
+- [ ] Construction order is topological; init order is topological; dispose order is reverse-topological.
+- [ ] Failed `init()` triggers reverse-topo dispose of already-initialized providers and rejects `createApp`.
+- [ ] Boot detects provider cycles and throws with the cycle path before any provider construction.
+- [ ] `app[Symbol.asyncDispose]()` drains in-flight requests (long handlers complete) before disposing providers.
+- [ ] Unit tests cover topological vs reverse-topological order, partial-dispose on init failure, and cycle detection.
+
+---
+
+## Phase 7: Module visibility and boot validation
+
+**User stories**: 5, 49, 51, 52, 54.
+
+### What to build
+
+Module resolver enforces visibility rules: providers are private to their declaring module unless listed in `exports`. Importing module A from module B does not auto-leak A's providers; if B wants to re-export A's provider, it must list it in B's `exports`. Controllers are always globally registered.
+
+Boot-time validation:
+
+- Detect duplicate provider tokens across the flattened graph; error with both declaring modules named.
+- Detect cycles between modules and between providers.
+- Verify every `@Inject(TOKEN)` resolves to a visible provider; error with the consumer and unresolved token.
+
+No glob / auto-discovery. All imports are explicit.
+
+### Acceptance criteria
+
+- [ ] Private-by-default providers: importing module A in module B does not let B's providers inject A's non-exported services.
+- [ ] `exports` lists make providers visible to importers.
+- [ ] Re-exports through chains (A imports B, A exports B's token) are explicit and required for transitive visibility.
+- [ ] Duplicate tokens across the flattened module graph throw at boot with both source modules in the message.
+- [ ] Unresolved `@Inject(TOKEN)` references throw at boot with consumer + token info.
+- [ ] No file-system / glob-based module loading anywhere in the boot path.
+- [ ] Unit tests cover all visibility scenarios (private, exported, re-exported, leak attempt) and each validation error class.
+
+---
+
+## Phase 8: Headless context
+
+**User stories**: 33, 34, 35, 64.
+
+### What to build
+
+`createContext({ imports }): Promise<Context>` returns a `Context` with `resolve` and `Symbol.asyncDispose` — no router, no fetch, no middleware. Useful for CLIs, queue consumers, cron, migrations, tests. `App extends Context` so helpers written against `Context` work in `App` too. Controllers in modules used by `createContext` are silently ignored (no warnings).
+
+`await using` is the canonical pattern for short-lived contexts; auto-dispose on scope exit, even on throw.
+
+### Acceptance criteria
+
+- [ ] `createContext({ imports })` exists and resolves to a `Context` with `resolve` and `Symbol.asyncDispose`.
+- [ ] `Context` shares the same module/provider/lifecycle plumbing as `createApp` (no duplication).
+- [ ] `App extends Context` structurally; helpers typed against `Context` work inside `createApp` returns.
+- [ ] Controllers in imported modules are accepted but unused when boot is via `createContext`.
+- [ ] E2E: a CLI fixture using `await using ctx = await createContext(...)` runs a service method and exits with provider dispose having fired.
+- [ ] Unit tests cover `createContext` boot, `App extends Context` structural compatibility, and `await using` integration.
+
+---
+
+## Phase 9: File uploads (buffered)
+
+**User stories**: 24.
+
+### What to build
+
+Users declare `@Body() data: { title: string; image: File & MaxSize<5_000_000> & MimeTypes<'image/png' | 'image/jpeg'> }` on a handler. tsgonest analyzer recognizes the `File` type and the new tag constraints. Codegen generates a multipart parser that reads `event.body.formData()`, extracts each named entry, validates `File` entries against `MaxSize`/`MinSize`/`MimeTypes`, and throws `TsgonestValidationError` on violation. Handler receives Web standard `File` instances.
+
+New tag types in `@tsgonest/types`: `MaxSize<N>`, `MinSize<N>`, `MimeTypes<U>` (with wildcard support like `'image/*'`).
+
+### Acceptance criteria
+
+- [ ] `File`, `MaxSize<N>`, `MinSize<N>`, `MimeTypes<U>` types are added to `@tsgonest/types` (or runtime types) and recognized by the analyzer.
+- [ ] Wildcard MIME patterns (`'image/*'`) match correctly.
+- [ ] `@Body()` with file fields parses multipart via `event.body.formData()`, validates per-file constraints, and passes `File` instances to the handler.
+- [ ] Validation failure produces an RFC 9457 problem-details response with per-field detail.
+- [ ] Array fields (`photos: Array<File & ...>`) parse and validate as a list.
+- [ ] OpenAPI emits `multipart/form-data` request body schemas for these routes.
+- [ ] E2E: round-trip a buffered file upload (valid → 200, oversize → 400, wrong MIME → 400).
+- [ ] Analyzer/codegen unit tests cover the new types and the generated parser shape.
+
+---
+
+## Phase 10: File uploads (streaming)
+
+**User stories**: 24, 25.
+
+### What to build
+
+Users declare `@Body() data: { filename: string; file: FileStream & MaxSize<5_000_000_000> }`. `FileStream` is distinct from `File` and signals streaming parse. Codegen emits a streaming multipart parser (a runtime-shipped utility) that reads `event.body.stream()`, yields each field as it arrives, and aborts the connection when a `FileStream`'s incremental byte count exceeds `MaxSize`. The handler receives `FileStream { name, type, stream }` where `stream` is a `ReadableStream<Uint8Array>`.
+
+### Acceptance criteria
+
+- [ ] `FileStream` type exists and is recognized by the analyzer as distinct from `File`.
+- [ ] A multipart streaming parser ships in the runtime (or framework package) and reads from a `ReadableStream<Uint8Array>` source.
+- [ ] When any `FileStream` field exceeds its `MaxSize` mid-stream, the connection aborts and a 413 (or comparable problem-details) response is sent.
+- [ ] Memory usage during a multi-GB upload stays bounded (verified via integration test or a documented design constraint).
+- [ ] Mixed multipart (string fields + streaming files) parses correctly without buffering the entire body.
+- [ ] E2E: stream a large file to disk via the handler, then assert the file on disk matches the input; oversize uploads abort early.
+- [ ] Unit tests cover the parser's boundary detection, field dispatch, and abort semantics.
+
+---
+
+## Phase 11: SSE
+
+**User stories**: 26.
+
+### What to build
+
+A core runtime helper `sse<T>(generator: () => AsyncGenerator<T>): Response` returns a streaming `Response` with `text/event-stream` content type and proper SSE framing (`data: <json>\n\n`). Typed via `SSEStream<T>` so the existing `@Returns<SSEStream<T>>` pattern in tsgonest picks up the event type for OpenAPI/SDK generation.
+
+Handlers return `sse(async function* () { yield ...; })` or are typed as `Promise<SSEStream<EventType>>`.
+
+### Acceptance criteria
+
+- [ ] `sse()` helper exists in the runtime package and produces a correctly framed SSE response.
+- [ ] `SSEStream<T>` type is recognized by the analyzer; OpenAPI emits the event payload schema using the existing `@Returns<T>` machinery.
+- [ ] Generators can yield, await between yields, and close the stream by returning.
+- [ ] Client disconnects propagate to the generator (abort signal in the response stream).
+- [ ] E2E: connect a Bun client to an SSE endpoint, receive at least N events in framed form, disconnect, verify the generator cleanup runs.
+- [ ] Unit tests cover framing correctness and abort propagation.
+
+---
+
+## Phase 12: Bun adapter — `@mintkit/bun` (vendored package)
+
+**User stories**: 37, 38, 45, 46.
+
+### What to build
+
+A single vendored package at `packages/mint-bun` (npm name `@mintkit/bun`), intended to be copy-pasted into user repos under the shadcn philosophy, providing:
+
+- `wrap(app): { fetch }` — for users who need access to Bun's `Server` instance. Injects `BUN_SERVER` token onto each event before `app.fetch` runs.
+- `BUN_SERVER` token — typed reference to Bun's `Server` (e.g., for future WebSocket upgrades or socket inspection).
+- `gracefulShutdown(app, opts?)` helper — wires SIGTERM/SIGINT (configurable) to `app[Symbol.asyncDispose]()` with a configurable drain timeout.
+
+Zero-config users continue to write `Bun.serve({ fetch: app.fetch })`. The adapter is only needed when platform features are wanted.
+
+### Acceptance criteria
+
+- [ ] `@mintkit/bun` package exists at `packages/mint-bun` with `wrap`, `BUN_SERVER`, and `gracefulShutdown` exports.
+- [ ] `wrap(app)` returns a `{ fetch }` handler that injects `BUN_SERVER` on each event before delegating to `app.fetch`.
+- [ ] `BUN_SERVER` token resolves to Bun's `Server` inside handlers/middleware via `event.require(BUN_SERVER)`.
+- [ ] `gracefulShutdown` registers the configured signal handlers, calls `app[Symbol.asyncDispose]()`, enforces the timeout (hard-exits if drain exceeds).
+- [ ] E2E: SIGTERM during in-flight requests drains them, fires provider dispose in reverse-topo, and exits cleanly within the timeout window.
+- [ ] Documentation in the adapter's README walks through the canonical wiring and the customization points users are expected to edit.

--- a/plans/mint-spec.md
+++ b/plans/mint-spec.md
@@ -1,0 +1,646 @@
+# Mint — Technical Spec
+
+A tiny web framework — DI + modules + routing — built on tsgonest's compile-time pipeline, targeting Bun.
+
+- **Brand:** Mint.
+- **Core package:** `@mintkit/core` (workspace dir `packages/mint`).
+- **Bun adapter package:** `@mintkit/bun` (workspace dir `packages/mint-bun`, vendored/shadcn-style).
+- **Source PRD:** [`../.scratch/mint/PRD.md`](../.scratch/mint/PRD.md).
+- **Implementation plan:** [`./mint-plan.md`](./mint-plan.md).
+
+This document is the technical specification: API surfaces, contracts, runtime semantics. The PRD covers the "why" and the user stories; this covers the "how."
+
+---
+
+## Scope
+
+- **Runtime target (v1):** Bun. No Node, Workers, Deno, or Lambda adapters in v1.
+- **TypeScript:** 5.2+ at the consumer (required for `using` / `await using`).
+- **Compile-time:** tsgonest's existing pipeline, extended additively.
+- **Deferred (with reservations):** WebSockets, additional platform adapters, AsyncAPI, shadcn CLI.
+
+---
+
+## Core invariants
+
+These hold across the entire framework. Every other decision derives from them.
+
+1. **Web standards are the lingua franca.** `Request`, `Response`, `Headers`, `File`, `Blob`, `FormData`, `ReadableStream` are first-class. The framework wraps Web primitives only where wrapping solves a real problem (`event.body` memoization).
+2. **Decorators are compile-time only.** All framework decorators are statically analyzed by tsgonest and erased at runtime. The runtime does not depend on `reflect-metadata`.
+3. **Throw-based error contract.** Handlers and middleware throw to fail; the error mapper converts throws to Responses. No `Result` types in core.
+4. **Singleton + transient scope only.** No request scope, no per-connection scope, no child containers.
+5. **`createApp` is async; boot is fail-fast.** Partial-init states are not observable from outside.
+6. **WS-additive reservations.** Middleware/handler return type is `Response | Upgrade`. Router method is a free-form string. Token store is a shared interface. Compile-time validator codegen is framing-agnostic.
+
+---
+
+## Module layout
+
+13 modules. The first four are deep modules (algorithmic, isolatable, simple interfaces, change rarely).
+
+### Deep core
+
+1. **Container** — DI/provider resolution.
+2. **Module resolver** — flatten/dedupe/validate the module graph.
+3. **Router** — radix tree, method + path matching.
+4. **Middleware chain** — onion composition across four attach points.
+
+### Runtime state
+
+5. **Event** — per-request state; raw `request`, memoized `body`, mutable `response`, token store, `waitUntil`, `resolve`.
+6. **Error mapper** — pluggable throw → Response mapping; defaults for `HttpError` and `TsgonestValidationError`.
+7. **App / Context factory** — boot orchestration, lifecycle, `Symbol.asyncDispose`.
+
+### Compile-time (extensions to tsgonest)
+
+8. **Decorator analyzer extension** — recognize new decorators in the existing analyzer pipeline.
+9. **Route registration codegen** — emit `registerXxxController(app)` exports in `*.tsgonest.js` companions.
+
+### Runtime utilities
+
+10. **`sse()` helper** — async generator → SSE-framed Response.
+11. **`HttpError` hierarchy** — typed status-carrying error classes.
+12. **Public primitives** — `defineToken`, `defineModule`, `defineHandler`, `defineMiddleware`.
+
+### Vendored (shadcn-style, single package)
+
+13. **Bun adapter** — `wrap(app)`, `BUN_SERVER` token, `gracefulShutdown` helper.
+
+---
+
+## Container
+
+### Token
+
+```ts
+class Token<T> {
+  declare readonly _type: T;  // phantom, never assigned at runtime
+  constructor(public readonly name: string) {}
+}
+
+function defineToken<T>(name: string): Token<T>;
+```
+
+A class reference is itself a valid `Token<InstanceType<C>>` — class providers are registered under the class as the token.
+
+### Provider forms
+
+```ts
+type Provider<T = unknown> =
+  | (new (...args: any[]) => T)                                              // class shorthand
+  | { provide: Token<T>; useValue: T }                                       // value
+  | { provide: Token<T>; useFactory: (...deps: any[]) => T | Promise<T>;     // factory
+      inject?: Array<Token<any>>; scope?: 'singleton' | 'transient' };
+```
+
+Class providers carry their scope via `@Injectable({ scope?: 'singleton' | 'transient' })` decorator (default singleton).
+
+### Resolution
+
+```ts
+interface Container {
+  resolve<T>(token: Token<T>): T;  // throws if not registered
+}
+```
+
+- **Singleton** (default): construct on first resolve, cache for the container's lifetime.
+- **Transient**: construct on every resolve; never cached.
+
+### Boot ordering
+
+Providers are constructed in topological order (deps before dependents). `init()` runs in the same topological order after all construction completes. Dispose runs reverse-topologically.
+
+### Cycle detection
+
+Performed at boot. Throws with the full cycle path. No `forwardRef`.
+
+### What's not supported (v1)
+
+- `useExisting` (express as a factory)
+- Multi-providers
+- String-keyed tokens
+- Function-shape providers (`defineService((deps) => ({...}))`)
+- Child containers / per-context scopes
+
+---
+
+## Module resolver
+
+### Module shape
+
+```ts
+function defineModule(config: {
+  imports?:     Module[];
+  providers?:   Provider[];
+  exports?:     Token<any>[];
+  controllers?: ControllerConstructor[];
+  middleware?:  Middleware[];
+}): Module;
+```
+
+`Module` is a plain object; `defineModule` is a typed pass-through.
+
+### Dynamic modules
+
+Functions returning `Module`. There is no `DynamicModule` class.
+
+```ts
+function StorageModule(opts: StorageOptions): Module;
+function StorageModuleAsync(opts: {
+  inject: Token<any>[];
+  useFactory: (...deps: any[]) => Promise<StorageOptions> | StorageOptions;
+}): Module;
+```
+
+### Visibility rules
+
+- Providers are **private to the declaring module** unless listed in `exports`.
+- Controllers are **always globally registered** (URL paths are global; scoping them by module would not help).
+- Module-level `middleware` binds to **this module's `controllers` only**. Imported modules carry their own bindings; **no cascade to imports**.
+- Re-exports through chains are explicit (A imports B, A lists B's token in `exports`, then A's importers can see it).
+
+### Validation at boot
+
+- No duplicate provider tokens across the flattened graph (error: list both declaring modules).
+- No cycles between providers (error: print cycle path).
+- Every `@Inject(TOKEN)` resolves to a visible provider (error: token name + consumer).
+- No glob / auto-discovery.
+
+---
+
+## Router
+
+Radix tree. Method slot is a free-form string (`'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'WS' | ...`). Param extraction by name (`/:id`).
+
+```ts
+interface Router {
+  add(method: string, path: string, handler: RouteHandler): void;
+  match(method: string, path: string): { handler: RouteHandler; params: Record<string,string> } | undefined;
+}
+```
+
+Routes are added by tsgonest-generated `registerXxxController(app)` calls or by user code (`app.router.add(...)`).
+
+---
+
+## Middleware chain
+
+### Shape
+
+```ts
+type Middleware = (
+  event: Event,
+  next: () => Promise<Response | Upgrade>,
+) => Promise<Response | Upgrade>;
+
+type Upgrade = { _tag: 'upgrade'; /* WS handler refs — v1 unused */ };
+```
+
+V1 produces no `Upgrade` values; the union is reserved so adding WS later is non-breaking.
+
+### Attach points
+
+Four, in execution order (outer → inner):
+
+1. **App** — `app.use(mw)` or `app.use('/prefix', mw)`. Registered globally or for a URL prefix.
+2. **Module** — `defineModule({ middleware: [...] })`. Applies to that module's declared `controllers` only. No cascade.
+3. **Controller** — `@UseMiddleware(mw)` on the class. Applies to every route in that controller.
+4. **Method** — `@UseMiddleware(mw)` on the method. Applies to that single route.
+
+### Execution semantics
+
+- **Order:** outer-to-inner across layers; registration order within each layer. No precedence numbers, no `before`/`after` declarations.
+- **`await next()`** runs the rest of the chain; returns the downstream Response (or `Upgrade`).
+- **Short-circuit:** return a Response without calling `next()`.
+- **Throw:** propagates up the chain; unhandled throws hit the error mapper.
+- **No class middleware.** Function shape only. DI via `event.resolve(Token)`.
+- **No guard sugar.** Guards are middleware that throw on failure. `defineGuard` is intentionally absent — ecosystem modules ship guards as middleware.
+
+### Streaming + header timing
+
+Once a downstream handler returns a streaming Response, headers are committed. Middleware that wants to set headers must do so **before** `await next()`. Documented rule; not runtime-enforced.
+
+---
+
+## Event
+
+The per-request state object. Passed to every middleware and (in generated wrappers) every handler.
+
+```ts
+interface Event extends TokenStore {
+  request:    Request;                  // raw Web Request
+  body:       Body;                     // memoized body accessor
+  response:   { headers: Headers; status: number };
+  waitUntil(promise: Promise<unknown>): void;
+  resolve<T>(token: Token<T>): T;       // DI access from middleware
+}
+
+interface TokenStore {
+  set<T>(token: Token<T>, value: T): void;
+  get<T>(token: Token<T>): T | undefined;
+  require<T>(token: Token<T>): T;       // throws if not set
+}
+
+interface Body {
+  bytes():    Promise<Uint8Array>;      // memoized
+  text():     Promise<string>;          // derived from bytes
+  json<T = unknown>(): Promise<T>;      // derived from bytes
+  formData(): Promise<FormData>;        // derived from bytes
+  stream():   ReadableStream<Uint8Array>; // single-use; errors if bytes/text/json/formData already called
+}
+```
+
+`TokenStore` is declared as a shared interface so a future `Session` (for WS) implements the same surface.
+
+### Response state
+
+`event.response.headers` is a real `Headers` instance (`.set/.append/.delete/.has/.get`). `event.response.status` is a plain number. Both mutated directly — no `setHeader`/`setStatus` framework methods.
+
+### `waitUntil`
+
+Adapter wires this to platform-specific equivalents. On Bun, the default is fire-and-forget; promises run to completion after the response is sent. The abstraction exists so portable middleware can write `event.waitUntil(p)` without branching on platform.
+
+---
+
+## Error mapper
+
+### Default handlers
+
+```ts
+class HttpError extends Error {
+  constructor(public status: number, public body?: unknown);
+}
+class BadRequestError      extends HttpError { /* status 400 */ }
+class UnauthorizedError    extends HttpError { /* status 401 */ }
+class ForbiddenError       extends HttpError { /* status 403 */ }
+class NotFoundError        extends HttpError { /* status 404 */ }
+class ConflictError        extends HttpError { /* status 409 */ }
+class UnprocessableEntityError extends HttpError { /* status 422 */ }
+class TooManyRequestsError extends HttpError { /* status 429 */ }
+class InternalServerError  extends HttpError { /* status 500 */ }
+```
+
+Defaults:
+
+- **`HttpError` subclasses** → JSON response with `error.body`, the carried `status`, content-type `application/json`.
+- **`TsgonestValidationError`** (from tsgonest runtime) → RFC 9457 `application/problem+json`, status 400, `type`/`title`/`status`/`detail`/`errors` shape with per-field detail.
+- **Unhandled** → status 500, problem-details JSON with minimal detail (no leak), full error logged.
+
+### Extensibility
+
+```ts
+app.onError(predicate: (err: unknown) => boolean, handler: (err: unknown, event: Event) => Response | Promise<Response>);
+```
+
+User-registered handlers run before defaults. First match wins.
+
+---
+
+## App / Context factory
+
+### `createContext`
+
+```ts
+async function createContext(config: { imports: Module[] }): Promise<Context>;
+
+interface Context extends AsyncDisposable {
+  resolve<T>(token: Token<T>): T;
+}
+```
+
+The headless primitive. Use for CLIs, queue consumers, cron, migrations, tests. Controllers in imported modules are silently ignored — the route registration step (step 5 below) is skipped.
+
+### `createApp`
+
+```ts
+async function createApp(config: { imports: Module[] }): Promise<App>;
+
+interface App extends Context {
+  fetch(request: Request): Promise<Response>;
+  use(mw: Middleware): void;
+  use(prefix: string, mw: Middleware): void;
+  onError(predicate: (e: unknown) => boolean, handler: (e: unknown, ev: Event) => Response | Promise<Response>): void;
+
+  // For adapters
+  router: Router;
+  createEvent(request: Request, setup?: (event: Event) => void): Event;
+}
+```
+
+`App extends Context` — code written against `Context` works against `App`.
+
+### Boot sequence (fixed six-step order)
+
+1. **Flatten** module graph; dedupe by identity.
+2. **Validate** configuration: no cycles, no duplicate tokens, all `@Inject` targets visible. Fail fast.
+3. **Construct** providers in topological order.
+4. **Init** — call `init()` on each provider that has one, in topological order. If any throws, dispose already-initialized providers in reverse topological order and reject `createApp`.
+5. **Register** routes via tsgonest-generated `registerXxxController(app)` calls (App only; skipped for Context).
+6. **Resolve** the promise. `app.fetch` is now ready.
+
+### Lifecycle interfaces (structural, duck-typed)
+
+```ts
+interface OnInit {
+  init(): Promise<void> | void;
+}
+
+// AsyncDisposable comes from lib.esnext.disposable:
+// interface AsyncDisposable { [Symbol.asyncDispose](): PromiseLike<void>; }
+```
+
+Container duck-types at runtime: `if (typeof p.init === 'function') await p.init();` and `if (typeof p[Symbol.asyncDispose] === 'function') await p[Symbol.asyncDispose]();`.
+
+### Graceful shutdown
+
+`app[Symbol.asyncDispose]()`:
+
+1. Stop accepting new requests (adapter signals this to the platform).
+2. Drain in-flight requests.
+3. Run each provider's `[Symbol.asyncDispose]` in reverse topological order.
+4. Resolve when clean.
+
+The adapter wires the SIGTERM/SIGINT trigger; core does not install signal handlers.
+
+### `await using` pattern
+
+For short-lived contexts (CLI, scripts, tests):
+
+```ts
+await using ctx = await createContext({ imports: [...] });
+// auto-disposed when scope exits, even on throw
+```
+
+Requires TS 5.2+ and Bun (or any runtime supporting TC39 explicit resource management).
+
+---
+
+## Compile-time extensions to tsgonest
+
+These additions live in the existing `internal/analyzer/` and `internal/codegen/` Go packages. They are additive — existing NestJS support is untouched.
+
+### Decorator vocabulary
+
+Recognized via import path (`@mintkit/core`). Factory-wrapped decorators are not supported (existing tsgonest constraint).
+
+- `@Controller(path: string)` — class decorator.
+- HTTP verb decorators: `@Get(path?)`, `@Post(path?)`, `@Put(path?)`, `@Patch(path?)`, `@Delete(path?)`, `@Head(path?)`, `@Options(path?)`. Dynamic path args are warned and skipped (existing constraint).
+- Parameter decorators: `@Body()`, `@Query()`, `@Param(name?)`, `@Headers(name?)`, `@Ctx(TOKEN)`.
+- Middleware attach: `@UseMiddleware(mw)` on class or method.
+- DI: `@Injectable({ scope?: 'singleton' | 'transient' })`.
+- Param-level injection: `@Inject(TOKEN)` for non-class deps.
+
+### Validation rules
+
+- `@Ctx(TOKEN) name: T` — the parameter's declared `T` must match the token's phantom `T`. Compile-time diagnostic on mismatch.
+- `@Body() data: { file: File & MaxSize<N> & MimeTypes<U> }` — file uploads typed declaratively. `File` and `FileStream` types from `@tsgonest/types`.
+
+### Codegen output
+
+In addition to the existing `*.tsgonest.js` companion file, controllers now emit:
+
+```ts
+// Generated, inside the controller's companion file
+export function registerUserController(app: App): void {
+  app.router.add('GET', '/users/:id', async (event) => {
+    const ctrl = event.resolve(UserController);
+    const id   = validateUUID(event.params.id);
+    const q    = validateListQuery(event.query);
+    const out  = await ctrl.findOne(id, q);
+    return Response.json(serializeUserDto(out), {
+      status: event.response.status || 200,
+      headers: event.response.headers,
+    });
+  });
+}
+```
+
+(Wrapper details: read validated params from generated validators, invoke controller method, serialize return via generated serializer, assemble final Response from `event.response.status` + `event.response.headers` + serialized body.)
+
+User code calls `registerUserController(app)` at boot. Future improvement: auto-import via a generated `modules.gen.ts`.
+
+### Framing-agnostic generator
+
+The validator generator for `@Body()` should be parameterized over "source bytes" rather than "HTTP request body" — so the same generator can emit WS message validators when WS lands. No v1 code change required; the abstraction is "don't hardcode Request reads inside the validator emitter."
+
+---
+
+## File uploads
+
+### Typed declarations
+
+```ts
+@Post('/avatar')
+async setAvatar(@Body() data: {
+  title: string & MinLength<1>;
+  image: File & MaxSize<5_000_000> & MimeTypes<'image/png' | 'image/jpeg'>;
+}) { ... }
+
+@Post('/uploads/large')
+async largeUpload(@Body() data: {
+  filename: string;
+  file: FileStream & MaxSize<5_000_000_000>;  // 5GB streaming
+}) { ... }
+
+@Post('/gallery')
+async gallery(@Body() data: {
+  title: string;
+  photos: Array<File & MaxSize<10_000_000> & MimeTypes<'image/*'>>;
+}) { ... }
+```
+
+### Runtime behavior
+
+- **Buffered (`File`)** — parser calls `event.body.formData()`, extracts entries, validates `MaxSize`/`MimeTypes`, throws `TsgonestValidationError` on violation, passes `File` to handler. Web standard `File` extends `Blob`.
+- **Streaming (`FileStream`)** — parser reads `event.body.stream()` as multipart in streaming mode, yields the file field as `FileStream { name, type, stream }`. `MaxSize` enforced incrementally; over-limit aborts the stream.
+- **Array of files** — same parser, array result.
+
+### New tag types (in `@tsgonest/types`)
+
+- `MaxSize<N>`, `MinSize<N>` — byte limits.
+- `MimeTypes<U>` — union of allowed MIME types; wildcard `'image/*'` etc. supported.
+- `FileStream` — distinct from `File`; signals streaming parse to the codegen.
+
+### New runtime code
+
+A multipart streaming parser (~200 lines), shipped in `@mintkit/core`. Web `Request.formData()` is fine for the buffered case; the streaming case is what Mint adds.
+
+---
+
+## SSE
+
+```ts
+function sse<T>(generator: () => AsyncGenerator<T>): Response;
+
+@Get('/events')
+events(): Promise<Response> {
+  return sse<{ type: 'tick'; ts: number }>(async function* () {
+    while (true) {
+      yield { type: 'tick', ts: Date.now() };
+      await Bun.sleep(1000);
+    }
+  });
+}
+```
+
+Sugar around a `ReadableStream` Response with `text/event-stream` content type and proper SSE framing (`data: ...\n\n`). Typed via `SSEStream<T>` so OpenAPI/SDK pick up the event type.
+
+OpenAPI integration follows the existing `@Returns<T>` pattern in tsgonest.
+
+---
+
+## Bun adapter (vendored, shadcn-style)
+
+Single package, copy-pasted into user repos. Owned and customizable by the user.
+
+### `wrap(app)`
+
+```ts
+function wrap(app: App): { fetch: (req: Request, server: Server) => Promise<Response> };
+```
+
+For zero-config use, `app.fetch` alone is sufficient:
+
+```ts
+Bun.serve({ fetch: app.fetch, port: 3000 });
+```
+
+For Bun-specific features (the `Server` reference), use `wrap`:
+
+```ts
+const handler = wrap(app);  // injects BUN_SERVER token per-request
+Bun.serve({ fetch: handler.fetch, port: 3000 });
+```
+
+### `BUN_SERVER` token
+
+```ts
+export const BUN_SERVER = defineToken<import('bun').Server>('BUN_SERVER');
+```
+
+Set by `wrap` on each event before `app.fetch` runs. Handlers/middleware can `event.require(BUN_SERVER)` to access the underlying server (e.g., for future WS upgrades or to inspect socket info).
+
+### `gracefulShutdown`
+
+```ts
+function gracefulShutdown(app: App, opts?: {
+  signals?:  Array<'SIGINT' | 'SIGTERM' | string>;
+  timeout?:  number;  // ms; how long to wait for drain before hard-killing
+}): void;
+```
+
+Wires the signal handlers, calls `app[Symbol.asyncDispose]()`, enforces the timeout. Vendored because signal handling philosophy varies (immediate vs infinite drain vs hard cap).
+
+---
+
+## What's reserved for WS (no v1 work, no breaking change at WS-add time)
+
+Documented here so future maintainers know these are deliberate.
+
+1. **Middleware/handler return type is `Response | Upgrade`** from v1. V1 never produces `Upgrade`; the union exists so widening is non-breaking.
+2. **Router method is a free-form string.** `'WS'` slots in alongside HTTP verbs.
+3. **`TokenStore` is a shared interface.** `Event` implements it; a future `Session` will too. No fragmentation of the context API when WS lands.
+4. **Validator codegen is framing-agnostic.** The validator emitter doesn't hardcode "read from Request body"; it takes source bytes. Reusable for `@OnMessage` later.
+
+Out of scope for v1: gateway decorators (`@Gateway`, `@OnMessage`, `@OnOpen`, `@OnClose`), session APIs (broadcast, rooms), AsyncAPI generation, reconnect/heartbeat patterns.
+
+---
+
+## Vendored ecosystem module conventions
+
+Documented but not enforced. `tsgonest add <module>` (future CLI) scaffolds into:
+
+```
+src/modules/<name>/
+  <name>.module.ts         # exports Module(opts) + ModuleAsync({ ... })
+  <name>.service.ts        # @Injectable class(es)
+  <name>.controller.ts     # @Controller — optional
+  <name>.config.ts         # defineToken<Options>(...) + types
+  <name>.types.ts          # DTOs
+  <name>.middleware.ts     # any module-specific middleware
+  README.md                # usage notes
+```
+
+The framework does not enforce this layout — users own the code. Ecosystem authors who follow it produce modules that feel native; deviants make their modules feel foreign.
+
+---
+
+## Out of scope (v1)
+
+- WebSocket support
+- Node, Cloudflare Workers, Deno, Lambda adapters
+- Request scope / per-connection scope / child containers
+- `forwardRef`
+- String-keyed DI tokens; multi-providers; `useExisting`; function-shape providers
+- Glob / auto-discovery
+- AsyncAPI
+- Runtime serializer overrides (type-tag customization only)
+- `tsgonest add <module>` CLI (the module shape is specified; the scaffolder is a separate effort)
+- Class-shaped middleware
+- `defineGuard` and guard primitives
+- `onRequest` / `onResponse` lifecycle hooks separate from middleware
+- Cookies, CSRF, CORS, rate-limit, auth, session, observability, file-storage primitives in core (ship as vendored modules)
+- Microservice transports (gRPC, NATS, RabbitMQ)
+- NestJS migration codemod
+
+---
+
+## Testing strategy
+
+Every module ships with tests. Tests exercise external behavior; internal helpers and intermediate state are not under test. Prior art lives in tsgonest's existing test infrastructure.
+
+### Go unit tests
+
+Continuing the `internal/<pkg>/<pkg>_test.go` pattern with fixtures under `testdata/`.
+
+- **Decorator analyzer extension** — TS fixtures with the new decorators; assert the metadata model captures controllers, routes, parameter bindings, `@Ctx` token references; assert `@Ctx` type-mismatch produces a diagnostic. Mirrors `internal/analyzer/nestjs_test.go`.
+- **Route registration codegen** — fixtures with annotated controllers; assert generated `registerXxxController` exports have correct method/path/wrapper shape. Mirrors `internal/codegen/codegen_test.go`.
+
+### TypeScript unit tests (Vitest)
+
+In `packages/mint`, alongside source or under `__tests__`.
+
+- **Container** — register/resolve singleton, transient, class, useValue, useFactory. Topological order on construction. Reverse-topo on dispose. Cycle detection. Missing-token error.
+- **Module resolver** — flat graph, nested imports, dedupe by identity, visibility (private-by-default, explicit `exports`, re-exports through chains), duplicate-token detection across modules, cycle detection across modules.
+- **Router** — radix tree correctness, param extraction, method matching including `'WS'`, no-match.
+- **Middleware chain** — onion composition, registration order, outer-to-inner across layers, short-circuit semantics, throw propagation, response wrapping after `await next()`.
+- **Event** — body memoization (`bytes`/`text`/`json`/`formData` cache and stream single-use), `response.headers` is `Headers`, `response.status` mutable, token set/get/require, `waitUntil` delegation (mocked adapter).
+- **Error mapper** — default `HttpError` mapping, default `TsgonestValidationError` → RFC 9457 (assert response shape, status, content-type), user-handler precedence, fallthrough 500 for unmatched.
+- **App / Context boot** — six-step order via hook assertions, fast-fail on init throw with partial dispose, fast-fail on cycle, `Symbol.asyncDispose` drain semantics, `await using` lifecycle.
+
+### E2E tests (Vitest, spawning the built binary)
+
+Continuing the `e2e/compile.test.ts` pattern. Each scenario writes a TS app using framework decorators, runs `tsgonest build`, boots the resulting JS in a Bun subprocess, sends Web `Request`s via `fetch`, asserts response shapes/codes/headers.
+
+Coverage:
+
+- Validated `@Body`, `@Query`, `@Param`, `@Headers` round-trips.
+- File upload (buffered single file, buffered multi-file, streaming file with `MaxSize` enforcement at byte boundary).
+- SSE endpoint.
+- Validation error response (RFC 9457).
+- Thrown `HttpError` → status + body mapping.
+- Custom `app.onError` precedence.
+- Middleware ordering across all four attach points.
+- Module-level middleware scoping (no cascade to imports).
+- Headless `createContext` for a one-shot CLI script using `await using`.
+- Graceful shutdown drains in-flight requests (start a long handler, signal, assert response completes and provider dispose runs in reverse-topo).
+
+---
+
+## Open questions / future work
+
+These are intentionally not decided and are out of v1 scope.
+
+- **Locked.** Brand is **Mint**. Core is `@mintkit/core` at `packages/mint`. Bun adapter is `@mintkit/bun` at `packages/mint-bun`.
+- **NestJS migration codemod.** Decorator vocabulary aligns intentionally; codemod is a separate v2+ effort.
+- **WebSocket support.** Reservations in place; full design when WS work begins.
+- **Additional adapters.** Node and Workers are the obvious next targets; the core invariants support them without changes.
+- **`tsgonest add <module>` CLI.** The module *shape* is specified; the scaffolder is a separate effort.
+- **AsyncAPI generation.** Ships with WS support.
+- **String tokens.** Can be added later if demand emerges.
+
+---
+
+## Provenance
+
+This spec is the synthesis of a design conversation that worked through every decision in this document. The PRD ([`../.scratch/mint/PRD.md`](../.scratch/mint/PRD.md)) captures the user-facing goals; this spec captures the technical contracts. Implementation issues live under [`../.scratch/mint/issues/`](../.scratch/mint/issues/). The three are intended to be read together.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,31 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
 
+  packages/mint-bun:
+    dependencies:
+      '@mintkit/core':
+        specifier: workspace:*
+        version: link:../mint
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.3.0
+        version: 1.3.14
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      bun-types:
+        specifier: ^1.3.11
+        version: 1.3.14
+      tsdown:
+        specifier: ^0.21.7
+        version: 0.21.7(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+
   packages/platform-bun:
     devDependencies:
       '@nestjs/common':
@@ -335,6 +360,38 @@ importers:
       '@mintkit/core':
         specifier: workspace:*
         version: link:../../packages/mint
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.3.12
+        version: 1.3.14
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  testdata/mint-typed:
+    dependencies:
+      '@mintkit/core':
+        specifier: workspace:*
+        version: link:../../packages/mint
+      '@tsgonest/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.3.12
+        version: 1.3.14
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  testdata/mint-upload:
+    dependencies:
+      '@mintkit/core':
+        specifier: workspace:*
+        version: link:../../packages/mint
+      '@tsgonest/types':
+        specifier: workspace:*
+        version: link:../../packages/types
     devDependencies:
       '@types/bun':
         specifier: ^1.3.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,21 @@ importers:
         specifier: workspace:*
         version: link:../cli-win32-x64
 
+  packages/mint:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      tsdown:
+        specifier: ^0.21.7
+        version: 0.21.7(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+
   packages/platform-bun:
     devDependencies:
       '@nestjs/common':
@@ -311,6 +326,19 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  testdata/mint-hello:
+    dependencies:
+      '@mintkit/core':
+        specifier: workspace:*
+        version: link:../../packages/mint
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.3.12
+        version: 1.3.14
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -1827,6 +1855,9 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -2079,6 +2110,9 @@ packages:
 
   bun-types@1.3.11:
     resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -5351,6 +5385,10 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 25.5.0
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -5636,6 +5674,10 @@ snapshots:
       ieee754: 1.2.1
 
   bun-types@1.3.11:
+    dependencies:
+      '@types/node': 25.5.0
+
+  bun-types@1.3.14:
     dependencies:
       '@types/node': 25.5.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,5 @@ packages:
   - 'benchmarks/http'
   - 'testdata/integration'
   - 'testdata/mint-hello'
+  - 'testdata/mint-typed'
+  - 'testdata/mint-upload'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - 'benchmarks'
   - 'benchmarks/http'
   - 'testdata/integration'
+  - 'testdata/mint-hello'

--- a/testdata/mint-hello/package.json
+++ b/testdata/mint-hello/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mint-hello-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@mintkit/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.12",
+    "typescript": "^5.7.0"
+  }
+}

--- a/testdata/mint-hello/src/hello.controller.HelloController.tsgonest.d.ts
+++ b/testdata/mint-hello/src/hello.controller.HelloController.tsgonest.d.ts
@@ -1,0 +1,3 @@
+import type { App } from "@mintkit/core";
+
+export declare function registerHelloController(app: App): void;

--- a/testdata/mint-hello/src/hello.controller.ts
+++ b/testdata/mint-hello/src/hello.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from "@mintkit/core";
+
+@Controller("/hello")
+export class HelloController {
+  @Get()
+  hello(): string {
+    return "Hello from Mint!";
+  }
+}

--- a/testdata/mint-hello/src/main.ts
+++ b/testdata/mint-hello/src/main.ts
@@ -1,0 +1,16 @@
+import { createApp, defineModule } from "@mintkit/core";
+import { HelloController } from "./hello.controller";
+import { registerHelloController } from "./hello.controller.HelloController.tsgonest.js";
+
+const app = await createApp({
+  imports: [defineModule({ controllers: [HelloController] })],
+});
+
+registerHelloController(app);
+
+const server = Bun.serve({
+  port: Number(process.env.PORT ?? 0),
+  fetch: (req) => app.fetch(req),
+});
+
+process.stdout.write(`LISTENING:${server.url}\n`);

--- a/testdata/mint-hello/tsconfig.json
+++ b/testdata/mint-hello/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/testdata/mint-hello/tsgonest.config.json
+++ b/testdata/mint-hello/tsgonest.config.json
@@ -1,0 +1,12 @@
+{
+  "controllers": {
+    "include": ["src/**/*.controller.ts"]
+  },
+  "transforms": {
+    "validation": true,
+    "serialization": true
+  },
+  "openapi": {
+    "output": "dist/openapi.json"
+  }
+}

--- a/testdata/mint-typed/package.json
+++ b/testdata/mint-typed/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mint-typed-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@mintkit/core": "workspace:*",
+    "@tsgonest/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.12",
+    "typescript": "^5.7.0"
+  }
+}

--- a/testdata/mint-typed/src/main.ts
+++ b/testdata/mint-typed/src/main.ts
@@ -1,0 +1,16 @@
+import { createApp, defineModule } from "@mintkit/core";
+import { UsersController } from "./users.controller";
+import { registerUsersController } from "./users.controller.UsersController.tsgonest.js";
+
+const app = await createApp({
+  imports: [defineModule({ controllers: [UsersController] })],
+});
+
+registerUsersController(app);
+
+const server = Bun.serve({
+  port: Number(process.env.PORT ?? 0),
+  fetch: (req) => app.fetch(req),
+});
+
+process.stdout.write(`LISTENING:${server.url}\n`);

--- a/testdata/mint-typed/src/users.controller.UsersController.tsgonest.d.ts
+++ b/testdata/mint-typed/src/users.controller.UsersController.tsgonest.d.ts
@@ -1,0 +1,3 @@
+import type { App } from "@mintkit/core";
+
+export declare function registerUsersController(app: App): void;

--- a/testdata/mint-typed/src/users.controller.ts
+++ b/testdata/mint-typed/src/users.controller.ts
@@ -1,0 +1,37 @@
+import { Body, Controller, Get, Param, Post, Query } from "@mintkit/core";
+import type { CreateUserDto, ListQuery, UserResponse } from "./users.dto";
+
+@Controller("/users")
+export class UsersController {
+  @Get()
+  list(@Query() q: ListQuery): UserResponse[] {
+    const limit = q.limit ?? 10;
+    const out: UserResponse[] = [];
+    for (let i = 0; i < limit && i < 3; i++) {
+      out.push({
+        id: `11111111-1111-1111-1111-${String(i).padStart(12, "0")}`,
+        name: `user-${i}`,
+        email: `user${i}@example.com`,
+      });
+    }
+    return out;
+  }
+
+  @Get(":id")
+  one(@Param("id") id: string): UserResponse {
+    return {
+      id: id.length === 36 ? id : "11111111-1111-1111-1111-111111111111",
+      name: "ada",
+      email: "ada@example.com",
+    };
+  }
+
+  @Post()
+  create(@Body() body: CreateUserDto): UserResponse {
+    return {
+      id: "11111111-1111-1111-1111-111111111111",
+      name: body.name,
+      email: body.email,
+    };
+  }
+}

--- a/testdata/mint-typed/src/users.dto.ts
+++ b/testdata/mint-typed/src/users.dto.ts
@@ -1,0 +1,18 @@
+import { tags } from "@tsgonest/types";
+
+export interface CreateUserDto {
+  name: string & tags.MinLength<1>;
+  email: string & tags.Email;
+  age: number & tags.Minimum<0>;
+}
+
+export interface UserResponse {
+  id: string & tags.Uuid;
+  name: string;
+  email: string;
+}
+
+export interface ListQuery {
+  limit?: number & tags.Maximum<100>;
+  cursor?: string;
+}

--- a/testdata/mint-typed/tsconfig.json
+++ b/testdata/mint-typed/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/testdata/mint-typed/tsgonest.config.json
+++ b/testdata/mint-typed/tsgonest.config.json
@@ -1,0 +1,12 @@
+{
+  "controllers": {
+    "include": ["src/**/*.controller.ts"]
+  },
+  "transforms": {
+    "validation": true,
+    "serialization": true
+  },
+  "openapi": {
+    "output": "dist/openapi.json"
+  }
+}

--- a/testdata/mint-upload/package.json
+++ b/testdata/mint-upload/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mint-upload-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@mintkit/core": "workspace:*",
+    "@tsgonest/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.12",
+    "typescript": "^5.7.0"
+  }
+}

--- a/testdata/mint-upload/src/main.ts
+++ b/testdata/mint-upload/src/main.ts
@@ -1,0 +1,16 @@
+import { createApp, defineModule } from "@mintkit/core";
+import { UploadController } from "./upload.controller";
+import { registerUploadController } from "./upload.controller.UploadController.tsgonest.js";
+
+const app = await createApp({
+  imports: [defineModule({ controllers: [UploadController] })],
+});
+
+registerUploadController(app);
+
+const server = Bun.serve({
+  port: Number(process.env.PORT ?? 0),
+  fetch: (req) => app.fetch(req),
+});
+
+process.stdout.write(`LISTENING:${server.url}\n`);

--- a/testdata/mint-upload/src/upload.controller.UploadController.tsgonest.d.ts
+++ b/testdata/mint-upload/src/upload.controller.UploadController.tsgonest.d.ts
@@ -1,0 +1,3 @@
+import type { App } from "@mintkit/core";
+
+export declare function registerUploadController(app: App): void;

--- a/testdata/mint-upload/src/upload.controller.ts
+++ b/testdata/mint-upload/src/upload.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Post } from "@mintkit/core";
+import type { AvatarUpload, LargeUpload } from "./upload.dto";
+
+interface UploadResponse {
+  ok: true;
+  name: string;
+  type: string;
+  size: number;
+}
+
+interface StreamResponse {
+  ok: true;
+  filename: string;
+  type: string;
+  bytes: number;
+}
+
+@Controller("/uploads")
+export class UploadController {
+  @Post("/avatar")
+  async avatar(@Body() data: AvatarUpload): Promise<UploadResponse> {
+    return {
+      ok: true,
+      name: data.title,
+      type: data.image.type,
+      size: data.image.size,
+    };
+  }
+
+  @Post("/large")
+  async large(@Body() data: LargeUpload): Promise<StreamResponse> {
+    // Drain the stream, counting bytes (representative of a write-to-disk handler).
+    const reader = data.file.stream.getReader();
+    let total = 0;
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value) total += value.length;
+    }
+    return {
+      ok: true,
+      filename: data.filename,
+      type: data.file.type,
+      bytes: total,
+    };
+  }
+}

--- a/testdata/mint-upload/src/upload.dto.ts
+++ b/testdata/mint-upload/src/upload.dto.ts
@@ -1,0 +1,11 @@
+import { tags } from "@tsgonest/types";
+
+export interface AvatarUpload {
+  title: string & tags.MinLength<1>;
+  image: File & tags.MaxSize<10_000> & tags.MimeTypes<"image/png" | "image/jpeg">;
+}
+
+export interface LargeUpload {
+  filename: string & tags.MinLength<1>;
+  file: tags.FileStream & tags.MaxSize<5_000_000>;
+}

--- a/testdata/mint-upload/tsconfig.json
+++ b/testdata/mint-upload/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/testdata/mint-upload/tsgonest.config.json
+++ b/testdata/mint-upload/tsgonest.config.json
@@ -1,0 +1,12 @@
+{
+  "controllers": {
+    "include": ["src/**/*.controller.ts"]
+  },
+  "transforms": {
+    "validation": true,
+    "serialization": true
+  },
+  "openapi": {
+    "output": "dist/openapi.json"
+  }
+}


### PR DESCRIPTION
## Summary

Lands **Mint** — a tiny Bun-targeted web framework built on tsgonest's compile-time pipeline. Decorators are statically analyzed and erased at runtime; the framework runtime is small, throw-based, web-standards-native, with WS reservations baked in.

Companion docs: `.scratch/mint/PRD.md`, `plans/mint-spec.md`, `plans/mint-plan.md`. All 12 phase issues under `.scratch/mint/issues/`.

## What ships

### Packages

- **`@mintkit/core`** (`packages/mint`) — Container, Router, Event, App, Context, middleware chain, error mapper, lifecycle, SSE helper, streaming multipart parser, compile-time-only decorators.
- **`@mintkit/bun`** (`packages/mint-bun`) — vendored shadcn-style adapter. `wrap(app)` injects `BUN_SERVER` token per request; `gracefulShutdown` wires SIGTERM/SIGINT to `app[Symbol.asyncDispose]()` with a timeout.
- **`@tsgonest/types`** extended with `File`, `FileStream`, `MaxSize<N>`, `MinSize<N>`, `MimeTypes<U>` tags.

### Compile-time extensions (Go)

- Analyzer recognises Mint controllers via the `@mintkit/core` import origin. NestJS support is unchanged.
- Codegen emits `registerXxxController(app)` companions that read `@Body`/`@Query`/`@Param`/`@Headers` from the event, run the existing tsgonest validators, invoke the handler, and serialize the return value. Validation throws propagate to the RFC 9457 problem-details mapper.
- Multipart parsing for buffered uploads (`File` + size/MIME validation) and streaming uploads (`FileStream` with per-part `setLimit`).
- OpenAPI 3.2 picks up Mint routes (paths, request bodies, schemas, multipart) through the existing pipeline.
- The rewriter skips Mint controllers — NestJS-shaped interceptor injections would corrupt the emit.

### WS reservations (baked in from day 1)

- `RouteHandler` / `Middleware` return type is `Promise<Response | Upgrade>` (`Upgrade` reserved, never produced in v1).
- Router method slot is a free-form `string` — `'WS'` slots in without breaking changes.
- `TokenStore` interface implemented by `Event`; a future `Session` would implement the same surface.
- Multipart parser is framing-agnostic — same streaming machinery can drive WS message validators later.

## Phase-by-phase trail

| Phase | Scope |
|------:|-------|
| 1 | Hello World seam — `@Controller`/`@Get` → companion → Bun.serve |
| 2 | Typed `@Body`/`@Query`/`@Param`/`@Headers` + RFC 9457 validation errors + JSON serialization |
| 3 | DI providers (class / useValue / useFactory+inject); dynamic modules |
| 4 | Middleware chain (app + module); full `Event` surface; `@UseMiddleware` WeakMap groundwork |
| 5 | `HttpError` hierarchy; pluggable error mapper; `app.onError` |
| 6 | `OnInit` + reverse-topo `Symbol.asyncDispose`; drain in-flight |
| 7 | Module visibility (private-by-default, explicit `exports`); boot validation |
| 8 | `createContext({ imports })`; `App extends Context`; `await using` |
| 9 | Buffered file uploads (`File` + `MaxSize`/`MinSize`/`MimeTypes`) |
| 10 | Streaming file uploads (`FileStream` + `parseMultipartStream` with byte limits) |
| 11 | `sse()` helper with proper framing + abort propagation |
| 12 | `@mintkit/bun` adapter (`wrap`, `BUN_SERVER`, `gracefulShutdown`) |

## Tests

- **Go**: all internal packages green with `-race`. New tests in `internal/analyzer/mint_test.go`, `internal/analyzer/type_walker_test.go` (3 new), `internal/codegen/mint_register_test.go` (12 new).
- **`@mintkit/core`**: 117 tests across 15 files (container, router, event, middleware, errors, error-mapper, error-handling integration, sse, multipart, mime, lifecycle, module-visibility, context).
- **`@mintkit/bun`**: 8 tests (wrap injects BUN_SERVER, gracefulShutdown wires signals).
- **e2e**: 307 tests across 29 files. Three Mint fixtures: `mint-hello`, `mint-typed`, `mint-upload`. All boot real Bun subprocesses and exercise the compiled output.

## Punted (documented)

- `@UseMiddleware` decorator records into WeakMaps but isn't yet wired through the register codegen — it's runtime no-op for now (intentional: needs codegen extension). Module middleware applies through the deferred-register router buffer; per-controller / per-method decorator wiring is a follow-up.
- Streaming bodies support **one** `FileStream` per request (scalar fields are buffered first, then the stream is handed to the handler). Multi-FileStream bodies fall out of scope.
- `MultipartByteLimitError` currently maps to 400 problem-details; 413 mapping is a small mapper tweak left for a follow-up.

## Test plan
- [x] `just test` — Go (`-race`) + e2e
- [x] `pnpm --filter @mintkit/core test` (117)
- [x] `pnpm --filter @mintkit/bun test` (8)
- [x] `pnpm --filter @mintkit/core build` (ESM + CJS + d.mts + d.cts)
- [x] `pnpm --filter @mintkit/bun build`
- [x] `pnpm --filter @tsgonest/types build`
- [x] `just fmt`