### PR TITLE
chore: update typescript-go submodule to 9ea7f6b36e

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require golang.org/x/tools v0.44.0
 
 require (
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
-	github.com/microsoft/typescript-go v0.0.0-20260424234512-515d036f927a // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
@@ -32,6 +31,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433
+	github.com/microsoft/typescript-go v0.0.0-20260424234512-515d036f927a
 	github.com/microsoft/typescript-go/shim/ast v0.0.0-00010101000000-000000000000
 	github.com/microsoft/typescript-go/shim/bundled v0.0.0-00010101000000-000000000000
 	github.com/microsoft/typescript-go/shim/checker v0.0.0-00010101000000-000000000000

--- a/go.work.sum
+++ b/go.work.sum
@@ -3,9 +3,16 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7rTdLpC9gFG9kdI7zVLFTFFlqaH2Cncw=
 golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
+golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6/go.mod h1:Eqhaxk/wZsWEH8CRxLwj6xzEJbz7k1EFGqx7nyCoabE=
+golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
+golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=

--- a/internal/collections/ordered_map.go
+++ b/internal/collections/ordered_map.go
@@ -266,7 +266,7 @@ func (m *OrderedMap[K, V]) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if err != nil {
 		return err
 	}
-	if token.Kind() == 'n' { // jsontext.Null.Kind()
+	if token.Kind() == 'n' { // json.Null.Kind()
 		// By convention, to approximate the behavior of Unmarshal itself,
 		// Unmarshalers implement UnmarshalJSON([]byte("null")) as a no-op.
 		// https://pkg.go.dev/encoding/json#Unmarshaler

--- a/internal/compiler/program.go
+++ b/internal/compiler/program.go
@@ -258,7 +258,7 @@ func UpdateProgram(oldProgram *shimcompiler.Program, changedFilePath string, cwd
 	// Convert to tspath.Path — the canonicalized format used by program internals.
 	canonPath := tspath.ToPath(changedFilePath, cwd, oldProgram.UseCaseSensitiveFileNames())
 
-	newProgram, reused := oldProgram.UpdateProgram(canonPath, host, nil)
+	newProgram, _, reused := oldProgram.UpdateProgram(canonPath, host, nil)
 	if newProgram != nil {
 		newProgram.BindSourceFiles()
 	}

--- a/shim/ast/shim.go
+++ b/shim/ast/shim.go
@@ -218,6 +218,10 @@ type EqualsGreaterThanToken = ast.EqualsGreaterThanToken
 type EqualsToken = ast.EqualsToken
 //go:linkname EscapeAllInternalSymbolNames github.com/microsoft/typescript-go/internal/ast.EscapeAllInternalSymbolNames
 func EscapeAllInternalSymbolNames(name string) string
+//go:linkname EscapeInternalSymbolName github.com/microsoft/typescript-go/internal/ast.EscapeInternalSymbolName
+func EscapeInternalSymbolName(name string) string
+//go:linkname EscapeSymbolName github.com/microsoft/typescript-go/internal/ast.EscapeSymbolName
+func EscapeSymbolName(name string) string
 type ExclamationToken = ast.ExclamationToken
 type ExponentiationOperator = ast.ExponentiationOperator
 type ExportAssignment = ast.ExportAssignment
@@ -257,6 +261,8 @@ const FindAncestorTrue = ast.FindAncestorTrue
 func FindConstructorDeclaration(node *ast.ClassLikeDeclaration) *ast.Node
 //go:linkname FindLastVisibleNode github.com/microsoft/typescript-go/internal/ast.FindLastVisibleNode
 func FindLastVisibleNode(nodes []*ast.Node) *ast.Node
+//go:linkname FindManyAncestors github.com/microsoft/typescript-go/internal/ast.FindManyAncestors
+func FindManyAncestors(node *ast.Node, callbacks ...func(*ast.Node) bool) []*ast.Node
 type FlowFlags = ast.FlowFlags
 const FlowFlagsArrayMutation = ast.FlowFlagsArrayMutation
 const FlowFlagsAssignment = ast.FlowFlagsAssignment
@@ -876,8 +882,8 @@ func IsIdentifier(node *ast.Node) bool
 func IsIdentifierName(node *ast.Node) bool
 //go:linkname IsIfStatement github.com/microsoft/typescript-go/internal/ast.IsIfStatement
 func IsIfStatement(node *ast.Node) bool
-//go:linkname IsImplicitlyExportedJSTypeAlias github.com/microsoft/typescript-go/internal/ast.IsImplicitlyExportedJSTypeAlias
-func IsImplicitlyExportedJSTypeAlias(node *ast.Node) bool
+//go:linkname IsImplicitlyExportedJSDocDeclaration github.com/microsoft/typescript-go/internal/ast.IsImplicitlyExportedJSDocDeclaration
+func IsImplicitlyExportedJSDocDeclaration(node *ast.Node) bool
 //go:linkname IsImportAttribute github.com/microsoft/typescript-go/internal/ast.IsImportAttribute
 func IsImportAttribute(node *ast.Node) bool
 //go:linkname IsImportAttributes github.com/microsoft/typescript-go/internal/ast.IsImportAttributes
@@ -1170,6 +1176,8 @@ func IsModuleWithStringLiteralName(node *ast.Node) bool
 func IsMultiplicativeOperator(kind ast.Kind) bool
 //go:linkname IsMultiplicativeOperatorOrHigher github.com/microsoft/typescript-go/internal/ast.IsMultiplicativeOperatorOrHigher
 func IsMultiplicativeOperatorOrHigher(kind ast.Kind) bool
+//go:linkname IsNamedEvaluationSource github.com/microsoft/typescript-go/internal/ast.IsNamedEvaluationSource
+func IsNamedEvaluationSource(node *ast.Node) bool
 //go:linkname IsNamedExports github.com/microsoft/typescript-go/internal/ast.IsNamedExports
 func IsNamedExports(node *ast.Node) bool
 //go:linkname IsNamedImports github.com/microsoft/typescript-go/internal/ast.IsNamedImports
@@ -1294,6 +1302,8 @@ func IsPropertyName(node *ast.Node) bool
 func IsPropertyNameLiteral(node *ast.Node) bool
 //go:linkname IsPropertySignatureDeclaration github.com/microsoft/typescript-go/internal/ast.IsPropertySignatureDeclaration
 func IsPropertySignatureDeclaration(node *ast.Node) bool
+//go:linkname IsProtoSetter github.com/microsoft/typescript-go/internal/ast.IsProtoSetter
+func IsProtoSetter(node *ast.Node) bool
 //go:linkname IsPrototypeAccess github.com/microsoft/typescript-go/internal/ast.IsPrototypeAccess
 func IsPrototypeAccess(node *ast.Node) bool
 //go:linkname IsPseudoLiteralKind github.com/microsoft/typescript-go/internal/ast.IsPseudoLiteralKind
@@ -1528,6 +1538,7 @@ type JSDocComment = ast.JSDocComment
 type JSDocCommentBase = ast.JSDocCommentBase
 type JSDocDeprecatedTag = ast.JSDocDeprecatedTag
 type JSDocDeprecatedTagNode = ast.JSDocDeprecatedTagNode
+type JSDocFullName = ast.JSDocFullName
 type JSDocImplementsTag = ast.JSDocImplementsTag
 type JSDocImplementsTagNode = ast.JSDocImplementsTagNode
 type JSDocImportTag = ast.JSDocImportTag
@@ -2184,11 +2195,13 @@ const NodeFlagsHasExplicitReturn = ast.NodeFlagsHasExplicitReturn
 const NodeFlagsHasImplicitReturn = ast.NodeFlagsHasImplicitReturn
 const NodeFlagsHasJSDoc = ast.NodeFlagsHasJSDoc
 const NodeFlagsIdentifierHasExtendedUnicodeEscape = ast.NodeFlagsIdentifierHasExtendedUnicodeEscape
+const NodeFlagsIdentifierIsInJSDocNamespace = ast.NodeFlagsIdentifierIsInJSDocNamespace
 const NodeFlagsInWithStatement = ast.NodeFlagsInWithStatement
 const NodeFlagsJSDoc = ast.NodeFlagsJSDoc
 const NodeFlagsJavaScriptFile = ast.NodeFlagsJavaScriptFile
 const NodeFlagsJsonFile = ast.NodeFlagsJsonFile
 const NodeFlagsLet = ast.NodeFlagsLet
+const NodeFlagsNestedNamespace = ast.NodeFlagsNestedNamespace
 const NodeFlagsNone = ast.NodeFlagsNone
 const NodeFlagsOptionalChain = ast.NodeFlagsOptionalChain
 const NodeFlagsPermanentlySetIncrementalFlags = ast.NodeFlagsPermanentlySetIncrementalFlags
@@ -2198,6 +2211,7 @@ const NodeFlagsPossiblyContainsImportMeta = ast.NodeFlagsPossiblyContainsImportM
 const NodeFlagsReachabilityAndEmitFlags = ast.NodeFlagsReachabilityAndEmitFlags
 const NodeFlagsReachabilityCheckFlags = ast.NodeFlagsReachabilityCheckFlags
 const NodeFlagsReparsed = ast.NodeFlagsReparsed
+const NodeFlagsReparserTransformedLiteral = ast.NodeFlagsReparserTransformedLiteral
 const NodeFlagsSynthesized = ast.NodeFlagsSynthesized
 const NodeFlagsThisNodeHasError = ast.NodeFlagsThisNodeHasError
 const NodeFlagsThisNodeOrAnySubNodesHasError = ast.NodeFlagsThisNodeOrAnySubNodesHasError
@@ -2237,8 +2251,12 @@ type NumericLiteral = ast.NumericLiteral
 type NumericLiteralNode = ast.NumericLiteralNode
 type NumericOrStringLikeLiteral = ast.NumericOrStringLikeLiteral
 const OEKAll = ast.OEKAll
+const OEKAllExceptAssertionsOrExpressionsWithTypeArguments = ast.OEKAllExceptAssertionsOrExpressionsWithTypeArguments
 const OEKAssertions = ast.OEKAssertions
+const OEKAssignments = ast.OEKAssignments
+const OEKComma = ast.OEKComma
 const OEKExcludeJSDocTypeAssertion = ast.OEKExcludeJSDocTypeAssertion
+const OEKExpressionTypePassthrough = ast.OEKExpressionTypePassthrough
 const OEKExpressionsWithTypeArguments = ast.OEKExpressionsWithTypeArguments
 const OEKNonNullAssertions = ast.OEKNonNullAssertions
 const OEKParentheses = ast.OEKParentheses
@@ -2402,6 +2420,7 @@ func SkipPartiallyEmittedExpressions(node *ast.Expression) *ast.Expression
 //go:linkname SkipTypeParentheses github.com/microsoft/typescript-go/internal/ast.SkipTypeParentheses
 func SkipTypeParentheses(node *ast.Node) *ast.Node
 type SourceFile = ast.SourceFile
+type SourceFileDataKey[T any] = ast.SourceFileDataKey[T]
 type SourceFileLike = ast.SourceFileLike
 type SourceFileMetaData = ast.SourceFileMetaData
 type SourceFileNode = ast.SourceFileNode

--- a/shim/checker/shim.go
+++ b/shim/checker/shim.go
@@ -84,6 +84,7 @@ type CompositeSignature = checker.CompositeSignature
 type CompositeSymbolIdentity = checker.CompositeSymbolIdentity
 type CompositeTypeCacheIdentity = checker.CompositeTypeCacheIdentity
 type CompositeTypeMapper = checker.CompositeTypeMapper
+type ComputedNameNodeLinks = checker.ComputedNameNodeLinks
 type ConditionalRoot = checker.ConditionalRoot
 type ConditionalType = checker.ConditionalType
 type ConstrainedType = checker.ConstrainedType
@@ -152,6 +153,33 @@ const ExpandingFlagsTarget = checker.ExpandingFlagsTarget
 type ExportCollision = checker.ExportCollision
 type ExportCollisionTable = checker.ExportCollisionTable
 type ExportTypeLinks = checker.ExportTypeLinks
+type ExternalEmitHelpers = checker.ExternalEmitHelpers
+const ExternalEmitHelpersAddDisposableResourceAndDisposeResources = checker.ExternalEmitHelpersAddDisposableResourceAndDisposeResources
+const ExternalEmitHelpersAsyncDelegator = checker.ExternalEmitHelpersAsyncDelegator
+const ExternalEmitHelpersAsyncDelegatorIncludes = checker.ExternalEmitHelpersAsyncDelegatorIncludes
+const ExternalEmitHelpersAsyncGenerator = checker.ExternalEmitHelpersAsyncGenerator
+const ExternalEmitHelpersAsyncGeneratorIncludes = checker.ExternalEmitHelpersAsyncGeneratorIncludes
+const ExternalEmitHelpersAsyncValues = checker.ExternalEmitHelpersAsyncValues
+const ExternalEmitHelpersAwait = checker.ExternalEmitHelpersAwait
+const ExternalEmitHelpersAwaiter = checker.ExternalEmitHelpersAwaiter
+const ExternalEmitHelpersClassPrivateFieldGet = checker.ExternalEmitHelpersClassPrivateFieldGet
+const ExternalEmitHelpersClassPrivateFieldIn = checker.ExternalEmitHelpersClassPrivateFieldIn
+const ExternalEmitHelpersClassPrivateFieldSet = checker.ExternalEmitHelpersClassPrivateFieldSet
+const ExternalEmitHelpersDecorate = checker.ExternalEmitHelpersDecorate
+const ExternalEmitHelpersESDecorateAndRunInitializers = checker.ExternalEmitHelpersESDecorateAndRunInitializers
+const ExternalEmitHelpersExportStar = checker.ExternalEmitHelpersExportStar
+const ExternalEmitHelpersFirstEmitHelper = checker.ExternalEmitHelpersFirstEmitHelper
+const ExternalEmitHelpersForAwaitOfIncludes = checker.ExternalEmitHelpersForAwaitOfIncludes
+const ExternalEmitHelpersImportDefault = checker.ExternalEmitHelpersImportDefault
+const ExternalEmitHelpersImportStar = checker.ExternalEmitHelpersImportStar
+const ExternalEmitHelpersLastEmitHelper = checker.ExternalEmitHelpersLastEmitHelper
+const ExternalEmitHelpersMakeTemplateObject = checker.ExternalEmitHelpersMakeTemplateObject
+const ExternalEmitHelpersMetadata = checker.ExternalEmitHelpersMetadata
+const ExternalEmitHelpersParam = checker.ExternalEmitHelpersParam
+const ExternalEmitHelpersPropKey = checker.ExternalEmitHelpersPropKey
+const ExternalEmitHelpersRest = checker.ExternalEmitHelpersRest
+const ExternalEmitHelpersRewriteRelativeImportExtension = checker.ExternalEmitHelpersRewriteRelativeImportExtension
+const ExternalEmitHelpersSetFunctionName = checker.ExternalEmitHelpersSetFunctionName
 type FeatureMapEntry = checker.FeatureMapEntry
 type FlowLoopInfo = checker.FlowLoopInfo
 type FlowLoopKey = checker.FlowLoopKey
@@ -162,8 +190,12 @@ func FormatTypeFlags(flags checker.TypeFlags) []string
 type FunctionTypeMapper = checker.FunctionTypeMapper
 //go:linkname GetDeclarationModifierFlagsFromSymbol github.com/microsoft/typescript-go/internal/checker.GetDeclarationModifierFlagsFromSymbol
 func GetDeclarationModifierFlagsFromSymbol(s *ast.Symbol) ast.ModifierFlags
+//go:linkname GetPropertyNameFromType github.com/microsoft/typescript-go/internal/checker.GetPropertyNameFromType
+func GetPropertyNameFromType(t *checker.Type) string
 //go:linkname GetResolvedSignatureForSignatureHelp github.com/microsoft/typescript-go/internal/checker.GetResolvedSignatureForSignatureHelp
 func GetResolvedSignatureForSignatureHelp(node *ast.Node, argumentCount int, c *checker.Checker) (*checker.Signature, []*checker.Signature)
+//go:linkname GetSetAccessorValueParameter github.com/microsoft/typescript-go/internal/checker.GetSetAccessorValueParameter
+func GetSetAccessorValueParameter(accessor *ast.Node) *ast.Node
 //go:linkname GetSingleVariableOfVariableStatement github.com/microsoft/typescript-go/internal/checker.GetSingleVariableOfVariableStatement
 func GetSingleVariableOfVariableStatement(node *ast.Node) *ast.Node
 type Host = checker.Host
@@ -236,6 +268,8 @@ func IsPrivateIdentifierSymbol(symbol *ast.Symbol) bool
 func IsTupleType(t *checker.Type) bool
 //go:linkname IsTypeAny github.com/microsoft/typescript-go/internal/checker.IsTypeAny
 func IsTypeAny(t *checker.Type) bool
+//go:linkname IsTypeUsableAsPropertyName github.com/microsoft/typescript-go/internal/checker.IsTypeUsableAsPropertyName
+func IsTypeUsableAsPropertyName(t *checker.Type) bool
 type IterationTypeKind = checker.IterationTypeKind
 const IterationTypeKindNext = checker.IterationTypeKindNext
 const IterationTypeKindReturn = checker.IterationTypeKindReturn
@@ -454,6 +488,7 @@ const SignatureFlagsIsSignatureCandidateForOverloadFailure = checker.SignatureFl
 const SignatureFlagsIsUntypedSignatureInJSFile = checker.SignatureFlagsIsUntypedSignatureInJSFile
 const SignatureFlagsNone = checker.SignatureFlagsNone
 const SignatureFlagsPropagatingFlags = checker.SignatureFlagsPropagatingFlags
+type SignatureId = checker.SignatureId
 var SignatureKeyBase = checker.SignatureKeyBase
 var SignatureKeyCanonical = checker.SignatureKeyCanonical
 var SignatureKeyErased = checker.SignatureKeyErased

--- a/shim/core/shim.go
+++ b/shim/core/shim.go
@@ -19,6 +19,10 @@ type BreadthFirstSearchLevel[K comparable, N any] = core.BreadthFirstSearchLevel
 type BreadthFirstSearchOptions[K comparable, N any] = core.BreadthFirstSearchOptions[K,N]
 type BreadthFirstSearchResult[N any] = core.BreadthFirstSearchResult[N]
 type BuildOptions = core.BuildOptions
+type CheckerLifetime = core.CheckerLifetime
+const CheckerLifetimeAPI = core.CheckerLifetimeAPI
+const CheckerLifetimeDiagnostics = core.CheckerLifetimeDiagnostics
+const CheckerLifetimeTemporary = core.CheckerLifetimeTemporary
 //go:linkname CompareBooleans github.com/microsoft/typescript-go/internal/core.CompareBooleans
 func CompareBooleans(a bool, b bool) int
 //go:linkname CompareTextRanges github.com/microsoft/typescript-go/internal/core.CompareTextRanges
@@ -31,6 +35,8 @@ func ComputeECMALineStartsSeq(text string) iter.Seq[core.TextPos]
 type ECMALineStarts = core.ECMALineStarts
 var EmptyCompilerOptions = core.EmptyCompilerOptions
 var ExclusivelyPrefixedNodeCoreModules = core.ExclusivelyPrefixedNodeCoreModules
+//go:linkname GetCheckerLifetime github.com/microsoft/typescript-go/internal/core.GetCheckerLifetime
+func GetCheckerLifetime(ctx context.Context) core.CheckerLifetime
 //go:linkname GetNewLineKind github.com/microsoft/typescript-go/internal/core.GetNewLineKind
 func GetNewLineKind(s string) core.NewLineKind
 //go:linkname GetRequestID github.com/microsoft/typescript-go/internal/core.GetRequestID
@@ -185,6 +191,8 @@ const WatchFileKindPriorityPollingInterval = core.WatchFileKindPriorityPollingIn
 const WatchFileKindUseFsEvents = core.WatchFileKindUseFsEvents
 const WatchFileKindUseFsEventsOnParentDirectory = core.WatchFileKindUseFsEventsOnParentDirectory
 type WatchOptions = core.WatchOptions
+//go:linkname WithCheckerLifetime github.com/microsoft/typescript-go/internal/core.WithCheckerLifetime
+func WithCheckerLifetime(ctx context.Context, lifetime core.CheckerLifetime) context.Context
 //go:linkname WithRequestID github.com/microsoft/typescript-go/internal/core.WithRequestID
 func WithRequestID(ctx context.Context, id string) context.Context
 type WorkGroup = core.WorkGroup

--- a/shim/execute/incremental/shim.go
+++ b/shim/execute/incremental/shim.go
@@ -49,6 +49,8 @@ func GetFileEmitKind(options *core.CompilerOptions) incremental.FileEmitKind
 //go:linkname GetMTime github.com/microsoft/typescript-go/internal/execute/incremental.GetMTime
 func GetMTime(host compiler.CompilerHost, fileName string) time.Time
 type Host = incremental.Host
+//go:linkname IsBuildInfoFileNameDefaultLibrary github.com/microsoft/typescript-go/internal/execute/incremental.IsBuildInfoFileNameDefaultLibrary
+func IsBuildInfoFileNameDefaultLibrary(fileName string) bool
 //go:linkname NewBuildInfoReader github.com/microsoft/typescript-go/internal/execute/incremental.NewBuildInfoReader
 func NewBuildInfoReader(host compiler.CompilerHost) incremental.BuildInfoReader
 //go:linkname NewProgram github.com/microsoft/typescript-go/internal/execute/incremental.NewProgram

--- a/shim/scanner/shim.go
+++ b/shim/scanner/shim.go
@@ -55,6 +55,8 @@ func GetScannerForSourceFile(sourceFile *ast.SourceFile, pos int) *scanner.Scann
 func GetShebang(text string) string
 //go:linkname GetSourceTextOfNodeFromSourceFile github.com/microsoft/typescript-go/internal/scanner.GetSourceTextOfNodeFromSourceFile
 func GetSourceTextOfNodeFromSourceFile(sourceFile *ast.SourceFile, node *ast.Node, includeTrivia bool) string
+//go:linkname GetTextOfJSDocComment github.com/microsoft/typescript-go/internal/scanner.GetTextOfJSDocComment
+func GetTextOfJSDocComment(comment *ast.NodeList) string
 //go:linkname GetTextOfNode github.com/microsoft/typescript-go/internal/scanner.GetTextOfNode
 func GetTextOfNode(node *ast.Node) string
 //go:linkname GetTextOfNodeFromSourceText github.com/microsoft/typescript-go/internal/scanner.GetTextOfNodeFromSourceText

--- a/shim/tsoptions/shim.go
+++ b/shim/tsoptions/shim.go
@@ -95,7 +95,7 @@ func ParseCompilerOptions(key string, value any, allOptions *core.CompilerOption
 func ParseConfigFileTextToJson(fileName string, path tspath.Path, jsonText string) (any, []*ast.Diagnostic)
 type ParseConfigHost = tsoptions.ParseConfigHost
 //go:linkname ParseExtendedConfig github.com/microsoft/typescript-go/internal/tsoptions.ParseExtendedConfig
-func ParseExtendedConfig(fileName string, path tspath.Path, resolutionStack []string, host tsoptions.ParseConfigHost, extendedConfigCache tsoptions.ExtendedConfigCache) *tsoptions.ExtendedConfigCacheEntry
+func ParseExtendedConfig(fileName string, path tspath.Path, resolutionStack []tspath.Path, host tsoptions.ParseConfigHost, extendedConfigCache tsoptions.ExtendedConfigCache) *tsoptions.ExtendedConfigCacheEntry
 //go:linkname ParseJsonConfigFileContent github.com/microsoft/typescript-go/internal/tsoptions.ParseJsonConfigFileContent
 func ParseJsonConfigFileContent(json any, host tsoptions.ParseConfigHost, basePath string, existingOptions *core.CompilerOptions, configFileName string, resolutionStack []tspath.Path, extraFileExtensions []tsoptions.FileExtensionInfo, extendedConfigCache tsoptions.ExtendedConfigCache) *tsoptions.ParsedCommandLine
 //go:linkname ParseJsonSourceFileConfigFileContent github.com/microsoft/typescript-go/internal/tsoptions.ParseJsonSourceFileConfigFileContent


### PR DESCRIPTION
Updates the typescript-go submodule from `092b34f534` to upstream main `9ea7f6b36e` (~120 commits).

## Adaptations

- `internal/compiler/program.go`: `Program.UpdateProgram` now returns three values.
- `internal/collections`: re-synced from upstream. Upstream switched `ordered_map.go` to their new `internal/json` wrapper, which is not importable from outside their module; `just _patch-collections` rewrites it to use `go-json-experiment` directly.
- Shims regenerated for ast, checker, core, execute/incremental, scanner, and tsoptions.

## Shim removability

- `Checker.IsArrayType` is now exported upstream (`internal/checker/exports.go`), so the `isArrayType` entry in `shim/checker/extra-shim.json` can be dropped in a follow-up.
- `isReadonlySymbol` remains unexported; shim stays.

## Notable upstream changes

- Always accumulate deferred diagnostics (#4640)
- Conditional type base constraint limiter (#4468)
- Rebuilt build mode around `fswatch` package (#4326), fswatch coalescing fixes
- Multiple declaration emit fixes (expando properties, CJS export destructuring, const enum elision)
- tsoptions: validate project reference fields (#4494), nil-safe extended config handling

## Testing

- Full suite green: Go unit tests + 287 e2e tests (26 files).
- Closed Dependabot PR #219 (superseded, it targeted an older upstream commit).

https://claude.ai/code/session_0139uZWLEgwa6Zt1RbzcB5bo