### PR TITLE
feat(analyzer): branded constraints on arrays + multipart boolean coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
       - uses: extractions/setup-just@v3
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: '10'
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
         run: just init
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: '10'
 
       # Node 24 LTS. Do NOT set registry-url here — actions/setup-node injects
       # _authToken=${NODE_AUTH_TOKEN} into .npmrc and sets NODE_AUTH_TOKEN to

--- a/e2e/upload.test.ts
+++ b/e2e/upload.test.ts
@@ -30,6 +30,7 @@ function uploadTests(getUrl: () => string) {
     );
     formData.append("title", "My Upload");
     formData.append("category", "42");
+    formData.append("isLegacy", "true");
 
     const res = await fetch(`${getUrl()}/upload/single`, {
       method: "POST",
@@ -42,6 +43,8 @@ function uploadTests(getUrl: () => string) {
     expect(body.title).toBe("My Upload");
     // category should be coerced from string "42" to number 42
     expect(body.category).toBe(42);
+    // isLegacy should be coerced from string "true" to boolean true (issue #213)
+    expect(body.isLegacy).toBe(true);
   });
 
   it("should upload multiple files", async () => {

--- a/internal/analyzer/branded.go
+++ b/internal/analyzer/branded.go
@@ -9,25 +9,26 @@ import (
 )
 
 // tryDetectBranded checks if an intersection is a branded type pattern like
-// `string & { __brand: 'Email' }`. Returns the atomic type if detected,
-// otherwise nil. Also extracts validation constraints from phantom properties
-// with the `__tsgonest_` prefix (from @tsgonest/types branded types) and
-// the `__typia_tag_` prefix (for typia migration compatibility).
+// `string & { __brand: 'Email' }` or `string[] & tags.MaxItems<100>`. Returns
+// the base type if detected, otherwise nil. Also extracts validation
+// constraints from phantom properties with the `__tsgonest_` prefix (from
+// @tsgonest/types branded types) and the `__typia_tag_` prefix (for typia
+// migration compatibility).
 // rawTypes are the original shimchecker types corresponding to members, used for
 // function type resolution (Validate<typeof fn>).
 func (w *TypeWalker) tryDetectBranded(rawTypes []*shimchecker.Type, members []metadata.Metadata) *metadata.Metadata {
-	var atomicMember *metadata.Metadata
+	var baseMember *metadata.Metadata
 	var phantomMembers []*metadata.Metadata
 	var rawPhantomTypes []*shimchecker.Type
 	phantomCount := 0
 
 	for i := range members {
 		m := &members[i]
-		if m.Kind == metadata.KindAtomic || m.Kind == metadata.KindLiteral {
-			if atomicMember != nil {
-				return nil // Multiple atomics/literals — not a branded type
+		if isBrandableBase(m.Kind) {
+			if baseMember != nil {
+				return nil // Multiple base candidates — not a branded type
 			}
-			atomicMember = m
+			baseMember = m
 		} else if m.Kind == metadata.KindObject && isPhantomObject(m) {
 			phantomMembers = append(phantomMembers, m)
 			if i < len(rawTypes) {
@@ -35,23 +36,37 @@ func (w *TypeWalker) tryDetectBranded(rawTypes []*shimchecker.Type, members []me
 			}
 			phantomCount++
 		} else {
-			return nil // Non-atomic, non-phantom member — not a branded type
+			return nil // Non-base, non-phantom member — not a branded type
 		}
 	}
 
-	if atomicMember != nil && phantomCount > 0 {
-		// Return the atomic type, stripping the phantom objects
-		result := *atomicMember
+	if baseMember != nil && phantomCount > 0 {
+		// Return the base type, stripping the phantom objects
+		result := *baseMember
 
 		// Extract constraints from __tsgonest_* and __typia_tag_* phantom properties
 		constraints := w.extractBrandedConstraints(rawPhantomTypes, phantomMembers)
 		if constraints != nil {
-			result.Constraints = constraints
+			if result.Constraints != nil {
+				merged := *result.Constraints
+				mergeConstraints(&merged, constraints)
+				result.Constraints = &merged
+			} else {
+				result.Constraints = constraints
+			}
 		}
 
 		return &result
 	}
 	return nil
+}
+
+// isBrandableBase reports whether a metadata kind can carry branded phantom
+// tags: atomics/literals (string formats, numeric bounds) and arrays/tuples
+// (MinItems/MaxItems/UniqueItems).
+func isBrandableBase(kind metadata.Kind) bool {
+	return kind == metadata.KindAtomic || kind == metadata.KindLiteral ||
+		kind == metadata.KindArray || kind == metadata.KindTuple
 }
 
 // extractBrandedConstraints inspects phantom object members for constraint info:

--- a/internal/analyzer/type_walker_test.go
+++ b/internal/analyzer/type_walker_test.go
@@ -2162,6 +2162,59 @@ interface User {
 	assertKind(t, nameProp.Type, metadata.KindAtomic)
 }
 
+func TestWalkBrandedArrayConstraints(t *testing.T) {
+	env := setupWalker(t, `
+type MinItems<N extends number> = { readonly __tsgonest_minItems?: N };
+type MaxItems<N extends number> = { readonly __tsgonest_maxItems?: N };
+interface Request {
+  members: string[] & MinItems<1> & MaxItems<500>;
+}
+`)
+	defer env.release()
+
+	m := env.walkExportedType(t, "Request")
+	if m.Kind == metadata.KindRef {
+		reg := env.walkExportedTypeWithRegistryOnly(t, "Request")
+		if resolved := reg.Types[m.Ref]; resolved != nil {
+			m = *resolved
+		}
+	}
+
+	membersProp := findProperty(t, m.Properties, "members")
+	assertKind(t, membersProp.Type, metadata.KindArray)
+	if membersProp.Constraints == nil {
+		t.Fatal("members should have constraints from branded array tags")
+	}
+	if membersProp.Constraints.MinItems == nil || *membersProp.Constraints.MinItems != 1 {
+		t.Errorf("expected minItems 1, got %v", membersProp.Constraints.MinItems)
+	}
+	if membersProp.Constraints.MaxItems == nil || *membersProp.Constraints.MaxItems != 500 {
+		t.Errorf("expected maxItems 500, got %v", membersProp.Constraints.MaxItems)
+	}
+}
+
+func TestWalkArrayIntersectRealObjectNotBranded(t *testing.T) {
+	env := setupWalker(t, `
+interface Request {
+  weird: string[] & { realProp: number };
+}
+`)
+	defer env.release()
+
+	m := env.walkExportedType(t, "Request")
+	if m.Kind == metadata.KindRef {
+		reg := env.walkExportedTypeWithRegistryOnly(t, "Request")
+		if resolved := reg.Types[m.Ref]; resolved != nil {
+			m = *resolved
+		}
+	}
+
+	weirdProp := findProperty(t, m.Properties, "weird")
+	if weirdProp.Type.Kind == metadata.KindArray {
+		t.Error("array & real object must not collapse to a bare array")
+	}
+}
+
 func TestWalkBrandedNumericConstraints(t *testing.T) {
 	env := setupWalker(t, `
 type Minimum<N extends number> = { readonly __tsgonest_minimum: N };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tsgonest-monorepo",
   "private": true,
   "version": "0.0.1",
-  "description": "tsgonest monorepo — native-speed TypeScript compiler + NestJS runtime tooling",
+  "description": "native-speed TypeScript compiler + NestJS runtime tooling",
   "repository": {
     "type": "git",
     "url": "https://github.com/tsgonest/tsgonest"
@@ -22,5 +22,6 @@
   },
   "devDependencies": {
     "tsdown": "^0.21.7"
-  }
+  },
+  "packageManager": "pnpm@11.2.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,7 @@ packages:
   - 'benchmarks'
   - 'benchmarks/http'
   - 'testdata/integration'
+allowBuilds:
+  '@nestjs/core': true
+  esbuild: true
+  sharp: true

--- a/testdata/integration/src/dto.ts
+++ b/testdata/integration/src/dto.ts
@@ -18,6 +18,9 @@ export interface UploadDto {
   title: string;
   /** @minimum 1 */
   category: number;
+  // Optional boolean field — over multipart it arrives as the string "true"/"false"
+  // and must be coerced to boolean by the generated assert (issue #213).
+  isLegacy?: boolean;
 }
 
 // Multi-file upload DTO

--- a/testdata/integration/src/upload.controller.ts
+++ b/testdata/integration/src/upload.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, UseInterceptors } from "@nestjs/common";
+import { Controller, Post, UseInterceptors } from "@nestjs/common";
 import { FormDataBody, FormDataInterceptor } from "@tsgonest/runtime";
 import multer from "multer";
 import type { UploadDto, GalleryUploadDto } from "./dto";
@@ -13,12 +13,13 @@ export class UploadController {
   @Post("single")
   @UseInterceptors(FormDataInterceptor)
   uploadSingle(
-    @Body() @FormDataBody(() => createMulter()) body: UploadDto
-  ): { fileName: string; title: string; category: number } {
+    @FormDataBody(() => createMulter()) body: UploadDto
+  ): { fileName: string; title: string; category: number; isLegacy: boolean } {
     return {
       fileName: body.file instanceof File ? body.file.name : "unknown",
       title: body.title,
       category: body.category,
+      isLegacy: body.isLegacy ?? false,
     };
   }
 
@@ -26,7 +27,7 @@ export class UploadController {
   @Post("gallery")
   @UseInterceptors(FormDataInterceptor)
   uploadGallery(
-    @Body() @FormDataBody(() => createMulter()) body: GalleryUploadDto
+    @FormDataBody(() => createMulter()) body: GalleryUploadDto
   ): { fileCount: number; albumName: string } {
     return {
       fileCount: Array.isArray(body.images) ? body.images.length : 0,
@@ -38,7 +39,7 @@ export class UploadController {
   @Post("validate")
   @UseInterceptors(FormDataInterceptor)
   uploadValidate(
-    @Body() @FormDataBody(() => createMulter()) body: UploadDto
+    @FormDataBody(() => createMulter()) body: UploadDto
   ): { ok: boolean } {
     return { ok: true };
   }


### PR DESCRIPTION
Follow-up work that was sitting uncommitted alongside #220, now rebased onto merged main.

## Branded constraints on array and tuple types

`tryDetectBranded` only accepted atomics and literals as the base of a branded intersection, so `string[] & tags.MinItems<1>` fell through and the item constraints were silently dropped. Arrays and tuples now qualify as a branded base via `isBrandableBase`, and constraints already on the base are merged with the extracted phantom tags rather than overwritten.

Covered by two new walker tests: one asserting `MinItems`/`MaxItems` land on the array, one asserting `string[] & { realProp: number }` does **not** collapse to a bare array (a real object member still disqualifies the intersection).

## Multipart boolean coercion (#213)

Coercion itself already works in `internal/codegen/validate_assert.go`; this adds the missing regression coverage. `UploadDto` gains an optional `isLegacy?: boolean`, and the e2e test asserts the multipart string `"true"` arrives as boolean `true`. Also drops the redundant `@Body()` alongside `@FormDataBody` in the upload controller.

## Housekeeping

Pins `packageManager` to `pnpm@11.2.2` and adds `allowBuilds` for `@nestjs/core`, `esbuild`, and `sharp`.

## Testing

Full suite green locally: Go unit tests + 287 e2e tests (26 files).

https://claude.ai/code/session_0139uZWLEgwa6Zt1RbzcB5bo